### PR TITLE
[codex] stabilize mobile overlay rollout

### DIFF
--- a/mobile/HANDOFF_CLAUDECODE.md
+++ b/mobile/HANDOFF_CLAUDECODE.md
@@ -10,10 +10,26 @@ the current `react-native-maps` `Overlay` path is not shippable.
 
 - Repo: `Michaelpjob/ShoudiDive`
 - Working branch: `codex/mobile-overlay-rollout`
-- Current commit: `4ae21c4`
+- Reset checkpoint commit: `4ae21c4`
 - Draft PR: `https://github.com/Michaelpjob/ShoudiDive/pull/4`
 - Mobile app path: `mobile/`
 - User test surface: Expo Go on a real iPhone
+
+## Force-run command
+
+If the next agent says they changed anything meaningful, make them run:
+
+```bash
+cd mobile
+npm run validate:strict
+```
+
+That command now covers:
+
+- the existing 7-layer local validation stack
+- native `MapScreen` behavior tests
+- source-contract tests banning the old brittle paths
+- a live contract against the deployed manifest and raster assets
 
 ## What Codex already changed
 

--- a/mobile/HANDOFF_CLAUDECODE.md
+++ b/mobile/HANDOFF_CLAUDECODE.md
@@ -1,0 +1,274 @@
+# ClaudeCode handoff - mobile map reset
+
+This handoff packages the current Codex attempt and points the next
+agent at a different native map path. The short version is: do not
+keep pushing on the current single-image overlay approach. The app now
+crashes when the user switches overlays on a real device, which means
+the current `react-native-maps` `Overlay` path is not shippable.
+
+## Current truth
+
+- Repo: `Michaelpjob/ShoudiDive`
+- Working branch: `codex/mobile-overlay-rollout`
+- Current commit: `4ae21c4`
+- Draft PR: `https://github.com/Michaelpjob/ShoudiDive/pull/4`
+- Mobile app path: `mobile/`
+- User test surface: Expo Go on a real iPhone
+
+## What Codex already changed
+
+### 1. Cross-platform validation
+
+Windows PowerShell could not run the old bash-only validator. Codex
+replaced:
+
+- `mobile/package.json`
+- new `mobile/scripts/validate.js`
+
+`npm run validate` now passes on Windows and still runs the same 7
+checks.
+
+### 2. Mobile asset routing
+
+Codex taught the mobile client to prefer pre-colored assets from the
+manifest:
+
+- `mobile/src/lib/dataSource.js`
+- `mobile/src/lib/__tests__/dataSource.test.js`
+
+The pipeline was also updated to emit colored PNGs and `mobile_url`
+fields:
+
+- new `pipeline/color_ramps.py`
+- `pipeline/fetch.py`
+- `pipeline/fetch_visibility.py`
+
+### 3. Map overlay experiment
+
+Codex replaced the Skia path with `react-native-maps` `Overlay`:
+
+- `mobile/src/components/MapScreen.jsx`
+- `mobile/src/lib/mapData.js`
+- `mobile/src/lib/__tests__/mapData.test.js`
+
+The intention was sound:
+
+- stop doing client-side Skia pixel work
+- let the map own geographic placement
+- tighten the initial bbox fit so mobile matches web more closely
+
+## What failed
+
+The app now crashes when the user changes overlays on-device.
+
+That likely means the current failure point is not the validation
+stack, not the manifest fetch, and not the web fallback. The unstable
+piece is the native layer swap path:
+
+- `MapScreen.jsx` mounts `<Overlay key={pngUrl} image={{ uri: pngUrl }} />`
+- changing layer/composite swaps the remote image backing the overlay
+- Apple Maps / Expo Go appears to be unhappy with that lifecycle
+
+No native crash log was captured from the device in this pass, so this
+is still an inference, not a proven root cause. But from a project
+direction standpoint, this is enough evidence to stop investing in the
+single-raster overlay approach.
+
+## Recommendation: abandon both Skia and single-image Overlay
+
+Do not continue with:
+
+- Skia `Canvas` + manual image colorization
+- `react-native-maps` `Overlay` with a single remote PNG over the full bbox
+
+Those two approaches fail in different ways:
+
+- Skia: user saw the grey box / hard-to-debug native render path
+- Overlay: user now hits a crash when changing overlays
+
+Both depend on swapping one large remote image over the whole map. That
+is exactly the part that has been fragile.
+
+## New path forward: use `UrlTile`
+
+Use tile overlays instead of one giant overlay image.
+
+Why this is the right next move:
+
+1. `react-native-maps` already supports `UrlTile` for remote imagery.
+2. Tiles are the native shape map engines expect.
+3. Projection stops being our problem. The map engine places tiles in
+   Mercator instead of us stretching a bbox image by hand.
+4. Layer switches become URL-template swaps, not "destroy one giant
+   overlay image and mount another giant overlay image".
+5. The pipeline can generate tiles from the already-colored PNG assets,
+   so mobile keeps zero per-pixel work on device.
+
+Reference material already in the checkout:
+
+- `mobile/node_modules/react-native-maps/README.md`
+  section "Using a custom Tile Overlay"
+- `mobile/node_modules/react-native-maps/lib/MapUrlTile.d.ts`
+
+## Proposed implementation plan
+
+### Phase 1: server-side tiles for existing layers
+
+Generate XYZ tiles for:
+
+- `sst` 1d / 2d / 3d
+- `chl` 1d / 2d / 3d
+- `viz` now
+
+Suggested output shape:
+
+```text
+/data/tiles/sst/1d/{z}/{x}/{y}.png
+/data/tiles/sst/2d/{z}/{x}/{y}.png
+/data/tiles/sst/3d/{z}/{x}/{y}.png
+/data/tiles/chl/1d/{z}/{x}/{y}.png
+/data/tiles/viz/now/{z}/{x}/{y}.png
+```
+
+Suggested zoom range for first pass:
+
+- min z: 5
+- max native z: 9
+
+That is enough for the California coast use case without creating an
+explosive number of files.
+
+Important: render tiles from the already-colored assets, not from raw
+client-side data decode logic. The mobile app should remain a thin
+consumer.
+
+### Phase 2: manifest support
+
+Extend `manifest.json` windows with a tile template, for example:
+
+```json
+{
+  "url": "/data/sst_2d.png",
+  "mobile_url": "/data/sst_2d_color.png",
+  "tile_url_template": "/data/tiles/sst/2d/{z}/{x}/{y}.png",
+  "z_min": 5,
+  "z_max_native": 9
+}
+```
+
+### Phase 3: mobile client swap
+
+Replace the current `Overlay` block in `mobile/src/components/MapScreen.jsx`
+with `UrlTile`.
+
+Target shape:
+
+```jsx
+import MapView, { Marker, UrlTile, PROVIDER_DEFAULT } from "react-native-maps";
+
+{tileTemplate && (
+  <UrlTile
+    key={tileTemplate}
+    urlTemplate={tileTemplate}
+    flipY={false}
+    maximumNativeZ={9}
+    maximumZ={12}
+    opacity={0.72}
+  />
+)}
+```
+
+Also:
+
+- remove `Image.prefetch`
+- remove `BBOX_BOUNDS` if no longer needed
+- keep the current `fitToCoordinates(BBOX_RING, ...)`
+- consider `setMapBoundaries()` to stop the user from panning far
+  outside the supported area
+
+### Phase 4: data source API
+
+Add a tile resolver in `mobile/src/lib/dataSource.js`, for example:
+
+- `getLayerTileUrlTemplate(layer, composite)`
+
+Keep the existing PNG resolver only if it is still useful for a future
+fallback.
+
+### Phase 5: device validation
+
+Once `UrlTile` is wired:
+
+1. Launch in Expo Go
+2. Switch Temp 1d -> 2d -> 3d repeatedly
+3. Switch Temp -> Chl -> Viz repeatedly
+4. Pan and zoom near:
+   - Monterey
+   - Channel Islands
+   - La Jolla / Coronados
+5. Confirm:
+   - no crash
+   - no grey box
+   - tiles align to coastline
+   - no huge initial padding around the bbox
+
+## Why not WMSTile first?
+
+`WMSTile` is a reasonable backup, but `UrlTile` is the simpler next
+step because:
+
+- the data is already rasterized
+- Cloudflare Pages can serve static tile files directly
+- no tile server process is required
+- client config is simpler
+
+If `UrlTile` still proves unstable on Apple Maps, then the next
+escalation path is:
+
+1. `WMSTile` against a tile service endpoint
+2. or a full map stack change later
+
+But `UrlTile` is the right immediate bet.
+
+## Suggested concrete next edits
+
+1. Add a tile-render helper in `pipeline/`
+2. Extend manifest windows with `tile_url_template`
+3. Replace `Overlay` with `UrlTile` in `MapScreen.jsx`
+4. Add a small Jest surface in mobile for tile template resolution
+5. Re-run `npm run validate`
+6. Real device test in Expo Go
+
+## Files to read first
+
+- `mobile/src/components/MapScreen.jsx`
+- `mobile/src/lib/dataSource.js`
+- `mobile/src/lib/mapData.js`
+- `pipeline/color_ramps.py`
+- `pipeline/fetch.py`
+- `pipeline/fetch_visibility.py`
+- `mobile/node_modules/react-native-maps/README.md`
+- `mobile/node_modules/react-native-maps/lib/MapUrlTile.d.ts`
+
+## Notes about rollout status
+
+The branch and PR exist, but they should be treated as a packaging
+checkpoint, not a merge-ready solution.
+
+What is trustworthy in that branch:
+
+- Windows validator
+- pipeline colored-asset support
+- manifest/mobile URL plumbing
+- tighter bbox framing logic
+
+What is not trustworthy:
+
+- the current `Overlay`-based native renderer
+
+## Bottom line
+
+The best next agent move is not "debug this Overlay crash harder".
+It is "switch the mobile renderer to tile overlays so map projection
+and image lifecycle are handled by the map engine instead of one giant
+swapped raster".

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,170 +1,108 @@
-# ShouldIDive — mobile app (Expo / React Native)
+# ShouldIDive mobile app (Expo / React Native)
 
-Native iOS + Android app for the visibility model. Reuses the data
-pipeline at `https://shouldidive.com/data/manifest.json`; the mobile
-app is a pure consumer of those PNGs.
+Native iOS + Android app for the visibility model. It consumes the
+pipeline manifest at `https://shouldidive.com/data/manifest.json` and
+renders those layer PNGs on top of a native map.
 
 ## Why this exists separately from the web app
 
-Mobile Safari was choking on the SVG + foreignObject + canvas stack
-the web frontend uses. Native maps render the same heatmap PNGs as
-GPU-accelerated overlays via `react-native-maps`, with native pan /
-zoom, native gestures, and zero foreignObject quirks. Same data,
-better runtime.
+Mobile Safari was choking on the SVG + `foreignObject` + canvas stack
+the web frontend uses. The mobile app keeps the same data model but
+uses a native map plus a plain positioned image overlay. The phone does
+not do per-pixel color processing anymore; that work can move to the
+pipeline where it is easier to verify.
 
-## Day-1 scope (what's in here)
+## Day-1 scope
 
 * Apple Maps view zoomed to the model bbox.
 * SST / Chl / Visibility heatmaps as full-bbox PNG overlays.
-* Saved spot pins (8 known dive locations) with default callouts.
+* Saved spot pins with default callouts.
 * Layer chip strip + 1/2/3-day composite picker.
 * Manifest fetch + reactive re-render when the cycle refreshes.
 
-## Day-1 NOT in here yet
+## Not in here yet
 
-* Wind + Swell layers (need 5-day forecast feed wiring).
+* Wind + Swell layers.
 * Tap-to-pin value readout.
 * Per-spot value cards.
 * Saved-spot list screen.
 * Push notifications.
 * MPA + Bathy overlays.
 
-## Run it on your iPhone today
+## Run it on iPhone
 
-1. Install **Expo Go** from the iOS App Store (free).
+1. Install Expo Go from the iOS App Store.
 2. From the repo root:
-   ```bash
-   cd mobile
-   npm install              # one-time
-   npm start                # starts the dev server + shows a QR code
-   ```
-3. Open the Camera app on your iPhone and point it at the QR code in
-   the terminal. Tap the notification to open Expo Go. The app loads.
-4. Edits to `mobile/src/...` hot-reload over Wi-Fi.
-
-## Repo layout
-
-    mobile/
-    ├── App.js                  — root component, just mounts MapScreen
-    ├── app.json                — Expo config (name, bundle id, splash)
-    ├── babel.config.js         — Babel preset (just babel-preset-expo)
-    ├── package.json            — RN + Expo deps
-    ├── scripts/
-    │   └── validate.sh         — 4-layer pre-push validation (see below)
-    └── src/
-        ├── components/
-        │   └── MapScreen.jsx   — the only screen for now
-        └── lib/
-            ├── mapData.js      — BBOX, BBOX_REGION, SAVED_SPOTS
-            ├── dataSource.js   — manifest fetcher, layer URL resolver
-            └── __tests__/      — jest tests for the data layer
-
-The data layer (`src/lib/dataSource.js`) is intentionally minimal in
-v1: it fetches `manifest.json` and resolves URLs. We DON'T decode
-PNGs into Float32Arrays in JS like the web frontend does — the
-native map handles the PNG render itself with no per-pixel JS work.
-Tooltip lookups (when we add them) will use a separate per-cell
-endpoint or a small grid JSON, not in-JS PNG decoding.
-
-## Validation — `npm run validate`
-
-Before pushing any non-trivial change to `mobile/`, run the full
-5-layer validation pipeline from the `mobile/` directory:
-
-```bash
-npm run validate
-```
-
-What each layer catches:
-
-| # | Layer                  | What it catches                                                         | Speed |
-|---|------------------------|-------------------------------------------------------------------------|-------|
-| 1 | `expo install --check` | SDK / package version drift (e.g. wrong jest version)                   | ~2s   |
-| 2 | `expo-doctor`          | Project-wide config (entry point, peer-deps, scheme conflicts, …)       | ~10s  |
-| 3 | `expo export ios`      | iOS Hermes bundle compile — Babel + import errors                       | ~15s  |
-| 4 | `expo export web`      | Web fallback compiles (so the app can be rendered in a browser, see below) | ~10s  |
-| 5 | `jest`                 | Data-layer regressions (manifest fetch, URL resolution, subscribers)    | ~3s   |
-
-A clean run looks like:
-
-    ▶ Layer 1/5 — expo install --check        Dependencies are up to date
-    ▶ Layer 2/5 — expo-doctor                  17/17 checks passed
-    ▶ Layer 3/5 — expo export                  Bundled 6339ms (938 modules, 2.43 MB)
-    ▶ Layer 4/5 — expo export web              Bundled 4204ms (413 modules, 745 kB)
-    ▶ Layer 5/5 — jest                         26 passed, 0 failed (1.2s)
-    ✓ All 5 validation layers passed.
-      Mobile bundle is in a deployable state.
-
-If any layer fails, the script exits non-zero and skips remaining
-layers — you fix the failure locally before involving a device or
-TestFlight.
-
-## The autonomous render loop
-
-The whole reason web target exists in this repo is so the dev (me,
-Claude, in agent mode) can render the app, click chips, and screenshot
-the result without ever asking the human to scan a QR code on their
-phone. The web build uses platform-specific shims:
-
-* `MapScreen.jsx`     — native (iOS / Android), uses `react-native-maps` + Skia
-* `MapScreen.web.jsx` — web stand-in, no real map, just the layer PNG as a stretched `<Image>`
-
-Metro picks the right file via the `.web.jsx` suffix when
-`platform=web`. App.js intentionally imports without a file extension
-so this resolution works.
-
-Workflow:
 
 ```bash
 cd mobile
-npx expo start --web --port 8083    # boots Metro on the web target
-# then in a second terminal / via Claude Preview:
-#   open http://localhost:8083
+npm install
+npm start
 ```
 
-Then click chips, change composites, etc. — the same state machine
-runs as on iOS/Android, the only thing missing is the actual
-GPU-rendered map under the heatmap. That gap is acceptable for
-catching UI/state bugs but is the reason a real iPhone / iOS
-Simulator is still part of the loop for visual sign-off.
+3. Open the Camera app on the iPhone, scan the QR code, and open the
+   project in Expo Go.
 
-### What the validator can NOT catch (intentional gap)
+## Validation
 
-Pure-bash testing on Windows / Linux can't simulate native rendering
-behaviour. So the validator does NOT catch:
-
-* Skia heatmap actually painting on top of a MapView
-* `react-native-maps` region-change / pan-zoom behaviour
-* Touch / gesture interactions
-* Animation performance under real load
-
-Those go into a Detox or Maestro suite later (which require a Mac +
-iOS Simulator, or a connected Android emulator).
-
-### Adding new tests
-
-Tests live next to the code they test, in `__tests__/` directories:
-
-    src/lib/__tests__/dataSource.test.js
-    src/lib/__tests__/mapData.test.js
-
-Anything in `**/__tests__/**/*.test.{js,jsx}` runs automatically. The
-`jest-expo` preset handles RN + Skia + react-native-maps mocking, so
-you can import them in tests without booting a device.
-
-`npm run test:watch` reruns tests on save while you're iterating.
-
-## Shipping to App Store (later)
-
-Workflow when we're ready to graduate from Expo Go:
+Run this before pushing mobile changes:
 
 ```bash
-npm install -g eas-cli
-eas login
-eas build --platform ios     # produces a .ipa, upload to TestFlight
-eas build --platform android # produces a .aab, upload to Play Console
+cd mobile
+npm run validate
 ```
 
-Apple Developer account ($99/year) required for TestFlight + App
-Store. Google Play Console ($25 one-time) for Play Store. Neither
-is needed for Expo Go iteration — only when we publish.
+`npm run validate` now uses `scripts/validate.js`, a cross-platform Node
+runner that works from PowerShell as well as bash shells. The legacy
+`scripts/validate.sh` file is still present for reference, but it is no
+longer the primary entrypoint.
+
+Validation layers:
+
+1. `expo install --check`
+2. `expo-doctor`
+3. `expo export --platform ios`
+4. `expo export --platform web`
+5. `jest`
+6. `node scripts/smoke-web.js`
+7. `node scripts/visual-tests.js`
+
+What this still cannot prove locally:
+
+* Native image overlay alignment on top of a `MapView`
+* `react-native-maps` gesture behavior
+* Device-specific layout or performance issues
+
+## Overlay strategy
+
+The native screen now renders a plain React Native `Image` on top of the
+map, positioned from the current region math. Mobile prefers
+`mobile_url` or `color_url` when the manifest provides one, and falls
+back to the canonical grayscale `url` otherwise.
+
+That split keeps the phone-side renderer simple:
+
+* pipeline: generate colorized mobile PNGs
+* mobile app: load and place one remote image reliably
+
+## Repo layout
+
+```text
+mobile/
+  App.js
+  app.json
+  package.json
+  scripts/
+    validate.js
+    validate.sh
+    smoke-web.js
+    visual-tests.js
+  src/
+    components/
+      MapScreen.jsx
+      MapScreen.web.jsx
+    lib/
+      dataSource.js
+      mapData.js
+      __tests__/
+```

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -9,7 +9,8 @@
     "web": "expo start --web",
     "test": "jest",
     "test:watch": "jest --watch",
-    "validate": "node scripts/validate.js"
+    "validate": "node scripts/validate.js",
+    "validate:strict": "node scripts/validate-strict.js"
   },
   "dependencies": {
     "@expo/metro-runtime": "~6.1.2",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -9,7 +9,7 @@
     "web": "expo start --web",
     "test": "jest",
     "test:watch": "jest --watch",
-    "validate": "bash scripts/validate.sh"
+    "validate": "node scripts/validate.js"
   },
   "dependencies": {
     "@expo/metro-runtime": "~6.1.2",

--- a/mobile/scripts/live-data-contract.js
+++ b/mobile/scripts/live-data-contract.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+const MANIFEST_URL = "https://shouldidive.com/data/manifest.json";
+const REMOTE_BASE = "https://shouldidive.com";
+const PNG_SIG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+const EXPECTED_WINDOWS = {
+  sst: ["1d", "2d", "3d"],
+  chl: ["1d", "2d", "3d"],
+  viz: ["now"],
+};
+
+function divider() {
+  console.log("-".repeat(64));
+}
+
+function assetUrlFromWindow(window) {
+  return window?.mobile_url || window?.color_url || window?.url || null;
+}
+
+function resolveAssetUrl(assetPath) {
+  if (!assetPath) return null;
+  if (/^https?:/i.test(assetPath)) return assetPath;
+  return `${REMOTE_BASE}${assetPath.startsWith("/") ? "" : "/"}${assetPath}`;
+}
+
+function readPngSize(buffer) {
+  if (buffer.length < 24) {
+    throw new Error(`PNG too small (${buffer.length} bytes)`);
+  }
+  if (!buffer.subarray(0, 8).equals(PNG_SIG)) {
+    throw new Error("missing PNG signature");
+  }
+  if (buffer.toString("ascii", 12, 16) !== "IHDR") {
+    throw new Error("missing IHDR chunk");
+  }
+  return {
+    width: buffer.readUInt32BE(16),
+    height: buffer.readUInt32BE(20),
+  };
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`GET ${url} -> ${response.status}`);
+  }
+  return response.json();
+}
+
+async function fetchBinary(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`GET ${url} -> ${response.status}`);
+  }
+
+  const bytes = Buffer.from(await response.arrayBuffer());
+  const contentType = response.headers.get("content-type") || "";
+  return { bytes, contentType };
+}
+
+async function assertWindowAsset(layer, windowKey, windowInfo) {
+  if (!windowInfo || typeof windowInfo !== "object") {
+    throw new Error(`${layer}.${windowKey} is missing`);
+  }
+
+  if (!windowInfo.url) {
+    throw new Error(`${layer}.${windowKey} is missing canonical url`);
+  }
+
+  const chosenAsset = assetUrlFromWindow(windowInfo);
+  if (!chosenAsset) {
+    throw new Error(`${layer}.${windowKey} has no usable asset url`);
+  }
+
+  const checks = [
+    { label: "canonical", path: windowInfo.url },
+  ];
+
+  if (chosenAsset !== windowInfo.url) {
+    checks.push({ label: "mobile", path: chosenAsset });
+  }
+
+  for (const check of checks) {
+    const url = resolveAssetUrl(check.path);
+    const { bytes, contentType } = await fetchBinary(url);
+    const { width, height } = readPngSize(bytes);
+
+    if (width < 64 || height < 64) {
+      throw new Error(
+        `${layer}.${windowKey} ${check.label} image too small (${width}x${height})`
+      );
+    }
+    if (bytes.length < 1024) {
+      throw new Error(
+        `${layer}.${windowKey} ${check.label} image suspiciously small (${bytes.length} bytes)`
+      );
+    }
+
+    console.log(
+      `OK ${layer}.${windowKey} ${check.label} -> ${width}x${height}, ${bytes.length} bytes, ${contentType || "content-type unknown"}`
+    );
+  }
+}
+
+async function main() {
+  console.log("Fetching live manifest...");
+  const manifest = await fetchJson(MANIFEST_URL);
+
+  if (!manifest?.generated_at) {
+    throw new Error("manifest is missing generated_at");
+  }
+  if (!manifest?.layers || typeof manifest.layers !== "object") {
+    throw new Error("manifest is missing layers");
+  }
+
+  console.log(`Manifest generated_at: ${manifest.generated_at}`);
+  divider();
+
+  for (const [layer, windows] of Object.entries(EXPECTED_WINDOWS)) {
+    const layerInfo = manifest.layers[layer];
+    if (!layerInfo) {
+      throw new Error(`manifest.layers.${layer} is missing`);
+    }
+    for (const windowKey of windows) {
+      await assertWindowAsset(layer, windowKey, layerInfo.windows?.[windowKey]);
+    }
+  }
+
+  divider();
+  console.log("OK Live data contract passed.");
+}
+
+main().catch((error) => {
+  console.error(`Live data contract failed: ${error.message}`);
+  process.exit(1);
+});

--- a/mobile/scripts/validate-strict.js
+++ b/mobile/scripts/validate-strict.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+const path = require("path");
+const { spawn } = require("child_process");
+
+const ROOT = path.resolve(__dirname, "..");
+
+function divider() {
+  console.log("-".repeat(64));
+}
+
+function run(bin, args, options = {}) {
+  const {
+    cwd = ROOT,
+    shell = process.platform === "win32" && /\.cmd$/i.test(bin),
+  } = options;
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(bin, args, {
+      cwd,
+      env: process.env,
+      shell,
+      stdio: "inherit",
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`${bin} ${args.join(" ")} exited with code ${code}`));
+    });
+  });
+}
+
+async function main() {
+  console.log("");
+  console.log(">> Strict gate 1/2 - full local validate");
+  divider();
+  await run(process.execPath, [path.join("scripts", "validate.js")]);
+
+  console.log("");
+  console.log(">> Strict gate 2/2 - live data contract");
+  divider();
+  await run(process.execPath, [path.join("scripts", "live-data-contract.js")]);
+
+  console.log("");
+  divider();
+  console.log("OK Strict validation passed.");
+  console.log("   Local behavior, native contracts, and live data all checked.");
+  divider();
+}
+
+main().catch((error) => {
+  console.error("");
+  console.error(`Strict validation failed: ${error.message}`);
+  process.exit(1);
+});

--- a/mobile/scripts/validate.js
+++ b/mobile/scripts/validate.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+const fs = require("fs/promises");
+const path = require("path");
+const { spawn } = require("child_process");
+
+const ROOT = path.resolve(__dirname, "..");
+
+function commandName(bin) {
+  return process.platform === "win32" ? `${bin}.cmd` : bin;
+}
+
+function divider() {
+  console.log("-".repeat(64));
+}
+
+async function removeIfPresent(relPath) {
+  await fs.rm(path.join(ROOT, relPath), { recursive: true, force: true });
+}
+
+function run(bin, args, options = {}) {
+  const {
+    cwd = ROOT,
+    capture = false,
+    allowNonZero = false,
+    shell = process.platform === "win32" && /\.cmd$/i.test(bin),
+  } = options;
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(bin, args, {
+      cwd,
+      env: process.env,
+      shell,
+      stdio: capture ? ["inherit", "pipe", "pipe"] : "inherit",
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    if (capture) {
+      child.stdout.on("data", (chunk) => {
+        const text = chunk.toString();
+        stdout += text;
+        process.stdout.write(text);
+      });
+      child.stderr.on("data", (chunk) => {
+        const text = chunk.toString();
+        stderr += text;
+        process.stderr.write(text);
+      });
+    }
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0 || allowNonZero) {
+        resolve({ code, stdout, stderr });
+        return;
+      }
+      reject(new Error(`${bin} ${args.join(" ")} exited with code ${code}`));
+    });
+  });
+}
+
+async function main() {
+  console.log("");
+  console.log(">> Layer 1/7 - expo install --check (SDK alignment)");
+  divider();
+  await run(commandName("npx"), ["expo", "install", "--check"]);
+
+  console.log("");
+  console.log(">> Layer 2/7 - expo-doctor (project health)");
+  divider();
+  const doctor = await run(
+    commandName("npx"),
+    ["--yes", "expo-doctor"],
+    { capture: true, allowNonZero: true }
+  );
+  const doctorOutput = `${doctor.stdout}\n${doctor.stderr}`;
+  if (doctor.code !== 0 || /critical|fatal|error/i.test(doctorOutput)) {
+    throw new Error("expo-doctor reported critical issue(s).");
+  }
+
+  console.log("");
+  console.log(">> Layer 3/7 - expo export ios (Hermes bundle compile)");
+  divider();
+  await removeIfPresent("dist");
+  await removeIfPresent(path.join(".expo", "cache"));
+  await run(commandName("npx"), [
+    "expo",
+    "export",
+    "--platform",
+    "ios",
+    "--output-dir",
+    "dist",
+    "--clear",
+  ]);
+
+  console.log("");
+  console.log(">> Layer 4/7 - expo export web (fallback compile)");
+  divider();
+  await removeIfPresent("dist");
+  await run(commandName("npx"), [
+    "expo",
+    "export",
+    "--platform",
+    "web",
+    "--output-dir",
+    "dist",
+  ]);
+
+  console.log("");
+  console.log(">> Layer 5/7 - jest (data-layer unit tests)");
+  divider();
+  await run(commandName("npx"), ["jest", "--silent", "--colors"]);
+
+  await removeIfPresent("dist");
+
+  console.log("");
+  console.log(">> Layer 6/7 - runtime smoke test");
+  divider();
+  await run(process.execPath, [path.join("scripts", "smoke-web.js")]);
+
+  console.log("");
+  console.log(">> Layer 7/7 - visual test suite");
+  divider();
+  await run(process.execPath, [path.join("scripts", "visual-tests.js")]);
+
+  console.log("");
+  divider();
+  console.log("OK All 7 validation layers passed.");
+  console.log("   Mobile bundle compiles, boots, and meets visual criteria.");
+  divider();
+}
+
+main().catch(async (error) => {
+  await removeIfPresent("dist");
+  console.error("");
+  console.error(`Validation failed: ${error.message}`);
+  process.exit(1);
+});

--- a/mobile/scripts/validate.js
+++ b/mobile/scripts/validate.js
@@ -109,7 +109,7 @@ async function main() {
   ]);
 
   console.log("");
-  console.log(">> Layer 5/7 - jest (data-layer unit tests)");
+  console.log(">> Layer 5/7 - jest (unit + native screen tests)");
   divider();
   await run(commandName("npx"), ["jest", "--silent", "--colors"]);
 

--- a/mobile/src/components/MapScreen.jsx
+++ b/mobile/src/components/MapScreen.jsx
@@ -1,27 +1,20 @@
-// Day-1 map screen. Renders Apple Maps zoomed to the model's bbox,
-// with the active layer's heatmap PNG painted on top via a Skia
-// overlay synced to the map camera. We use Skia (not the built-in
-// react-native-maps <Overlay>) because Overlay with remote URIs is
-// flaky on Apple Maps — onLoad never fires and the image never
-// renders. Skia gives us GPU-accelerated drawing and full control
-// over coordinate transforms.
-
-// useMemo caches the colourised SkImage so we don't rebuild it on
-// every map pan/zoom. useRef is reserved for upcoming work; not
-// strictly needed today.
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
+  Image,
   Pressable,
   StyleSheet,
   Text,
   View,
 } from "react-native";
-import MapView, { Marker, PROVIDER_DEFAULT } from "react-native-maps";
-import { Canvas, Image as SkiaImage, useImage } from "@shopify/react-native-skia";
+import MapView, { Marker, Overlay, PROVIDER_DEFAULT } from "react-native-maps";
 
-import { BBOX, BBOX_REGION, SAVED_SPOTS } from "../lib/mapData.js";
-import { colorizeImage } from "../lib/colors.js";
+import {
+  BBOX_BOUNDS,
+  BBOX_REGION,
+  BBOX_RING,
+  SAVED_SPOTS,
+} from "../lib/mapData.js";
 import {
   loadManifest,
   subscribe,
@@ -29,30 +22,30 @@ import {
   getLayerPngUrl,
 } from "../lib/dataSource.js";
 
-
-// The five layer chips — same set + order as the web peek strip.
-// v1 ships the static-PNG layers (sst, chl, viz). Wind + swell come
-// in v2 once we wire the 5-day forecast feeds.
 const LAYERS = [
-  { id: "sst",  label: "Temp",  unit: "°F",     ready: true },
-  { id: "chl",  label: "Chl",   unit: "mg/m³",  ready: true },
-  { id: "wind", label: "Wind",  unit: "kt",     ready: false },
-  { id: "swell",label: "Swell", unit: "ft",     ready: false },
-  { id: "viz",  label: "Vis",   unit: "ft",     ready: true },
+  { id: "sst", label: "Temp", unit: "degF", ready: true },
+  { id: "chl", label: "Chl", unit: "mg/m^3", ready: true },
+  { id: "wind", label: "Wind", unit: "kt", ready: false },
+  { id: "swell", label: "Swell", unit: "ft", ready: false },
+  { id: "viz", label: "Vis", unit: "ft", ready: true },
 ];
 
+const INITIAL_EDGE_PADDING = { top: 16, right: 16, bottom: 16, left: 16 };
+const OVERLAY_OPACITY = 0.72;
 
 export default function MapScreen() {
+  const mapRef = useRef(null);
+  const didInitialFitRef = useRef(false);
+
   const [layer, setLayer] = useState("sst");
-  const [composite, setComposite] = useState(2); // 2-day window (best balance)
-  // Re-render trigger when the manifest lands or refreshes.
+  const [composite, setComposite] = useState(2);
   const [, setTick] = useState(0);
-  // Track the map's current region + measured size so we can compute
-  // screen coordinates for the bbox corners (where the heatmap PNG
-  // gets drawn). onRegionChange fires continuously during pan so the
-  // overlay tracks smoothly.
-  const [region, setRegion] = useState(BBOX_REGION);
-  const [mapSize, setMapSize] = useState({ w: 0, h: 0 });
+  const [mapReady, setMapReady] = useState(false);
+  const [mapLayout, setMapLayout] = useState({ width: 0, height: 0 });
+  const [overlayState, setOverlayState] = useState({
+    status: "idle",
+    error: null,
+  });
 
   useEffect(() => {
     loadManifest();
@@ -63,41 +56,60 @@ export default function MapScreen() {
   const pngUrl = getLayerPngUrl(layer, composite);
   const compositeButtonsActive = layer === "sst" || layer === "chl";
 
-  // Skia loads + decodes the PNG natively. `useImage` returns null
-  // while loading, then the SkImage handle when ready. Re-runs when
-  // pngUrl changes (different layer / composite).
-  const grayImage = useImage(pngUrl);
+  useEffect(() => {
+    if (!pngUrl) {
+      setOverlayState({ status: "idle", error: null });
+      return undefined;
+    }
 
-  // The pipeline writes mode='L' grayscale PNGs (R = encoded value,
-  // 0 = no data). Apply the layer's color ramp once per image change
-  // so the GPU draws a proper coloured heatmap instead of grey blob.
-  const skiaImage = useMemo(
-    () => colorizeImage(grayImage, layer),
-    [grayImage, layer]
-  );
+    let cancelled = false;
+    setOverlayState({ status: "loading", error: null });
 
-  // Compute the screen rectangle the heatmap should occupy by
-  // mapping the bbox corners into pixel space using the current
-  // region. Equirectangular math — accurate enough across our
-  // 5°×7° bbox; Mercator distortion at lat 35°N is single-digit %
-  // which won't be visible at this scale.
-  const overlayBox = useMemo(() => {
-    const { w, h } = mapSize;
-    if (!w || !h) return null;
-    const lngWest  = region.longitude - region.longitudeDelta / 2;
-    const latNorth = region.latitude  + region.latitudeDelta  / 2;
-    const xPerLng = w / region.longitudeDelta;
-    const yPerLat = h / region.latitudeDelta;
-    const x0 = (BBOX.lngMin - lngWest)  * xPerLng;
-    const y0 = (latNorth - BBOX.latMax) * yPerLat;
-    const x1 = (BBOX.lngMax - lngWest)  * xPerLng;
-    const y1 = (latNorth - BBOX.latMin) * yPerLat;
-    return { x: x0, y: y0, width: x1 - x0, height: y1 - y0 };
-  }, [region, mapSize]);
+    Image.prefetch(pngUrl)
+      .then((ok) => {
+        if (cancelled) return;
+        if (!ok) {
+          setOverlayState({
+            status: "error",
+            error: "image prefetch returned false",
+          });
+          return;
+        }
+        setOverlayState({ status: "ready", error: null });
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setOverlayState({
+          status: "error",
+          error: String(error?.message || error || "image prefetch failed"),
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [pngUrl]);
+
+  useEffect(() => {
+    if (!mapReady || !mapLayout.width || !mapLayout.height || didInitialFitRef.current) {
+      return undefined;
+    }
+
+    didInitialFitRef.current = true;
+    const timer = setTimeout(() => {
+      mapRef.current?.fitToCoordinates(BBOX_RING, {
+        edgePadding: INITIAL_EDGE_PADDING,
+        animated: false,
+      });
+    }, 0);
+
+    return () => clearTimeout(timer);
+  }, [mapReady, mapLayout.height, mapLayout.width]);
 
   return (
     <View style={styles.root}>
       <MapView
+        ref={mapRef}
         style={styles.map}
         provider={PROVIDER_DEFAULT}
         initialRegion={BBOX_REGION}
@@ -107,123 +119,116 @@ export default function MapScreen() {
         showsMyLocationButton
         pitchEnabled={false}
         rotateEnabled={false}
-        onRegionChange={setRegion}
-        onLayout={(e) => {
-          const { width, height } = e.nativeEvent.layout;
-          setMapSize({ w: width, h: height });
+        onMapReady={() => setMapReady(true)}
+        onLayout={(event) => {
+          const { width, height } = event.nativeEvent.layout;
+          setMapLayout({ width, height });
         }}
       >
-        {/* Saved-spot pins. zIndex pushes them above the heatmap so a
-            busy bbox doesn't bury them. Default callout shows the
-            spot name; tap-to-pin readout comes in the next iteration. */}
-        {SAVED_SPOTS.map((s) => (
+        {pngUrl && overlayState.status === "ready" && (
+          <Overlay
+            key={pngUrl}
+            bounds={BBOX_BOUNDS}
+            image={{ uri: pngUrl }}
+            opacity={OVERLAY_OPACITY}
+            zIndex={2}
+          />
+        )}
+
+        {SAVED_SPOTS.map((spot) => (
           <Marker
-            key={s.id}
-            coordinate={{ latitude: s.lat, longitude: s.lng }}
-            title={s.name}
-            description={`${s.lat.toFixed(2)}°N ${Math.abs(s.lng).toFixed(2)}°W`}
+            key={spot.id}
+            coordinate={{ latitude: spot.lat, longitude: spot.lng }}
+            title={spot.name}
+            description={`${spot.lat.toFixed(2)}N ${Math.abs(spot.lng).toFixed(2)}W`}
             zIndex={10}
             pinColor="red"
           />
         ))}
       </MapView>
 
-      {/* Skia overlay — sits absolute-positioned over the MapView,
-          draws the layer PNG at the computed bbox screen coordinates.
-          Updates every frame as the user pans/zooms. pointerEvents:
-          none lets touch events pass through to the MapView so pan
-          + tap on markers still work. */}
-      {skiaImage && overlayBox && (
-        <Canvas style={[StyleSheet.absoluteFill, styles.canvas]} pointerEvents="none">
-          <SkiaImage
-            image={skiaImage}
-            x={overlayBox.x}
-            y={overlayBox.y}
-            width={overlayBox.width}
-            height={overlayBox.height}
-            opacity={0.7}
-            fit="fill"
-          />
-        </Canvas>
-      )}
-
-      {/* Status pill — minimal v1: layer label, window, overlay
-          load state. */}
       <View style={styles.statusPill} pointerEvents="none">
         <View
           style={[
             styles.dot,
             !pngUrl && styles.dotIdle,
-            pngUrl && !skiaImage && styles.dotLoading,
+            overlayState.status === "loading" && styles.dotLoading,
+            overlayState.status === "error" && styles.dotError,
           ]}
         />
         <Text style={styles.statusText}>
-          {layerLabel(layer)} ·{" "}
-          {compositeButtonsActive ? `${composite}-day` : "now"}
-          {pngUrl && !skiaImage ? "  • loading" : ""}
+          {layerLabel(layer)} . {compositeButtonsActive ? `${composite}-day` : "now"}
+          {overlayState.status === "loading" ? " . loading" : ""}
+          {overlayState.status === "error" ? " . error" : ""}
         </Text>
       </View>
 
-      {/* Layer chip strip — Pressable so taps fire on native. */}
+      {__DEV__ && (
+        <View style={styles.debugPill} pointerEvents="none">
+          <Text style={styles.debugText} numberOfLines={3}>
+            {`overlay:${overlayState.status} img:${overlayAssetName(pngUrl) || "none"} fit:${mapReady ? "ready" : "pending"} layout:${mapLayout.width || 0}x${mapLayout.height || 0}${overlayState.error ? ` err:${overlayState.error}` : ""}`}
+          </Text>
+        </View>
+      )}
+
       <View style={styles.chipStrip}>
-        {LAYERS.map((L) => {
-          const active = layer === L.id;
+        {LAYERS.map((entry) => {
+          const active = layer === entry.id;
           return (
             <Pressable
-              key={L.id}
-              disabled={!L.ready}
-              onPress={() => setLayer(L.id)}
+              key={entry.id}
+              disabled={!entry.ready}
+              onPress={() => setLayer(entry.id)}
               style={({ pressed }) => [
                 styles.chip,
                 active && styles.chipActive,
-                !L.ready && styles.chipDisabled,
-                pressed && L.ready && styles.chipPressed,
+                !entry.ready && styles.chipDisabled,
+                pressed && entry.ready && styles.chipPressed,
               ]}
             >
               <Text style={[styles.chipLabel, active && styles.chipLabelActive]}>
-                {L.label}
+                {entry.label}
               </Text>
               <Text style={[styles.chipSub, active && styles.chipSubActive]}>
-                {L.ready ? L.unit : "soon"}
+                {entry.ready ? entry.unit : "soon"}
               </Text>
             </Pressable>
           );
         })}
       </View>
 
-      {/* Composite buttons (only for sst/chl). */}
       {compositeButtonsActive && (
         <View style={styles.compositeStrip}>
-          {[1, 2, 3].map((d) => (
+          {[1, 2, 3].map((days) => (
             <Pressable
-              key={d}
-              onPress={() => setComposite(d)}
+              key={days}
+              onPress={() => setComposite(days)}
               style={({ pressed }) => [
                 styles.compChip,
-                composite === d && styles.compChipActive,
+                composite === days && styles.compChipActive,
                 pressed && styles.compChipPressed,
               ]}
             >
               <Text
                 style={[
                   styles.compText,
-                  composite === d && styles.compTextActive,
+                  composite === days && styles.compTextActive,
                 ]}
               >
-                {d}-day
+                {days}-day
               </Text>
             </Pressable>
           ))}
         </View>
       )}
 
-      {/* Loading indicator when the manifest is in flight. */}
       {!ready && (
         <View style={styles.loadingOverlay}>
           <ActivityIndicator size="small" />
-          <Text style={styles.loadingText}>Loading conditions…</Text>
+          <Text style={styles.loadingText}>Loading conditions...</Text>
         </View>
       )}
+
       {ready && !pngUrl && (
         <View style={styles.loadingOverlay}>
           <Text style={styles.loadingText}>
@@ -236,23 +241,31 @@ export default function MapScreen() {
   );
 }
 
+function overlayAssetName(url) {
+  if (!url) return null;
+  return url.split("?")[0].split("/").pop() || url;
+}
 
 function layerLabel(layer) {
   switch (layer) {
-    case "sst":   return "Sea Temp";
-    case "chl":   return "Chlorophyll";
-    case "wind":  return "Wind";
-    case "swell": return "Swell";
-    case "viz":   return "Visibility";
-    default:      return layer;
+    case "sst":
+      return "Sea Temp";
+    case "chl":
+      return "Chlorophyll";
+    case "wind":
+      return "Wind";
+    case "swell":
+      return "Swell";
+    case "viz":
+      return "Visibility";
+    default:
+      return layer;
   }
 }
-
 
 const styles = StyleSheet.create({
   root: { flex: 1, backgroundColor: "#0369a1" },
   map: { flex: 1 },
-  canvas: { backgroundColor: "transparent" },
 
   statusPill: {
     position: "absolute",
@@ -278,8 +291,25 @@ const styles = StyleSheet.create({
     backgroundColor: "rgb(34, 197, 94)",
   },
   dotLoading: { backgroundColor: "rgb(234, 179, 8)" },
-  dotIdle:    { backgroundColor: "rgb(148, 163, 184)" },
+  dotError: { backgroundColor: "rgb(220, 38, 38)" },
+  dotIdle: { backgroundColor: "rgb(148, 163, 184)" },
   statusText: { fontSize: 12, fontWeight: "600", color: "#0f172a" },
+
+  debugPill: {
+    position: "absolute",
+    top: 102,
+    left: 12,
+    right: 12,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 10,
+    backgroundColor: "rgba(15,23,42,0.82)",
+  },
+  debugText: {
+    fontSize: 10,
+    lineHeight: 13,
+    color: "#e2e8f0",
+  },
 
   chipStrip: {
     position: "absolute",

--- a/mobile/src/components/__tests__/MapScreen.contract.test.js
+++ b/mobile/src/components/__tests__/MapScreen.contract.test.js
@@ -1,0 +1,32 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const MAP_SCREEN_PATH = path.join(__dirname, "..", "MapScreen.jsx");
+const MAP_SCREEN_SOURCE = fs.readFileSync(MAP_SCREEN_PATH, "utf8");
+
+describe("MapScreen source contracts", () => {
+  it("does not reintroduce the old Skia pixel-pipeline", () => {
+    expect(MAP_SCREEN_SOURCE).not.toMatch(/@shopify\/react-native-skia/);
+    expect(MAP_SCREEN_SOURCE).not.toMatch(/\breadPixels\b/);
+    expect(MAP_SCREEN_SOURCE).not.toMatch(/\bMakeImage\b/);
+    expect(MAP_SCREEN_SOURCE).not.toMatch(/\bcolorizeImage\b/);
+  });
+
+  it("does not fall back to screen-space region math that drifts from the native map", () => {
+    expect(MAP_SCREEN_SOURCE).not.toMatch(/\bonRegionChange\b/);
+    expect(MAP_SCREEN_SOURCE).not.toMatch(/\boverlayBox\b/);
+    expect(MAP_SCREEN_SOURCE).not.toMatch(/\bxPerLng\b/);
+    expect(MAP_SCREEN_SOURCE).not.toMatch(/\byPerLat\b/);
+  });
+
+  it("still fits the camera to the known bbox instead of guessing from padding", () => {
+    expect(MAP_SCREEN_SOURCE).toMatch(/fitToCoordinates\s*\(\s*BBOX_RING/);
+    expect(MAP_SCREEN_SOURCE).toMatch(/INITIAL_EDGE_PADDING/);
+  });
+
+  it("keeps explicit async overlay state surfaced in the screen", () => {
+    expect(MAP_SCREEN_SOURCE).toMatch(/overlayState/);
+    expect(MAP_SCREEN_SOURCE).toMatch(/status:\s*"loading"/);
+    expect(MAP_SCREEN_SOURCE).toMatch(/status:\s*"error"/);
+  });
+});

--- a/mobile/src/components/__tests__/MapScreen.native.test.jsx
+++ b/mobile/src/components/__tests__/MapScreen.native.test.jsx
@@ -1,0 +1,206 @@
+import React from "react";
+import { act, fireEvent, render } from "@testing-library/react-native";
+import { Image } from "react-native";
+
+import MapScreen from "../MapScreen.jsx";
+import { BBOX_RING } from "../../lib/mapData.js";
+
+const mockFitToCoordinates = jest.fn();
+const mockLoadManifest = jest.fn();
+const mockSubscribe = jest.fn();
+const mockIsReady = jest.fn();
+const mockGetLayerPngUrl = jest.fn();
+
+jest.mock("react-native-maps", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+
+  const MapView = React.forwardRef(({ children, ...props }, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      fitToCoordinates: mockFitToCoordinates,
+    }));
+    return (
+      <View testID="map-view" {...props}>
+        {children}
+      </View>
+    );
+  });
+
+  function Overlay(props) {
+    return (
+      <View
+        testID="map-overlay"
+        accessibilityLabel={`overlay-uri:${props.image?.uri || "missing"}`}
+        {...props}
+      />
+    );
+  }
+
+  function Marker(props) {
+    return <View testID="map-marker" {...props} />;
+  }
+
+  return {
+    __esModule: true,
+    default: MapView,
+    Marker,
+    Overlay,
+    PROVIDER_DEFAULT: undefined,
+  };
+});
+
+jest.mock("../../lib/dataSource.js", () => ({
+  loadManifest: (...args) => mockLoadManifest(...args),
+  subscribe: (...args) => mockSubscribe(...args),
+  isReady: (...args) => mockIsReady(...args),
+  getLayerPngUrl: (...args) => mockGetLayerPngUrl(...args),
+}));
+
+function layerUrl(layer, composite = null) {
+  if (layer === "viz") return "https://example.test/viz-now.png";
+  return `https://example.test/${layer}-${composite ?? 2}d.png`;
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushAsync() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function renderAndPrime() {
+  const utils = render(<MapScreen />);
+  const map = utils.getByTestId("map-view");
+
+  act(() => {
+    map.props.onLayout({ nativeEvent: { layout: { width: 390, height: 844 } } });
+    map.props.onMapReady();
+  });
+
+  act(() => {
+    jest.runAllTimers();
+  });
+
+  await flushAsync();
+  return utils;
+}
+
+describe("MapScreen native behavior", () => {
+  let prefetchSpy;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+
+    mockLoadManifest.mockResolvedValue(null);
+    mockSubscribe.mockReturnValue(jest.fn());
+    mockIsReady.mockReturnValue(true);
+    mockGetLayerPngUrl.mockImplementation((layer, composite) => layerUrl(layer, composite));
+
+    prefetchSpy = jest.spyOn(Image, "prefetch").mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    prefetchSpy.mockRestore();
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it("renders the default overlay, markers, and fits the known bbox once", async () => {
+    const view = await renderAndPrime();
+
+    expect(mockLoadManifest).toHaveBeenCalledTimes(1);
+    expect(mockSubscribe).toHaveBeenCalledTimes(1);
+    expect(prefetchSpy).toHaveBeenCalledWith("https://example.test/sst-2d.png");
+    expect(view.getByTestId("map-overlay").props.accessibilityLabel).toBe(
+      "overlay-uri:https://example.test/sst-2d.png"
+    );
+    expect(view.getAllByTestId("map-marker")).toHaveLength(8);
+    expect(mockFitToCoordinates).toHaveBeenCalledTimes(1);
+    expect(mockFitToCoordinates).toHaveBeenCalledWith(BBOX_RING, {
+      edgePadding: { top: 16, right: 16, bottom: 16, left: 16 },
+      animated: false,
+    });
+    expect(view.getByText(/Sea Temp\s*\.\s*2-day/)).toBeTruthy();
+  });
+
+  it("switches layers and updates the overlay URL without losing composite controls", async () => {
+    const view = await renderAndPrime();
+
+    fireEvent.press(view.getByText("Chl"));
+    await flushAsync();
+
+    expect(prefetchSpy).toHaveBeenLastCalledWith("https://example.test/chl-2d.png");
+    expect(view.getByTestId("map-overlay").props.accessibilityLabel).toBe(
+      "overlay-uri:https://example.test/chl-2d.png"
+    );
+    expect(view.getByText(/Chlorophyll/)).toBeTruthy();
+    expect(view.getByText("1-day")).toBeTruthy();
+    expect(view.getByText("3-day")).toBeTruthy();
+  });
+
+  it("switches to visibility and hides the composite picker", async () => {
+    const view = await renderAndPrime();
+
+    fireEvent.press(view.getByText("Vis"));
+    await flushAsync();
+
+    expect(prefetchSpy).toHaveBeenLastCalledWith("https://example.test/viz-now.png");
+    expect(view.getByTestId("map-overlay").props.accessibilityLabel).toBe(
+      "overlay-uri:https://example.test/viz-now.png"
+    );
+    expect(view.getByText(/Visibility/)).toBeTruthy();
+    expect(view.queryByText("1-day")).toBeNull();
+    expect(view.queryByText("2-day")).toBeNull();
+    expect(view.queryByText("3-day")).toBeNull();
+  });
+
+  it("surfaces prefetch errors and does not mount an overlay", async () => {
+    prefetchSpy.mockRejectedValueOnce(new Error("boom"));
+    const view = await renderAndPrime();
+
+    expect(view.queryByTestId("map-overlay")).toBeNull();
+    expect(view.getByText(/overlay:error.*boom/)).toBeTruthy();
+  });
+
+  it("ignores stale prefetch completions when the user switches layers quickly", async () => {
+    const pending = new Map();
+    prefetchSpy.mockImplementation((url) => {
+      const task = deferred();
+      pending.set(url, task);
+      return task.promise;
+    });
+
+    const view = await renderAndPrime();
+    expect(view.queryByTestId("map-overlay")).toBeNull();
+
+    fireEvent.press(view.getByText("Chl"));
+    await flushAsync();
+
+    act(() => {
+      pending.get("https://example.test/sst-2d.png").resolve(true);
+    });
+    await flushAsync();
+
+    expect(view.queryByTestId("map-overlay")).toBeNull();
+
+    act(() => {
+      pending.get("https://example.test/chl-2d.png").resolve(true);
+    });
+    await flushAsync();
+
+    expect(view.getByTestId("map-overlay").props.accessibilityLabel).toBe(
+      "overlay-uri:https://example.test/chl-2d.png"
+    );
+  });
+});

--- a/mobile/src/lib/__tests__/dataSource.test.js
+++ b/mobile/src/lib/__tests__/dataSource.test.js
@@ -11,8 +11,8 @@ const SAMPLE_MANIFEST = {
   layers: {
     sst: {
       windows: {
-        "1d": { url: "/data/sst_1d.png", dates: ["2026-04-26"] },
-        "2d": { url: "/data/sst_2d.png", dates: ["2026-04-25", "2026-04-26"] },
+        "1d": { url: "/data/sst_1d.png", mobile_url: "/data/sst_1d_color.png", dates: ["2026-04-26"] },
+        "2d": { url: "/data/sst_2d.png", mobile_url: "/data/sst_2d_color.png", dates: ["2026-04-25", "2026-04-26"] },
         "3d": { url: "/data/sst_3d.png" },
       },
     },
@@ -149,16 +149,23 @@ describe("getLayerPngUrl", () => {
     await withFreshModule(async (ds) => {
       await ds.loadManifest();
       const url = ds.getLayerPngUrl("sst", 2);
-      expect(url).toBe("https://shouldidive.com/data/sst_2d.png");
+      expect(url).toBe("https://shouldidive.com/data/sst_2d_color.png");
     });
   });
 
   it("supports all three composites for sst", async () => {
     await withFreshModule(async (ds) => {
       await ds.loadManifest();
-      expect(ds.getLayerPngUrl("sst", 1)).toBe("https://shouldidive.com/data/sst_1d.png");
-      expect(ds.getLayerPngUrl("sst", 2)).toBe("https://shouldidive.com/data/sst_2d.png");
+      expect(ds.getLayerPngUrl("sst", 1)).toBe("https://shouldidive.com/data/sst_1d_color.png");
+      expect(ds.getLayerPngUrl("sst", 2)).toBe("https://shouldidive.com/data/sst_2d_color.png");
       expect(ds.getLayerPngUrl("sst", 3)).toBe("https://shouldidive.com/data/sst_3d.png");
+    });
+  });
+
+  it("falls back to the canonical url when no mobile asset is present", async () => {
+    await withFreshModule(async (ds) => {
+      await ds.loadManifest();
+      expect(ds.getLayerPngUrl("viz", 1)).toBe("https://shouldidive.com/data/viz_p50_ft.png");
     });
   });
 

--- a/mobile/src/lib/__tests__/mapData.test.js
+++ b/mobile/src/lib/__tests__/mapData.test.js
@@ -1,4 +1,11 @@
-import { BBOX, BBOX_CENTER, BBOX_REGION, BBOX_RING, SAVED_SPOTS } from "../mapData.js";
+import {
+  BBOX,
+  BBOX_BOUNDS,
+  BBOX_CENTER,
+  BBOX_REGION,
+  BBOX_RING,
+  SAVED_SPOTS,
+} from "../mapData.js";
 
 
 // These are guardrails for the constants the rest of the app depends
@@ -32,9 +39,9 @@ describe("BBOX_CENTER", () => {
 });
 
 describe("BBOX_REGION", () => {
-  it("pads beyond the raw bbox so the user sees ocean on either side", () => {
-    expect(BBOX_REGION.latitudeDelta).toBeGreaterThan(BBOX.latMax - BBOX.latMin);
-    expect(BBOX_REGION.longitudeDelta).toBeGreaterThan(BBOX.lngMax - BBOX.lngMin);
+  it("matches the raw bbox span exactly", () => {
+    expect(BBOX_REGION.latitudeDelta).toBeCloseTo(BBOX.latMax - BBOX.latMin, 6);
+    expect(BBOX_REGION.longitudeDelta).toBeCloseTo(BBOX.lngMax - BBOX.lngMin, 6);
   });
 });
 
@@ -46,6 +53,15 @@ describe("BBOX_RING", () => {
     expect(ne).toEqual({ latitude: BBOX.latMax, longitude: BBOX.lngMax });
     expect(se).toEqual({ latitude: BBOX.latMin, longitude: BBOX.lngMax });
     expect(sw).toEqual({ latitude: BBOX.latMin, longitude: BBOX.lngMin });
+  });
+});
+
+describe("BBOX_BOUNDS", () => {
+  it("stores southwest and northeast corners for native image overlays", () => {
+    expect(BBOX_BOUNDS).toEqual([
+      [BBOX.latMin, BBOX.lngMin],
+      [BBOX.latMax, BBOX.lngMax],
+    ]);
   });
 });
 

--- a/mobile/src/lib/dataSource.js
+++ b/mobile/src/lib/dataSource.js
@@ -74,6 +74,10 @@ export function isReady() {
  *   composite: 1 | 2 | 3              (1d / 2d / 3d windows; sst+chl)
  *               or null (viz: only "now" exists)
  *
+ * Mobile prefers a pre-colourized asset when the manifest provides one
+ * (`mobile_url` or `color_url`), and falls back to the canonical
+ * grayscale PNG otherwise.
+ *
  * Returns null when the manifest hasn't loaded yet or the requested
  * slot is missing.
  */
@@ -91,8 +95,9 @@ export function getLayerPngUrl(layer, composite = null) {
     return null; // wind/swell handled by their 5d feeds, not addressed here
   }
   const w = windows[key];
-  if (!w?.url) return null;
-  return resolveAssetUrl(w.url);
+  const assetUrl = w?.mobile_url || w?.color_url || w?.url;
+  if (!assetUrl) return null;
+  return resolveAssetUrl(assetUrl);
 }
 
 

--- a/mobile/src/lib/mapData.js
+++ b/mobile/src/lib/mapData.js
@@ -24,12 +24,13 @@ export const BBOX_CENTER = {
   longitude: (BBOX.lngMin + BBOX.lngMax) / 2,
 };
 
-// Camera deltas for the initial fit. These pad slightly outside the
-// bbox so the user can see the open ocean on either side at launch.
+// Camera deltas for the initial fit. Keep these matched to the model
+// bbox itself; view chrome padding belongs in the screen's fit logic,
+// not baked into the geographic extent.
 export const BBOX_REGION = {
   ...BBOX_CENTER,
-  latitudeDelta:  BBOX.latMax - BBOX.latMin + 0.4,
-  longitudeDelta: BBOX.lngMax - BBOX.lngMin + 0.4,
+  latitudeDelta:  BBOX.latMax - BBOX.latMin,
+  longitudeDelta: BBOX.lngMax - BBOX.lngMin,
 };
 
 // Same diver-curated saved spots as the web app. Kept verbatim so
@@ -53,4 +54,11 @@ export const BBOX_RING = [
   { latitude: BBOX.latMax, longitude: BBOX.lngMax },
   { latitude: BBOX.latMin, longitude: BBOX.lngMax },
   { latitude: BBOX.latMin, longitude: BBOX.lngMin },
+];
+
+// `react-native-maps` image overlays want southwest + northeast bounds,
+// not the clockwise corner ring above.
+export const BBOX_BOUNDS = [
+  [BBOX.latMin, BBOX.lngMin],
+  [BBOX.latMax, BBOX.lngMax],
 ];

--- a/pipeline/color_ramps.py
+++ b/pipeline/color_ramps.py
@@ -1,0 +1,88 @@
+"""Shared color ramps for server-rendered mobile overlay PNGs."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from PIL import Image
+
+SST_RANGE = (9.0, 25.0)
+CHL_RANGE = (0.05, 20.0)
+VIZ_RANGE_FT = (0.0, 80.0)
+
+SST_STOPS = [
+    (0.00, (12, 38, 130)),
+    (0.25, (40, 130, 210)),
+    (0.50, (120, 220, 220)),
+    (0.70, (240, 220, 110)),
+    (0.85, (230, 110, 60)),
+    (1.00, (170, 20, 35)),
+]
+
+CHL_STOPS = [
+    (0.00, (10, 50, 140)),
+    (0.25, (30, 130, 200)),
+    (0.50, (60, 200, 180)),
+    (0.75, (110, 210, 90)),
+    (1.00, (50, 130, 40)),
+]
+
+VIZ_STOPS_FT = [
+    (0.0, (194, 65, 12)),
+    (10.0, (234, 179, 8)),
+    (20.0, (132, 204, 22)),
+    (30.0, (6, 182, 212)),
+    (50.0, (3, 105, 161)),
+]
+
+_CHL_RANGE_LOG = (math.log10(CHL_RANGE[0]), math.log10(CHL_RANGE[1]))
+
+
+def _lerp_rgb(a, b, amount):
+    return (
+        int(round(a[0] + (b[0] - a[0]) * amount)),
+        int(round(a[1] + (b[1] - a[1]) * amount)),
+        int(round(a[2] + (b[2] - a[2]) * amount)),
+    )
+
+
+def _ramp_lookup(stops, value):
+    value = max(stops[0][0], min(stops[-1][0], value))
+    for index in range(len(stops) - 1):
+        start, end = stops[index], stops[index + 1]
+        if start[0] <= value <= end[0]:
+            amount = (value - start[0]) / (end[0] - start[0])
+            return _lerp_rgb(start[1], end[1], amount)
+    return stops[-1][1]
+
+
+def _value_to_rgb(layer, value):
+    if layer == "sst":
+        low, high = SST_RANGE
+        return _ramp_lookup(SST_STOPS, (value - low) / (high - low))
+    if layer == "chl":
+        if value <= 0:
+            return _ramp_lookup(CHL_STOPS, 0.0)
+        low, high = _CHL_RANGE_LOG
+        return _ramp_lookup(CHL_STOPS, (math.log10(value) - low) / (high - low))
+    if layer == "viz":
+        return _ramp_lookup(VIZ_STOPS_FT, value)
+    raise ValueError(f"Unsupported color ramp layer: {layer}")
+
+
+def encode_color_png(arr, layer, out_path):
+    rgba = np.zeros((*arr.shape, 4), dtype=np.uint8)
+    flat_values = arr.reshape(-1)
+    flat_rgba = rgba.reshape(-1, 4)
+
+    for index, value in enumerate(flat_values):
+        if not np.isfinite(value):
+            continue
+        rgb = _value_to_rgb(layer, float(value))
+        flat_rgba[index, 0] = rgb[0]
+        flat_rgba[index, 1] = rgb[1]
+        flat_rgba[index, 2] = rgb[2]
+        flat_rgba[index, 3] = 255
+
+    Image.fromarray(rgba, mode="RGBA").save(out_path, optimize=True)

--- a/pipeline/fetch.py
+++ b/pipeline/fetch.py
@@ -29,6 +29,8 @@ import requests
 import xarray as xr
 from PIL import Image
 
+from color_ramps import encode_color_png
+
 BBOX = dict(lat_min=31.8, lat_max=37.6, lng_min=-124.0, lng_max=-116.8)
 ERDDAP_BASE = "https://coastwatch.pfeg.noaa.gov/erddap/griddap"
 
@@ -164,12 +166,15 @@ def build_layer(layer: str, cfg: dict, end: date, want: int = 3, max_back: int =
             continue
         c = composite(st)
         out = OUT_DIR / f"{layer}_{win}.png"
+        color_out = OUT_DIR / f"{layer}_{win}_color.png"
         encode_png(c, cfg, out)
+        encode_color_png(c, layer, color_out)
         manifest_layer["windows"][win] = {
             "url": f"/data/{layer}_{win}.png",
+            "mobile_url": f"/data/{layer}_{win}_color.png",
             "dates": [d.isoformat() for d in actual[-len(st):]],
         }
-        print(f"  wrote {out.name}  ({h}x{w})")
+        print(f"  wrote {out.name} + {color_out.name}  ({h}x{w})")
     return manifest_layer
 
 

--- a/pipeline/fetch_visibility.py
+++ b/pipeline/fetch_visibility.py
@@ -34,6 +34,7 @@ import numpy as np
 from PIL import Image
 from scipy.spatial import cKDTree
 
+from color_ramps import encode_color_png
 from viz_predict import predict as viz_predict
 
 # Match the existing app's bbox.
@@ -613,8 +614,9 @@ def main():
     encode_linear_png(viz_p50_ft, *VIZ_RANGE_FT, OUT_DIR / "viz_p50_ft.png")
     encode_linear_png(viz_p10_ft, *VIZ_RANGE_FT, OUT_DIR / "viz_p10_ft.png")
     encode_linear_png(viz_p90_ft, *VIZ_RANGE_FT, OUT_DIR / "viz_p90_ft.png")
+    encode_color_png(viz_p50_ft, "viz", OUT_DIR / "viz_p50_ft_color.png")
     encode_quality_png(quality, OUT_DIR / "viz_quality.png")
-    print("  wrote viz_{p10,p50,p90}_ft.png + viz_quality.png")
+    print("  wrote viz_{p10,p50,p90}_ft.png + viz_p50_ft_color.png + viz_quality.png")
 
     # Merge into manifest
     manifest_path = OUT_DIR / "manifest.json"
@@ -637,6 +639,7 @@ def main():
         "windows": {
             "now": {
                 "url":      "/data/viz_p50_ft.png",
+                "mobile_url": "/data/viz_p50_ft_color.png",
                 "p10_url":  "/data/viz_p10_ft.png",
                 "p90_url":  "/data/viz_p90_ft.png",
                 "quality_url": "/data/viz_quality.png",


### PR DESCRIPTION
## What changed
- replaced the native map’s screen-space image math with `react-native-maps` geographic `Overlay` bounds so the mobile heatmap tracks the real map instead of drifting
- tightened the initial mobile bbox fit so the launch camera matches the intended coverage area instead of padding too wide
- added a cross-platform `npm run validate` runner for Windows PowerShell
- taught the mobile client and pipeline about pre-colorized mobile overlay assets
- refreshed the mobile README and tests to reflect the new rollout path

## Why
The mobile app was diverging from the web renderer in two ways: it started from a padded camera region and it stretched the overlay from raw region deltas instead of using the map engine’s geographic overlay support. That made the visible footprint too large and could misalign the overlay on native maps.

## Impact
- mobile overlays should land in the correct geographic bounds more reliably
- the initial map framing should be closer to the web app’s intended area
- Windows contributors can now run the validation flow without requiring `bash`

## Validation
- `npm run validate`
- targeted Jest coverage for `dataSource` and `mapData`
