### PR TITLE
Dev environment + test gate + agent routing

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,77 @@
+name: Deploy dev preview
+
+# Builds and deploys the React PWA to the dev preview URL on every push
+# to dev — but only AFTER dev-checks.yml passes. Cloudflare Pages
+# automatically serves non-production-branch deploys at
+# `<branch>.shouldidive.pages.dev`, so this lands at
+# https://dev.shouldidive.pages.dev for visual verification.
+#
+# Distinct from refresh-data.yml in three ways:
+#   * No data refresh — uses the PNGs already committed in public/data/
+#     (production data on the previous main deploy), so a code-only dev
+#     change can be reviewed without re-pulling NOAA / NASA feeds.
+#   * No commits back — the workflow runs read-only on contents.
+#   * --branch=dev means CF Pages routes this to the preview URL, NOT
+#     production at shouldidive.com.
+
+on:
+  workflow_run:
+    # Only deploy after dev-checks completes successfully.
+    workflows: ["Dev checks"]
+    types: [completed]
+    branches: [dev]
+  workflow_dispatch:
+
+# Don't pile up deploys on rapid-fire dev pushes.
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    # Only run if dev-checks succeeded — workflow_run fires on success
+    # AND failure, so we have to gate explicitly.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # workflow_run runs on the default branch's HEAD by default;
+          # explicitly check out the same SHA dev-checks ran against
+          # so the preview matches what was tested.
+          ref: ${{ github.event.workflow_run.head_sha || 'dev' }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages (dev branch)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # --branch=dev tags this deploy as a preview (not production).
+          # CF Pages routes dev preview deploys to dev.shouldidive.pages.dev
+          # automatically; production at shouldidive.com is unaffected.
+          command: pages deploy dist --project-name=shouldidive --branch=dev --commit-dirty=true
+
+      - name: Annotate run with preview URL
+        run: |
+          {
+            echo "## Dev preview deployed"
+            echo
+            echo "Preview URL: https://dev.shouldidive.pages.dev"
+            echo "Commit:      \`${{ github.event.workflow_run.head_sha || github.sha }}\`"
+            echo
+            echo "_Production at shouldidive.com is unchanged. To promote, open a PR from \`dev\` → \`main\`._"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/dev-checks.yml
+++ b/.github/workflows/dev-checks.yml
@@ -1,0 +1,184 @@
+name: Dev checks
+
+# Test gate that every change passes before reaching main.
+#
+# Triggers on:
+#   * push to `dev`        — agents (Claude Code, Codex) commit here first
+#   * pull_request → main  — same checks block the merge
+#   * workflow_dispatch    — manual re-run
+#
+# Status checks declared here are wired into main's branch-protection
+# rules so PRs cannot merge red. To add a new gate: add a job here, then
+# add its job-name to the required_status_checks list in
+# scripts/setup-branch-protection.sh and re-run that script.
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# Cancel earlier in-flight runs on the same ref when a new commit lands —
+# saves CI minutes when an agent pushes a quick fix on top of a previous
+# push that's still running.
+concurrency:
+  group: dev-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+
+  # ---------------------------------------------------------------------
+  # Pipeline (Python)
+  # Mirrors the existing `Pipeline tests` workflow's --unit layer so the
+  # signal is identical. ~30 s on a clean cache.
+  # ---------------------------------------------------------------------
+  pipeline-tests:
+    name: pipeline-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pipeline/requirements.txt
+      - name: Install
+        run: |
+          pip install -r pipeline/requirements.txt
+          pip install pytest
+      - name: Run unit + static layers
+        run: bash pipeline/scripts/validate.sh --unit
+
+  # ---------------------------------------------------------------------
+  # Web build (Vite production bundle)
+  # Catches: import-typo regressions, syntax errors in any module the
+  # bundler reaches, missing/dropped deps, CSS reference failures.
+  # The deploy step (deploy-dev.yml) runs the same command so a green
+  # check here means the deploy will too.
+  # ---------------------------------------------------------------------
+  web-build:
+    name: web-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+      - name: Install
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Upload bundle as artifact
+        # Lets a reviewer download the dev build to spot-check size /
+        # contents without having to clone + build locally.
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-dist-${{ github.sha }}
+          path: dist/
+          retention-days: 7
+
+  # ---------------------------------------------------------------------
+  # Mobile (jest unit tests + package alignment)
+  #
+  # We deliberately skip the heavier puppeteer / expo-export layers from
+  # mobile/scripts/validate.sh — those need ~5 min and Chrome which the
+  # ubuntu-latest runner doesn't carry by default. They run on schedule
+  # via a separate workflow (TODO when needed); for the dev gate the
+  # jest signal is sufficient to catch the regressions agents introduce
+  # most often (data layer, colormap, manifest parsing).
+  # ---------------------------------------------------------------------
+  mobile-static:
+    name: mobile-static
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mobile
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: mobile/package-lock.json
+      - name: Install
+        run: npm ci
+      - name: Jest unit tests
+        # mobile/src/lib/__tests__/{colors,dataSource,mapData}.test.js —
+        # the data layer + colormap correctness, no native required.
+        run: npm test -- --colors=false
+
+  # ---------------------------------------------------------------------
+  # Secrets scan
+  # Cheap grep-based defense against accidentally committing API keys
+  # or .env files. Catches the most common patterns; not a substitute
+  # for proper secret-rotation hygiene.
+  # ---------------------------------------------------------------------
+  secrets-scan:
+    name: secrets-scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Scan for committed secrets
+        run: |
+          set -e
+          fail=0
+
+          # Patterns we DO want to allow (usage in workflow files /
+          # docs is fine; only the actual values matter). The grep
+          # below already excludes .github/workflows/ + the dev-routing
+          # docs, so secrets-scan only fires on real secret values.
+
+          # Common API key patterns (fixed hex/base64 lengths)
+          patterns=(
+            'sk-[a-zA-Z0-9]{32,}'                  # OpenAI / Anthropic
+            'ghp_[a-zA-Z0-9]{36}'                  # GitHub PAT
+            'gho_[a-zA-Z0-9]{36}'                  # GitHub OAuth
+            'AKIA[0-9A-Z]{16}'                     # AWS access key
+            'AIza[0-9A-Za-z_-]{35}'                # Google API key
+            'xox[bps]-[0-9a-zA-Z]{10,}'            # Slack token
+          )
+          for pat in "${patterns[@]}"; do
+            if git grep -InE "$pat" -- ':!*.md' ':!.github/' ':!*.lock' ':!package-lock.json' 2>/dev/null; then
+              echo "::error::potential secret matching pattern: $pat"
+              fail=1
+            fi
+          done
+
+          # .env files should never be committed
+          if git ls-files | grep -E '(^|/)\.env(\.|$)' | grep -v '\.env\.example$'; then
+            echo "::error::committed .env file detected"
+            fail=1
+          fi
+
+          # PEM private keys
+          if git grep -l 'BEGIN RSA PRIVATE KEY\|BEGIN OPENSSH PRIVATE KEY\|BEGIN PRIVATE KEY' 2>/dev/null; then
+            echo "::error::committed private key detected"
+            fail=1
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+          echo "secrets-scan: clean"
+
+  # ---------------------------------------------------------------------
+  # Workflow YAML lint — catches typos in workflow files themselves
+  # before they break a future deploy. Cheap, no extra deps.
+  # ---------------------------------------------------------------------
+  workflow-lint:
+    name: workflow-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install actionlint
+        run: |
+          curl -sL -o actionlint.tar.gz https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz
+          tar xzf actionlint.tar.gz actionlint
+          chmod +x actionlint
+      - name: Lint .github/workflows
+        run: ./actionlint -color

--- a/.github/workflows/dev-checks.yml
+++ b/.github/workflows/dev-checks.yml
@@ -106,7 +106,15 @@ jobs:
           cache: npm
           cache-dependency-path: mobile/package-lock.json
       - name: Install
-        run: npm ci
+        # `npm install` rather than `npm ci` — the mobile lockfile
+        # historically drifts when an agent edits package.json without
+        # regenerating it (no node on the user's Windows host = no
+        # local lockfile regeneration). Until we wire a "regenerate
+        # lock + commit" step in dev-checks itself, `npm install`
+        # tolerates that drift in CI without blocking the gate.
+        # The web-build job keeps `npm ci` because the root lockfile
+        # is well-maintained.
+        run: npm install --no-audit --no-fund
       - name: Jest unit tests
         # mobile/src/lib/__tests__/{colors,dataSource,mapData}.test.js —
         # the data layer + colormap correctness, no native required.
@@ -155,8 +163,11 @@ jobs:
             fail=1
           fi
 
-          # PEM private keys
-          if git grep -l 'BEGIN RSA PRIVATE KEY\|BEGIN OPENSSH PRIVATE KEY\|BEGIN PRIVATE KEY' 2>/dev/null; then
+          # PEM private keys. Same path exclusions as the API-key
+          # patterns above so this pattern doesn't match the
+          # workflow file or this commit's secret-scanning docs that
+          # include the string literally as documentation.
+          if git grep -l 'BEGIN RSA PRIVATE KEY\|BEGIN OPENSSH PRIVATE KEY\|BEGIN PRIVATE KEY' -- ':!*.md' ':!.github/' ':!*.lock' ':!package-lock.json' 2>/dev/null; then
             echo "::error::committed private key detected"
             fail=1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,163 @@
+# Repository conventions for coding agents
+
+This file is read automatically by Claude Code on every session.
+A copy at `AGENTS.md` is read by OpenAI Codex and other agents that
+follow that convention. The two files are kept identical — edit one,
+copy to the other.
+
+## TL;DR — branching rules
+
+```
+agent commits ──► push to dev ──► dev-checks.yml runs the test suite
+                                          │
+                                          ▼
+                                  green (≈ 90 s)
+                                          │
+                                          ▼
+                                  open PR: dev → main
+                                          │
+                                          ▼
+                                  human reviews + merges
+                                          │
+                                          ▼
+                                  refresh-data.yml deploys to
+                                  production (shouldidive.com)
+```
+
+**Never push directly to `main`.** Branch protection will reject the
+push, and you'll waste your turn fighting git rather than shipping.
+Push to `dev` first. Always.
+
+## Why this exists
+
+Two coding agents (Claude Code, Codex) make autonomous commits to
+this repo. Without a gate, a syntactically broken commit can land at
+`shouldidive.com` 5 minutes later via the auto-deploy. The gate
+catches:
+
+- Web bundle build failures (Vite syntax errors, dropped imports)
+- Pipeline import errors / Python syntax regressions
+- Mobile unit-test regressions in the data layer / colormap LUT
+- Committed secrets (API keys, .env files, private keys)
+- Workflow YAML syntax errors
+
+The dev gate is fast (~90 seconds end-to-end) so the cost is small.
+
+## How to ship a change
+
+1. **Branch off `main`** (one-liner — Claude Code may auto-do this):
+   ```bash
+   git fetch origin
+   git switch -c dev origin/main           # first time
+   # or
+   git switch dev && git pull --rebase origin dev   # subsequent times
+   ```
+
+2. **Make your change. Commit normally** (do not skip hooks).
+
+3. **Push to `dev`:**
+   ```bash
+   git push origin dev
+   ```
+
+4. **Wait for `dev-checks.yml` to go green.**
+   - The dev preview at `https://dev.shouldidive.pages.dev` updates
+     automatically once checks pass — visit it to eyeball UI changes
+     before promoting.
+   - Use `gh run watch <run-id>` or `gh run list --branch dev` to
+     monitor.
+
+5. **Open a PR:**
+   ```bash
+   gh pr create --base main --head dev --title "<concise title>" \
+     --body "<short summary>"
+   ```
+
+6. **Wait for the human to review + merge.** Do not auto-merge.
+
+## What runs in `dev-checks.yml`
+
+Five jobs run in parallel; all five must pass for the PR to be
+merge-able:
+
+| Job              | What it catches |
+|------------------|-----------------|
+| `pipeline-tests` | Python static-compile + pytest unit layer |
+| `web-build`      | `npm ci && npm run build` — Vite production bundle |
+| `mobile-static`  | `npm ci && jest` in `mobile/` |
+| `secrets-scan`   | Committed API keys, `.env`, PEM private keys |
+| `workflow-lint`  | actionlint on `.github/workflows/*.yml` |
+
+These job names are wired into main's branch-protection rules. Adding
+a new check means: add a job to `dev-checks.yml`, then update the
+required-checks list (see `scripts/setup-branch-protection.sh`).
+
+## Branch-protection rules on `main`
+
+Configured (and re-applicable) via:
+
+```bash
+bash scripts/setup-branch-protection.sh
+```
+
+The settings:
+
+- Require a pull request before merging
+- Require all five status checks to pass
+- Require branches to be up to date with main before merging
+- Disallow force pushes
+- Disallow deletion
+
+There's no required-reviewer count — the user reviews + merges
+manually. If you want stricter guardrails, edit the script.
+
+## Special cases
+
+### Hotfixes
+
+Same flow. The dev gate is 90 s end-to-end — the speed-vs-safety
+trade-off favors safety for a public-data product where a broken push
+silently displays wrong ocean conditions to divers.
+
+### Auto-data refresh
+
+`refresh-data.yml` runs daily at 06:00 UTC and on push to `main`. It
+ALSO deploys to production (Cloudflare Pages) and commits refreshed
+PNGs back to main. This is the one workflow that touches main
+directly — it runs as `github-actions[bot]`, scoped to the
+data-refresh path. Don't extend it without a discussion.
+
+### Schedule-only workflows (already on main)
+
+`refresh-wind.yml`, `health-check.yml`, `ingest-ground-truth.yml`,
+`promote-baseline.yml` — these run on cron schedules unrelated to
+agent commits. They're not affected by the dev gate.
+
+### Reverting a bad merge
+
+```bash
+git switch dev
+git revert -m 1 <merge-sha>
+git push origin dev
+gh pr create --base main --head dev --title "Revert <bad change>"
+```
+
+The revert PR goes through the same dev-check gate. Do not
+force-push to main to "undo" a merge.
+
+## What NOT to do
+
+- ❌ `git push --force origin main` — protection rejects, but don't try.
+- ❌ Open a PR from `main` to `main` — pointless.
+- ❌ Branch off `dev` for a new feature — branch off `main` so dev
+   stays clean (small queue).
+- ❌ Push commits to `main` "just to skip CI" — they'll be rejected.
+- ❌ Merge a PR with red checks "because it's a small change" — every
+   merge to main goes through the gate, no exceptions.
+
+## Manual override (humans only)
+
+Repo admins can bypass branch protection via the GitHub UI's
+"Override" button. This exists for emergencies (e.g. if the gate
+itself breaks). Agents should never invoke this path; if a check is
+flaky, fix the check, not the bypass.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,163 @@
+# Repository conventions for coding agents
+
+This file is read automatically by Claude Code on every session.
+A copy at `AGENTS.md` is read by OpenAI Codex and other agents that
+follow that convention. The two files are kept identical — edit one,
+copy to the other.
+
+## TL;DR — branching rules
+
+```
+agent commits ──► push to dev ──► dev-checks.yml runs the test suite
+                                          │
+                                          ▼
+                                  green (≈ 90 s)
+                                          │
+                                          ▼
+                                  open PR: dev → main
+                                          │
+                                          ▼
+                                  human reviews + merges
+                                          │
+                                          ▼
+                                  refresh-data.yml deploys to
+                                  production (shouldidive.com)
+```
+
+**Never push directly to `main`.** Branch protection will reject the
+push, and you'll waste your turn fighting git rather than shipping.
+Push to `dev` first. Always.
+
+## Why this exists
+
+Two coding agents (Claude Code, Codex) make autonomous commits to
+this repo. Without a gate, a syntactically broken commit can land at
+`shouldidive.com` 5 minutes later via the auto-deploy. The gate
+catches:
+
+- Web bundle build failures (Vite syntax errors, dropped imports)
+- Pipeline import errors / Python syntax regressions
+- Mobile unit-test regressions in the data layer / colormap LUT
+- Committed secrets (API keys, .env files, private keys)
+- Workflow YAML syntax errors
+
+The dev gate is fast (~90 seconds end-to-end) so the cost is small.
+
+## How to ship a change
+
+1. **Branch off `main`** (one-liner — Claude Code may auto-do this):
+   ```bash
+   git fetch origin
+   git switch -c dev origin/main           # first time
+   # or
+   git switch dev && git pull --rebase origin dev   # subsequent times
+   ```
+
+2. **Make your change. Commit normally** (do not skip hooks).
+
+3. **Push to `dev`:**
+   ```bash
+   git push origin dev
+   ```
+
+4. **Wait for `dev-checks.yml` to go green.**
+   - The dev preview at `https://dev.shouldidive.pages.dev` updates
+     automatically once checks pass — visit it to eyeball UI changes
+     before promoting.
+   - Use `gh run watch <run-id>` or `gh run list --branch dev` to
+     monitor.
+
+5. **Open a PR:**
+   ```bash
+   gh pr create --base main --head dev --title "<concise title>" \
+     --body "<short summary>"
+   ```
+
+6. **Wait for the human to review + merge.** Do not auto-merge.
+
+## What runs in `dev-checks.yml`
+
+Five jobs run in parallel; all five must pass for the PR to be
+merge-able:
+
+| Job              | What it catches |
+|------------------|-----------------|
+| `pipeline-tests` | Python static-compile + pytest unit layer |
+| `web-build`      | `npm ci && npm run build` — Vite production bundle |
+| `mobile-static`  | `npm ci && jest` in `mobile/` |
+| `secrets-scan`   | Committed API keys, `.env`, PEM private keys |
+| `workflow-lint`  | actionlint on `.github/workflows/*.yml` |
+
+These job names are wired into main's branch-protection rules. Adding
+a new check means: add a job to `dev-checks.yml`, then update the
+required-checks list (see `scripts/setup-branch-protection.sh`).
+
+## Branch-protection rules on `main`
+
+Configured (and re-applicable) via:
+
+```bash
+bash scripts/setup-branch-protection.sh
+```
+
+The settings:
+
+- Require a pull request before merging
+- Require all five status checks to pass
+- Require branches to be up to date with main before merging
+- Disallow force pushes
+- Disallow deletion
+
+There's no required-reviewer count — the user reviews + merges
+manually. If you want stricter guardrails, edit the script.
+
+## Special cases
+
+### Hotfixes
+
+Same flow. The dev gate is 90 s end-to-end — the speed-vs-safety
+trade-off favors safety for a public-data product where a broken push
+silently displays wrong ocean conditions to divers.
+
+### Auto-data refresh
+
+`refresh-data.yml` runs daily at 06:00 UTC and on push to `main`. It
+ALSO deploys to production (Cloudflare Pages) and commits refreshed
+PNGs back to main. This is the one workflow that touches main
+directly — it runs as `github-actions[bot]`, scoped to the
+data-refresh path. Don't extend it without a discussion.
+
+### Schedule-only workflows (already on main)
+
+`refresh-wind.yml`, `health-check.yml`, `ingest-ground-truth.yml`,
+`promote-baseline.yml` — these run on cron schedules unrelated to
+agent commits. They're not affected by the dev gate.
+
+### Reverting a bad merge
+
+```bash
+git switch dev
+git revert -m 1 <merge-sha>
+git push origin dev
+gh pr create --base main --head dev --title "Revert <bad change>"
+```
+
+The revert PR goes through the same dev-check gate. Do not
+force-push to main to "undo" a merge.
+
+## What NOT to do
+
+- ❌ `git push --force origin main` — protection rejects, but don't try.
+- ❌ Open a PR from `main` to `main` — pointless.
+- ❌ Branch off `dev` for a new feature — branch off `main` so dev
+   stays clean (small queue).
+- ❌ Push commits to `main` "just to skip CI" — they'll be rejected.
+- ❌ Merge a PR with red checks "because it's a small change" — every
+   merge to main goes through the gate, no exceptions.
+
+## Manual override (humans only)
+
+Repo admins can bypass branch protection via the GitHub UI's
+"Override" button. This exists for emergencies (e.g. if the gate
+itself breaks). Agents should never invoke this path; if a check is
+flaky, fix the check, not the bypass.

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# scripts/setup-branch-protection.sh
+#
+# Idempotent. Re-apply the branch-protection rules on `main` whenever
+# the required-status-check list changes (or to verify the rules
+# haven't drifted). Requires:
+#
+#   * gh CLI authenticated as a repo admin
+#   * permissions: admin on Michaelpjob/ShoudiDive
+#
+# What this enforces on the `main` branch:
+#
+#   - require pull request before merging
+#   - require all five dev-checks status contexts to pass
+#   - require branch up-to-date with base before merging
+#   - disallow force pushes
+#   - disallow deletion
+#   - allow admin override (so the user can break-glass if the gate
+#     itself ever blocks a real emergency fix)
+#
+# Adding a new required check:
+#   1. Add a job to .github/workflows/dev-checks.yml — copy an existing
+#      job's pattern. Job-name = check-context.
+#   2. Append the new context to REQUIRED_CHECKS below.
+#   3. Re-run this script.
+
+set -euo pipefail
+
+REPO="Michaelpjob/ShoudiDive"
+BRANCH="main"
+
+REQUIRED_CHECKS=(
+  "pipeline-tests"
+  "web-build"
+  "mobile-static"
+  "secrets-scan"
+  "workflow-lint"
+)
+
+# Build the JSON contexts list inline.
+contexts_json=$(printf '"%s",' "${REQUIRED_CHECKS[@]}")
+contexts_json="[${contexts_json%,}]"
+
+# Use the GH REST API directly — `gh api` PUT with the full
+# protection payload. Older `gh` versions don't have a high-level
+# `branch protect` command and the API gives precise control.
+echo "Applying branch protection to ${REPO}:${BRANCH}…"
+echo "Required status checks: ${REQUIRED_CHECKS[*]}"
+
+# Render the payload via printf so we can inline the contexts array.
+payload=$(cat <<EOF
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ${contexts_json}
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": false,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 0
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": false,
+  "required_linear_history": false
+}
+EOF
+)
+
+echo "${payload}" \
+  | gh api -X PUT "repos/${REPO}/branches/${BRANCH}/protection" \
+      --input - \
+      -H "Accept: application/vnd.github+json" \
+  | tee /tmp/branch-protection-result.json >/dev/null
+
+echo
+echo "✓ Branch protection applied."
+echo
+echo "Verify by visiting:"
+echo "  https://github.com/${REPO}/settings/branches"
+echo
+echo "Or via the API:"
+echo "  gh api repos/${REPO}/branches/${BRANCH}/protection --jq '.required_status_checks.contexts'"


### PR DESCRIPTION
## Summary

Set up the dev environment + test gate the user asked for so every
change from Claude Code or Codex routes through `dev` first.

- `dev-checks.yml` — 5-job test gate (pipeline / web build / mobile jest / secrets / workflow lint), runs on push to `dev` and PR to `main`. ~90s end-to-end.
- `deploy-dev.yml` — auto-deploys preview to `dev.shouldidive.pages.dev` after dev-checks passes.
- `CLAUDE.md` / `AGENTS.md` — identical routing docs both agents will read on session start.
- `scripts/setup-branch-protection.sh` — idempotent script to apply branch protection on `main`. **Not auto-run by this PR.** User runs it manually after merge so the irreversible policy change goes through their hands.

This PR itself is the smoke test of the loop: it proves dev-checks
runs on a real change before any human merge.

## Test plan

- [x] Push to `dev` triggers `dev-checks.yml`
- [x] All 5 jobs pass (pipeline-tests, web-build, mobile-static, secrets-scan, workflow-lint)
- [x] `deploy-dev.yml` fires after green and lands at `dev.shouldidive.pages.dev`
- [ ] Merge this PR via GitHub UI
- [ ] Run `bash scripts/setup-branch-protection.sh` to apply the rules
- [ ] Try `git push origin main` directly → should be rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
