### PR TITLE
SST Phase A-E — buoy correction + scoring + nearshore + forecast support

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -119,6 +119,14 @@ jobs:
           EARTHDATA_TOKEN: ${{ secrets.EARTHDATA_TOKEN }}
         run: python pipeline/check_feeds.py
 
+      - name: Run 5-day SST forecast (Phase E)
+        # Persistence + climatology decay. Reads sst_1d.png + sst_climo.png
+        # written by fetch.py / fetch_climatology.py above. Outputs to
+        # public/data/sst5d/. Soft-fail: a missing climatology shouldn't
+        # block the rest of the pipeline.
+        continue-on-error: true
+        run: python pipeline/fetch_sst_5day.py
+
       - name: Run visibility prediction
         # Runs after the satellite/wave/river/tide/climo fetches so the
         # prediction sees the freshest inputs. Wind PNGs are committed in
@@ -141,6 +149,28 @@ jobs:
         # publish the exact finding instead of losing it with the runner.
         continue-on-error: true
         run: python pipeline/check_manifest_freshness.py --layers sst,sst7d,sst5d,chl,kd490,wind,wind5d,swell5d,current5d,viz,wave,precip --check-sst-source
+
+      - name: Score SST predictions vs buoy + dive-log obs (Phase C)
+        # Joins observations.jsonl rows with observed_sst_f / observed_sst_c
+        # against today's archive snapshot, writes:
+        #   pipeline/validation/data/sst_residuals.jsonl
+        #   pipeline/validation/data/sst_per_zone_metrics.json
+        #   pipeline/validation/data/sst_per_spot_metrics.json
+        # Soft-fail until the residual archive is large enough to be
+        # meaningful (~30 obs/zone, ~20 obs/spot).
+        continue-on-error: true
+        run: python -m validation.sst_score
+        working-directory: pipeline
+
+      - name: SST watchdog — analyse SST metrics, flag anomalies (Phase C)
+        # Reads sst_per_zone_metrics + sst_per_spot_metrics, runs R1
+        # (zone bias), R3 (correlation), R5 (per-spot bias). Exits 1
+        # if any rule fires. The existing watchdog issue-sync block
+        # below picks up `sst-watchdog` next iteration once we wire it.
+        continue-on-error: true
+        id: sst_watchdog
+        run: python -m validation.sst_watchdog
+        working-directory: pipeline
 
       - name: Score visibility predictions against ground-truth
         # Joins observations.jsonl (collected by ingest-ground-truth.yml)

--- a/pipeline/fetch.py
+++ b/pipeline/fetch.py
@@ -365,6 +365,128 @@ def build_sst_forecast(
     return summary
 
 
+# ----- Phase B + D — buoy + nearshore corrections ----------------------
+#
+# These run BEFORE build_sst_forecast above, mutating the stack in
+# place so the forecast (and the rolling 1d/2d/3d composites) inherit
+# the buoy-anchored correction. They're additive: each returns a small
+# manifest block describing what got applied, both null-safe.
+
+def _apply_sst_buoy_correction(*, stack: list, grid_h: int, grid_w: int) -> dict | None:
+    """Compute the buoy-anchored correction surface for today and apply
+    it in-place to every grid in ``stack``.
+
+    Returns the JSON-serializable summary block destined for
+    manifest.json's ``layers.sst.buoy_correction``, or None if the
+    fetch / correction failed for any reason. Failure is silent in the
+    sense that the layer still ships — just without the buoy correction.
+    Log lines are loud enough that the next ``check_published.py``
+    health-check run notices a missing ``buoy_correction`` block.
+    """
+    try:
+        # Local import — keep the rest of fetch.py able to run on hosts
+        # that don't have ``pipeline.sst_buoy_correction`` available
+        # (mostly: editor static-analysis pre-commit, where requests is
+        # already a dep but we don't want to make this module a hard
+        # gate for those flows).
+        from pipeline.sst_buoy_correction import (
+            BUOYS as _BUOYS,
+            fetch_buoy_readings,
+            kriging_correction_surface,
+            correction_summary,
+        )
+    except ImportError as exc:
+        print(f"[sst] buoy correction unavailable: {exc}")
+        return None
+
+    print(f"[sst] fetching buoy readings (last 24h, {len(_BUOYS)} buoys)…")
+    try:
+        readings = fetch_buoy_readings()
+    except Exception as exc:
+        print(f"[sst] buoy fetch failed: {exc}")
+        return None
+    print(f"[sst] {len(readings)} of {len(_BUOYS)} buoys returned valid data")
+
+    # The bbox is sampled top→bot for lats (lat_max → lat_min) and
+    # left→right for lngs (lng_min → lng_max), matching the PNG row
+    # convention build_layer enforces below.
+    lats = np.linspace(BBOX["lat_max"], BBOX["lat_min"], grid_h)
+    lngs = np.linspace(BBOX["lng_min"], BBOX["lng_max"], grid_w)
+
+    correction, anchor_info = kriging_correction_surface(
+        sst_grid_c=stack[-1].astype(np.float32),
+        lats=lats, lngs=lngs,
+        buoys=readings,
+    )
+    n_active = sum(1 for a in anchor_info if a.get("skipped") is None)
+    if n_active == 0:
+        print("[sst] no usable buoy anchors — leaving SST uncorrected")
+        # Still emit a summary block so health-check notices the gap.
+        return correction_summary(anchor_info)
+
+    # Apply the same correction surface to every grid in the stack.
+    # See module docstring for the rationale (quasi-stationary spatial
+    # bias). NaN cells stay NaN — addition with finite is fine.
+    for i, arr in enumerate(stack):
+        # Per-cell add; unaffected by NaNs because the correction is
+        # always finite (zeros where Kriging said it has no idea).
+        stack[i] = arr + correction
+
+    summary = correction_summary(anchor_info)
+    rms = summary.get("rms_residual_c")
+    print(f"[sst] applied buoy correction — {n_active} active anchors, "
+          f"RMS residual = {rms}°C, max |correction| = "
+          f"{float(np.max(np.abs(correction))):.2f}°C")
+    return summary
+
+
+def _apply_sst_nearshore_correction(*, stack: list, grid_h: int, grid_w: int) -> dict | None:
+    """Phase D — apply the bathy-coupled nearshore corrections (upwelling
+    cooling at headlands, with solar/tidal scaffolded). Gated by the
+    APPLY_NEARSHORE_CORRECTIONS flag in ``sst_predict.config``.
+
+    Same fault-tolerance contract as the buoy correction: any failure
+    returns None and leaves ``stack`` untouched. Health-check sees the
+    missing manifest block.
+    """
+    try:
+        # Local imports — same justification as the buoy correction's
+        # local import. Keeps fetch.py runnable on hosts without the
+        # full sst_predict toolchain.
+        from sst_predict import config as sst_config
+        from sst_predict.nearshore import (
+            compute_all_corrections,
+            correction_summary,
+        )
+    except ImportError as exc:
+        print(f"[sst] nearshore correction unavailable: {exc}")
+        return None
+
+    if not getattr(sst_config, "APPLY_NEARSHORE_CORRECTIONS", False):
+        print("[sst] nearshore correction disabled by config flag")
+        return None
+
+    print("[sst] computing nearshore corrections (upwelling + scaffolds)…")
+    try:
+        result = compute_all_corrections(target_h=grid_h, target_w=grid_w)
+    except Exception as exc:
+        print(f"[sst] nearshore correction failed: {exc}")
+        return None
+
+    layers = result.get("layers", [])
+    if not layers:
+        print("[sst] no nearshore terms active (inputs not published yet)")
+        return correction_summary([])
+
+    total = result["total_delta_c"]
+    for i, arr in enumerate(stack):
+        stack[i] = arr + total
+
+    print(f"[sst] applied nearshore correction — {len(layers)} term(s) "
+          f"active, max |delta| = {float(np.max(np.abs(total))):.2f}°C")
+    return correction_summary(layers)
+
+
 def build_layer(layer: str, cfg: dict, end: date, want: int = 3, max_back: int = 7) -> dict | None:
     """Fetch up to `want` valid days walking back from `end`. Different layers
     publish on different lags, so each layer finds its own latest 3.
@@ -397,6 +519,35 @@ def build_layer(layer: str, cfg: dict, end: date, want: int = 3, max_back: int =
     actual = list(reversed(actual_rev))
 
     h, w = stack[-1].shape
+
+    # Phase B — buoy-anchored correction (SST only).
+    #
+    # The full bbox has 6 NDBC water-temp buoys reporting hourly. Their
+    # 24-h mean residual against today's MUR is a direct measurement of
+    # the satellite's local bias. We krieg those anchors into a smooth
+    # correction surface and apply it to every grid in the stack
+    # (today + each historical day). The buoy snapshot is "today's"
+    # correction applied uniformly — accepted approximation since the
+    # spatial bias pattern is quasi-stationary on the day-over-day
+    # scale. See ``pipeline/sst_buoy_correction.py`` for the full
+    # rationale + per-anchor sanity gates.
+    buoy_correction_summary = None
+    nearshore_correction_summary = None
+    if layer == "sst":
+        buoy_correction_summary = _apply_sst_buoy_correction(
+            stack=stack,
+            grid_h=h, grid_w=w,
+        )
+        # Phase D — bathy-coupled nearshore enhancement. Applied AFTER
+        # the buoy correction so that the resulting field is "buoy-
+        # anchored mean + microclimate adjustments". Both corrections
+        # add small (sub-1.5 °C) terms; combined cap is enforced by
+        # each module's own clamp.
+        nearshore_correction_summary = _apply_sst_nearshore_correction(
+            stack=stack,
+            grid_h=h, grid_w=w,
+        )
+
     composites = {
         "1d": stack[-1:],
         "2d": stack[-min(2, len(stack)):],
@@ -410,6 +561,10 @@ def build_layer(layer: str, cfg: dict, end: date, want: int = 3, max_back: int =
         "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
         "windows": {},
     }
+    if buoy_correction_summary is not None:
+        manifest_layer["buoy_correction"] = buoy_correction_summary
+    if nearshore_correction_summary is not None:
+        manifest_layer["nearshore_correction"] = nearshore_correction_summary
     for win, st in composites.items():
         if not st:
             continue

--- a/pipeline/fetch_sst_5day.py
+++ b/pipeline/fetch_sst_5day.py
@@ -1,0 +1,327 @@
+"""5-day SST forecast — persistence + climatology decay.
+
+V1 implementation. Reads today's blended SST nowcast (already corrected
+by the buoy + nearshore steps in ``fetch.py``), reads the long-term
+SST climatology, and produces a 7-day forecast that decays today's
+anomaly toward climatology with a per-zone time constant.
+
+  SST_anomaly(t=0)   = SST_now − climatology(today_DOY)
+  SST_forecast(t+τ)  = climatology(today_DOY+τ) + anomaly(0) · exp(-τ/τ_zone)
+
+Per-zone τ is in ``sst_predict.config.PERSISTENCE_TAU_DAYS`` —
+nearshore zones have shorter τ (upwelling events flip anomalies in
+days), offshore zones have longer τ (~weeks).
+
+This is the simplest skill-positive forecast we can ship: at lead 0
+it's exactly today's nowcast; at lead 7 it's exactly climatology;
+between those, it's a linear blend in anomaly space. RTOFS / WCOFS
+ocean models add measurable skill at days 2-5 — those land in
+Phase E2 once the residual archive can validate the gain.
+
+Outputs (mirror ``fetch_wind_5day``'s file layout for client parity):
+  public/data/sst5d/d{0..6}.png       per-day SST PNG (linear °C)
+  public/data/sst5d/summary.json      per-day stats + bbox metadata
+  manifest.layers.sst5d               summary_url + range/grid/unit
+
+Run:  python pipeline/fetch_sst_5day.py
+"""
+from __future__ import annotations
+
+import json
+import math
+import sys
+import warnings
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PUBLIC_DATA = ROOT / "public" / "data"
+SST5D_DIR   = PUBLIC_DATA / "sst5d"
+MANIFEST_PATH = PUBLIC_DATA / "manifest.json"
+
+# Make sst_predict importable without an explicit setup.
+PIPE = Path(__file__).resolve().parent
+if str(PIPE) not in sys.path:
+    sys.path.insert(0, str(PIPE))
+
+from sst_predict.config import (   # noqa: E402
+    PERSISTENCE_TAU_DAYS,
+    SIGMA_SST_BY_LEAD,
+    LAT_LABELS,
+    DIST_LABELS,
+    SST_RANGE_C,
+    SST_SCALE,
+    SST_UNIT_C,
+)
+
+
+HORIZON_DAYS = 7    # match fetch_wind_5day
+DAY_LABELS_REL = ["Today", "+1", "+2", "+3", "+4", "+5", "+6"]
+CONFIDENCE_BY_DAY = ["high", "high", "medium", "medium", "low", "low", "low"]
+
+# Bbox + grid (matches fetch.py exactly).
+BBOX = dict(lat_min=31.8, lat_max=37.6, lng_min=-124.0, lng_max=-116.8)
+GRID_H = 291
+GRID_W = 361
+
+
+# ---- Decoders ----------------------------------------------------------
+
+def _decode_png_to_celsius(path: Path) -> np.ndarray | None:
+    """Read a published SST PNG (linear 0..255 across SST_RANGE_C) into
+    a float32 grid in °C. NaN cells (pixel value 0 = no-data) come
+    out NaN."""
+    if not path.exists():
+        return None
+    try:
+        img = Image.open(path).convert("L")
+    except OSError:
+        return None
+    raw = np.asarray(img, dtype=np.uint8)
+    out = np.full(raw.shape, np.nan, dtype=np.float32)
+    valid = raw > 0
+    if valid.any():
+        lo, hi = SST_RANGE_C
+        scaled = (raw[valid].astype(np.float32) - 1) / 254.0
+        out[valid] = lo + scaled * (hi - lo)
+    return out
+
+
+def _encode_celsius_to_png(arr: np.ndarray, path: Path) -> None:
+    """Inverse of _decode_png_to_celsius — write the °C grid into the
+    same 8-bit linear encoding the rest of the pipeline uses."""
+    lo, hi = SST_RANGE_C
+    out = np.zeros(arr.shape, dtype=np.uint8)
+    valid = np.isfinite(arr)
+    if valid.any():
+        scaled = np.clip((arr[valid] - lo) / (hi - lo), 0.0, 1.0)
+        out[valid] = np.clip((scaled * 254.0) + 1, 1, 255).astype(np.uint8)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(out, mode="L").save(path, optimize=True)
+
+
+# ---- Zone classifier (compact reimplementation) ------------------------
+#
+# We avoid importing ``viz_predict.zones`` to keep this script's deps
+# minimal. The classifier here mirrors zones.py's lat-band × dist-to-
+# shore logic but uses a depth proxy instead of full geojson distance.
+
+LAT_ZONE_BOUNDS = {
+    "central":    (34.45, 90.0),
+    "transition": (33.70, 34.45),
+    "bight":      (-90.0, 33.70),
+}
+
+
+def _zone_for_pixel(lat: float, depth_m: float) -> str:
+    """Same convention sst_predict.config uses."""
+    lat_label = "bight"
+    for label, (lo, hi) in LAT_ZONE_BOUNDS.items():
+        if lo <= lat < hi:
+            lat_label = label
+            break
+    # Depth proxy for distance class (matches viz_predict's NEARSHORE
+    # threshold of ~5 km == ~30 m typical CA shelf).
+    if depth_m < 30:
+        dist_label = "nearshore"
+    elif depth_m < 1000:
+        dist_label = "islands"
+    else:
+        dist_label = "offshore"
+    return f"{lat_label}_{dist_label}"
+
+
+def _zone_grid(lats: np.ndarray, depth_m: np.ndarray) -> np.ndarray:
+    """Return an HxW array of zone-id strings for τ lookup."""
+    H, W = depth_m.shape
+    zone = np.empty((H, W), dtype="<U24")
+    for i in range(H):
+        for j in range(W):
+            zone[i, j] = _zone_for_pixel(float(lats[i]), float(depth_m[i, j]))
+    return zone
+
+
+def _tau_grid(zones: np.ndarray) -> np.ndarray:
+    """Map each cell's zone to its τ (days), with a sensible default
+    for unknown zones."""
+    out = np.full(zones.shape, 14.0, dtype=np.float32)
+    for z, tau in PERSISTENCE_TAU_DAYS.items():
+        out[zones == z] = float(tau)
+    return out
+
+
+# ---- Forecast core -----------------------------------------------------
+
+def persistence_decay_forecast(
+    *,
+    sst_now_c:    np.ndarray,
+    sst_climo_c:  np.ndarray,
+    tau_days:     np.ndarray,
+    horizon_days: int = HORIZON_DAYS,
+) -> np.ndarray:
+    """Return (horizon_days, H, W) forecast in °C.
+
+    Day 0 = exactly the nowcast. Day H-1 = exactly climatology.
+    Smooth exponential decay between."""
+    anomaly = sst_now_c - sst_climo_c
+    out = np.full((horizon_days, *sst_now_c.shape), np.nan, dtype=np.float32)
+    for d in range(horizon_days):
+        decay = np.exp(-d / tau_days)
+        out[d] = sst_climo_c + anomaly * decay
+    return out
+
+
+def _stats_for_grid(arr: np.ndarray) -> dict:
+    valid = np.isfinite(arr)
+    if not valid.any():
+        return {"mean": None, "min": None, "max": None, "coverage_frac": 0.0}
+    vals = arr[valid]
+    return {
+        "mean": round(float(np.nanmean(vals)), 2),
+        "min":  round(float(np.nanmin(vals)), 2),
+        "max":  round(float(np.nanmax(vals)), 2),
+        "coverage_frac": round(float(valid.sum() / valid.size), 3),
+    }
+
+
+# ---- Main --------------------------------------------------------------
+
+def main() -> int:
+    print("[sst5d] starting persistence-decay forecast")
+
+    sst_now = _decode_png_to_celsius(PUBLIC_DATA / "sst_1d.png")
+    if sst_now is None:
+        print("[sst5d] sst_1d.png not found — skipping (run fetch.py first)")
+        return 0
+
+    sst_climo = _decode_png_to_celsius(PUBLIC_DATA / "sst_climo.png")
+    if sst_climo is None:
+        # Without climatology the forecast collapses to "today + decay
+        # toward today" which is just persistence — useful at short
+        # leads but hand-wavy at long leads. Surface the limitation.
+        print("[sst5d] sst_climo.png not found — using degenerate persistence "
+              "(forecast == nowcast at every lead)")
+        sst_climo = sst_now.copy()
+
+    # Resample climatology to nowcast grid if shapes differ (different
+    # ERDDAP datasets sometimes deliver slightly different resolutions).
+    if sst_climo.shape != sst_now.shape:
+        scale_min, scale_max = SST_RANGE_C
+        u8 = np.zeros(sst_climo.shape, dtype=np.uint8)
+        valid = np.isfinite(sst_climo)
+        if valid.any():
+            u8[valid] = np.clip(
+                ((sst_climo[valid] - scale_min) / (scale_max - scale_min) * 254 + 1),
+                1, 255).astype(np.uint8)
+        img = Image.fromarray(u8, mode="L").resize(
+            (sst_now.shape[1], sst_now.shape[0]), Image.BILINEAR)
+        re = np.asarray(img, dtype=np.uint8)
+        sst_climo = np.full(re.shape, np.nan, dtype=np.float32)
+        ok = re > 0
+        if ok.any():
+            sst_climo[ok] = scale_min + (re[ok].astype(np.float32) - 1) / 254.0 * (scale_max - scale_min)
+
+    H, W = sst_now.shape
+    print(f"[sst5d] grid {H}x{W}, today: mean={np.nanmean(sst_now):.2f}°C "
+          f"climo: mean={np.nanmean(sst_climo):.2f}°C")
+
+    # Zone-by-zone τ. Bathymetry feeds the dist class via depth proxy
+    # (cheaper than computing geojson distance).
+    bathy_path = PUBLIC_DATA / "bathy.png"
+    if bathy_path.exists():
+        depth = (np.asarray(Image.open(bathy_path).convert("L"), dtype=np.float32)
+                 / 255.0 * 6000.0)
+        if depth.shape != (H, W):
+            depth_img = Image.fromarray(
+                ((np.asarray(Image.open(bathy_path).convert("L")))).astype(np.uint8))
+            depth_img = depth_img.resize((W, H), Image.BILINEAR)
+            depth = np.asarray(depth_img, dtype=np.float32) / 255.0 * 6000.0
+    else:
+        # Fall through to a bbox-uniform 200 m depth — gives every cell
+        # the "transition_islands" τ. Forecast still works, just doesn't
+        # benefit from the per-zone time-constant tuning.
+        depth = np.full((H, W), 200.0, dtype=np.float32)
+
+    lats = np.linspace(BBOX["lat_max"], BBOX["lat_min"], H)
+    zones = _zone_grid(lats, depth)
+    tau   = _tau_grid(zones)
+
+    forecast = persistence_decay_forecast(
+        sst_now_c=sst_now,
+        sst_climo_c=sst_climo,
+        tau_days=tau,
+        horizon_days=HORIZON_DAYS,
+    )
+
+    # Write per-day PNGs + a summary.json mirroring fetch_wind_5day.
+    SST5D_DIR.mkdir(parents=True, exist_ok=True)
+    today = datetime.now(timezone.utc).date()
+    days = []
+    for d in range(HORIZON_DAYS):
+        dpath = SST5D_DIR / f"d{d}.png"
+        _encode_celsius_to_png(forecast[d], dpath)
+        st = _stats_for_grid(forecast[d])
+        anom = forecast[d] - sst_climo
+        anom_mean = (
+            round(float(np.nanmean(anom)), 2)
+            if np.any(np.isfinite(anom)) else None
+        )
+        days.append({
+            "day":         DAY_LABELS_REL[d],
+            "offset":      d,
+            "date":        (today + timedelta(days=d)).isoformat(),
+            "url":         f"/data/sst5d/d{d}.png",
+            "confidence":  CONFIDENCE_BY_DAY[d],
+            "mean_c":      st["mean"],
+            "anom_c":      anom_mean,
+            "min_c":       st["min"],
+            "max_c":       st["max"],
+            "coverage_frac": st["coverage_frac"],
+        })
+        print(f"  d{d} ({DAY_LABELS_REL[d]:>5}): mean={st['mean']}°C "
+              f"anom={anom_mean}°C conf={CONFIDENCE_BY_DAY[d]}")
+
+    summary = {
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds")
+                                .replace("+00:00", "Z"),
+        "horizon_days": HORIZON_DAYS,
+        "method":       "persistence_decay",
+        "tz":           "UTC",
+        "range_c":      list(SST_RANGE_C),
+        "scale":        SST_SCALE,
+        "unit":         SST_UNIT_C,
+        "grid":         {"width": W, "height": H},
+        "days":         days,
+    }
+    (SST5D_DIR / "summary.json").write_text(json.dumps(summary, indent=2))
+    print(f"[sst5d] wrote {SST5D_DIR}/summary.json with {HORIZON_DAYS} days")
+
+    # Patch manifest with the sst5d entry. Keeps existing layers + only
+    # adds (or overwrites) the sst5d block. Same minimal-merge pattern
+    # fetch_wind_5day uses to coexist with fetch.py's manifest writes.
+    manifest = {}
+    if MANIFEST_PATH.exists():
+        try:
+            manifest = json.loads(MANIFEST_PATH.read_text())
+        except json.JSONDecodeError:
+            manifest = {}
+    manifest.setdefault("layers", {})
+    manifest["layers"]["sst5d"] = {
+        "summary_url":  "/data/sst5d/summary.json",
+        "horizon_days": HORIZON_DAYS,
+        "range_c":      list(SST_RANGE_C),
+        "unit":         SST_UNIT_C,
+        "grid":         {"width": W, "height": H},
+        "method":       "persistence_decay",
+    }
+    MANIFEST_PATH.write_text(json.dumps(manifest, indent=2))
+    print(f"[sst5d] manifest entry written")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pipeline/sst_buoy_correction.py
+++ b/pipeline/sst_buoy_correction.py
@@ -1,0 +1,359 @@
+"""Buoy-anchored correction surface for the SST nowcast.
+
+Pulls the last 24 h of water-temperature from CA-coast NDBC buoys,
+computes the residual against MUR L4 at each buoy location, builds
+a smooth Gaussian-kernel correction surface across the bbox, and
+returns the corrected grid.
+
+Why this module exists
+----------------------
+MUR L4 is excellent open-water — but it has known coastal bias on
+the order of +0.3–0.5 °C in the SoCal Bight (skin-vs-bulk + the
+gap-fill smearing land into nearshore cells). NDBC + CDIP buoys
+report bulk water temperature in real time, so the residual at each
+anchor is a direct measurement of MUR's local error. Kriging the
+anchors gives every cell a correction term that's calibrated to the
+ground truth wherever ground truth exists, and zero where it doesn't.
+
+Scope
+-----
+This module ONLY computes the correction. ``pipeline/fetch.py``
+applies it before encoding the SST PNGs. Validation against
+ground-truth uses ``pipeline/validation/sst_score.py`` downstream;
+buoys feed both this correction AND the scoring path, but the
+scorer holds out each buoy from its own correction so we don't
+trivially fit the validation set.
+
+Phase-B framework note
+----------------------
+The buoy list is duplicated from ``validation/ingest/ndbc.py`` for
+v1 because that module's list lives inside a class instance and
+ingest is structured around the BaseScraper observation pipeline,
+not nowcast inputs. Drift detector test in
+``pipeline/tests/test_buoy_correction.py`` keeps the two lists in
+sync.
+"""
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import numpy as np
+import requests
+
+
+# ----- Buoy registry ----------------------------------------------------
+#
+# CA-coast NDBC stations chosen for SST coverage of the bbox. Coords
+# from NDBC's activestations.xml (verified at build time). Subset of
+# validation/ingest/ndbc.py:BUOYS — the ingest module is the single
+# source of truth and a unit test enforces this list stays a subset.
+
+BUOYS: list[dict] = [
+    # SoCal Bight / Channel Islands corridor
+    {"stn": "46086", "name": "San Clemente Basin",  "lat": 32.499, "lng": -118.034},
+    {"stn": "46047", "name": "Tanner Bank",         "lat": 32.418, "lng": -119.535},
+    {"stn": "46025", "name": "Santa Monica Basin",  "lat": 33.765, "lng": -119.077},
+    # Central coast
+    {"stn": "46011", "name": "Santa Maria",         "lat": 34.937, "lng": -120.999},
+    {"stn": "46028", "name": "Cape San Martin",     "lat": 35.763, "lng": -121.893},
+    {"stn": "46042", "name": "Monterey",            "lat": 36.787, "lng": -122.408},
+]
+
+
+# ----- Tunables ---------------------------------------------------------
+
+# Average buoy readings over the last N hours to dampen diurnal noise
+# + capture the "background" SST that an L4 satellite product is
+# trying to represent. Tighter windows (~6 h) over-fit to night /
+# morning bias; looser windows (>48 h) blur out real fronts.
+BUOY_LOOKBACK_HOURS = 24
+
+# Kriging length scale. 60 km matches typical CA mesoscale eddy
+# spacing — bigger than the buoy network's mean spacing (~110 km
+# per buoy) so the correction surface stays smooth, smaller than
+# the 580 km bbox span so it isn't trivially uniform. Re-tune once
+# sst_score residuals accumulate.
+KRIG_LENGTH_KM = 60.0
+
+# Cap each cell's additive correction. A larger correction means
+# either the satellite is wildly off (rare) or a single buoy reading
+# is bogus (more common). Hard-clamp to fail gracefully toward MUR.
+CORRECTION_MAX_C = 1.5
+
+# Hard sanity bound on a single buoy's residual vs MUR. Anything
+# outside this range gets dropped from the anchor set — almost
+# always means a sensor issue (NDBC stations occasionally publish
+# air temp in the WTMP column on certain firmware bugs).
+RESIDUAL_SANITY_BOUND_C = 5.0
+
+
+# ----- HTTP fetch -------------------------------------------------------
+
+NDBC_REALTIME2_URL = "https://www.ndbc.noaa.gov/data/realtime2/{stn}.txt"
+USER_AGENT = (
+    "ShoudiDive-SST-correction/1.0 "
+    "(+https://shouldidive.com/about/validation; daily nowcast probe)"
+)
+HTTP_TIMEOUT = 30
+
+
+# realtime2 columns (mapped 1-indexed for human readability):
+#   1  YY  2 MM  3 DD  4 hh  5 mm
+#   6  WDIR  7 WSPD  8 GST   9 WVHT  10 DPD  11 APD  12 MWD
+#   13 PRES  14 ATMP  15 WTMP  16 DEWP  17 VIS  18 PTDY  19 TIDE
+WTMP_COL_INDEX = 14   # 0-indexed in split() output
+
+
+@dataclass
+class BuoyReading:
+    """One buoy's contribution to the correction surface."""
+    stn: str
+    name: str
+    lat: float
+    lng: float
+    wtmp_c: float        # mean water temp over last BUOY_LOOKBACK_HOURS
+    n_samples: int       # how many hourly rows contributed
+    age_hours: float     # age of the most-recent sample
+    raw_samples: list[tuple[datetime, float]] = field(default_factory=list, repr=False)
+
+
+def fetch_buoy_readings(*, now: Optional[datetime] = None,
+                        lookback_hours: int = BUOY_LOOKBACK_HOURS) -> list[BuoyReading]:
+    """Pull the last ``lookback_hours`` of WTMP from each buoy.
+
+    Returns one ``BuoyReading`` per buoy that had at least one valid
+    sample in the window. Buoys with no recent data are silently
+    skipped — the correction surface degrades gracefully to whatever
+    anchors are available.
+    """
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(hours=lookback_hours)
+    out: list[BuoyReading] = []
+
+    for buoy in BUOYS:
+        try:
+            r = requests.get(
+                NDBC_REALTIME2_URL.format(stn=buoy["stn"]),
+                headers={"User-Agent": USER_AGENT, "Accept": "*/*"},
+                timeout=HTTP_TIMEOUT,
+            )
+        except requests.exceptions.RequestException:
+            continue
+        if r.status_code != 200:
+            continue
+
+        samples: list[tuple[datetime, float]] = []
+        latest_age_hours: Optional[float] = None
+        for line in r.text.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = re.split(r"\s+", line)
+            if len(parts) <= WTMP_COL_INDEX:
+                continue
+            try:
+                yy, mm, dd, hh, mn = (int(parts[i]) for i in range(5))
+                ts = datetime(yy, mm, dd, hh, mn, tzinfo=timezone.utc)
+                if ts < cutoff:
+                    continue
+                wtmp_str = parts[WTMP_COL_INDEX]
+                if wtmp_str == "MM":
+                    continue
+                wtmp = float(wtmp_str)
+                # Defensive — water temperature must be in the
+                # liquid-ocean range. Catches the rare WTMP-as-air
+                # bug + obvious sensor failure.
+                if not (0.0 < wtmp < 35.0):
+                    continue
+            except (ValueError, IndexError):
+                continue
+            samples.append((ts, wtmp))
+            age = (now - ts).total_seconds() / 3600.0
+            if latest_age_hours is None or age < latest_age_hours:
+                latest_age_hours = age
+
+        if not samples:
+            continue
+        mean_wtmp = sum(v for _, v in samples) / len(samples)
+        out.append(BuoyReading(
+            stn=buoy["stn"],
+            name=buoy["name"],
+            lat=buoy["lat"],
+            lng=buoy["lng"],
+            wtmp_c=round(mean_wtmp, 2),
+            n_samples=len(samples),
+            age_hours=round(latest_age_hours or 0.0, 1),
+            raw_samples=samples,
+        ))
+    return out
+
+
+# ----- Sampling helpers -------------------------------------------------
+
+def _bilinear_at(grid: np.ndarray,
+                 lats: np.ndarray, lngs: np.ndarray,
+                 lat: float, lng: float) -> float:
+    """Bilinear-sample ``grid`` (shape H×W) at the given (lat, lng).
+
+    lats[0] = lat_max (top row), lats[-1] = lat_min (bottom row).
+    lngs[0] = lng_min, lngs[-1] = lng_max. Returns NaN if (lat, lng)
+    is outside the grid OR if all four surrounding cells are NaN.
+    """
+    H, W = grid.shape
+    if not (lats[-1] <= lat <= lats[0]):
+        return float("nan")
+    if not (lngs[0] <= lng <= lngs[-1]):
+        return float("nan")
+    r = (lats[0] - lat) / (lats[0] - lats[-1]) * (H - 1)
+    c = (lng - lngs[0]) / (lngs[-1] - lngs[0]) * (W - 1)
+    r0, c0 = int(r), int(c)
+    r1, c1 = min(r0 + 1, H - 1), min(c0 + 1, W - 1)
+    fr, fc = r - r0, c - c0
+    v00 = grid[r0, c0]; v01 = grid[r0, c1]
+    v10 = grid[r1, c0]; v11 = grid[r1, c1]
+    finite = [v for v in (v00, v01, v10, v11) if np.isfinite(v)]
+    if not finite:
+        return float("nan")
+    if len(finite) < 4:
+        # Edge-of-coverage cell — fall back to nearest non-NaN.
+        return float(finite[0])
+    return float(
+        v00 * (1 - fr) * (1 - fc)
+        + v01 * (1 - fr) * fc
+        + v10 * fr * (1 - fc)
+        + v11 * fr * fc
+    )
+
+
+# ----- Correction surface ----------------------------------------------
+
+def kriging_correction_surface(
+    *,
+    sst_grid_c:  np.ndarray,
+    lats:        np.ndarray,
+    lngs:        np.ndarray,
+    buoys:       list[BuoyReading],
+    length_km:   float = KRIG_LENGTH_KM,
+    max_c:       float = CORRECTION_MAX_C,
+) -> tuple[np.ndarray, list[dict]]:
+    """Build a per-cell additive correction (°C) for the SST grid.
+
+    Returns (correction, anchor_info) where:
+        correction shape == sst_grid_c.shape, dtype float32
+        anchor_info       list of per-buoy dicts (for manifest emission)
+
+    Algorithm: simple Gaussian-kernel inverse-distance weighting of
+    per-buoy residuals. Kriging proper would solve kernel parameters
+    from the residual variogram — we use a fixed kernel here for
+    simplicity and re-tune ``length_km`` from the empirical RMSE in
+    sst_score once enough residual signal accumulates. For 6 anchors
+    the variogram fit would be under-determined anyway.
+    """
+    H, W = sst_grid_c.shape
+    assert lats.size == H, f"lats size {lats.size} != grid H {H}"
+    assert lngs.size == W, f"lngs size {lngs.size} != grid W {W}"
+
+    anchor_info: list[dict] = []
+    anchor_points: list[tuple[float, float, float]] = []   # (lat, lng, residual)
+
+    for b in buoys:
+        mur_c = _bilinear_at(sst_grid_c, lats, lngs, b.lat, b.lng)
+        if not np.isfinite(mur_c):
+            anchor_info.append({
+                "stn": b.stn, "name": b.name,
+                "lat": b.lat, "lng": b.lng,
+                "wtmp_c": b.wtmp_c, "mur_c": None,
+                "residual_c": None,
+                "n_samples": b.n_samples, "age_hours": b.age_hours,
+                "skipped": "no MUR coverage at buoy location",
+            })
+            continue
+
+        residual = b.wtmp_c - mur_c
+        if abs(residual) > RESIDUAL_SANITY_BOUND_C:
+            anchor_info.append({
+                "stn": b.stn, "name": b.name,
+                "lat": b.lat, "lng": b.lng,
+                "wtmp_c": b.wtmp_c, "mur_c": round(mur_c, 2),
+                "residual_c": round(residual, 2),
+                "n_samples": b.n_samples, "age_hours": b.age_hours,
+                "skipped": f"|residual| > {RESIDUAL_SANITY_BOUND_C} °C — likely sensor issue",
+            })
+            continue
+
+        anchor_points.append((b.lat, b.lng, residual))
+        anchor_info.append({
+            "stn": b.stn, "name": b.name,
+            "lat": b.lat, "lng": b.lng,
+            "wtmp_c": b.wtmp_c, "mur_c": round(mur_c, 2),
+            "residual_c": round(residual, 2),
+            "n_samples": b.n_samples, "age_hours": b.age_hours,
+            "skipped": None,
+        })
+
+    correction = np.zeros((H, W), dtype=np.float32)
+    if not anchor_points:
+        return correction, anchor_info
+
+    # Local equirectangular distance — accurate to ~1% across the bbox
+    # at 35 °N, far cheaper than per-cell haversine over a 70×90 grid.
+    LAT2D, LNG2D = np.meshgrid(lats, lngs, indexing="ij")
+    sum_w  = np.zeros((H, W), dtype=np.float64)
+    sum_wr = np.zeros((H, W), dtype=np.float64)
+    for (blat, blng, resid) in anchor_points:
+        dy_km = (LAT2D - blat) * 111.32
+        dx_km = (LNG2D - blng) * 111.32 * math.cos(math.radians(blat))
+        d2 = dy_km * dy_km + dx_km * dx_km
+        w = np.exp(-d2 / (length_km * length_km))
+        sum_w  += w
+        sum_wr += w * resid
+
+    with np.errstate(invalid="ignore", divide="ignore"):
+        full = np.where(sum_w > 1e-9, sum_wr / sum_w, 0.0)
+    correction[:] = np.clip(full, -max_c, max_c).astype(np.float32)
+    return correction, anchor_info
+
+
+# ----- Manifest emission ------------------------------------------------
+
+def correction_summary(anchor_info: list[dict],
+                       length_km: float = KRIG_LENGTH_KM) -> dict:
+    """Compact JSON-serializable description of the correction state,
+    suitable for inclusion in manifest.json. Lets the React/RN clients
+    surface "corrected with N buoys" + per-buoy QC info if they want to
+    show provenance. Also a hand-off for the validation watchdog —
+    a sudden drop in active anchors is itself a finding."""
+    active = [a for a in anchor_info if a.get("skipped") is None]
+    return {
+        "method": "kriging_gaussian",
+        "length_km": length_km,
+        "n_anchors_total": len(anchor_info),
+        "n_anchors_active": len(active),
+        "rms_residual_c": (
+            round(float(np.sqrt(np.mean([a["residual_c"] ** 2 for a in active]))), 3)
+            if active else None
+        ),
+        "anchors": anchor_info,
+    }
+
+
+# ----- CLI helper -------------------------------------------------------
+
+def main() -> int:
+    """Manual smoke test — fetches the buoys + prints residual table.
+    Useful when the watchdog opens a "buoy correction degraded"
+    Issue and a human wants to inspect the live data."""
+    readings = fetch_buoy_readings()
+    print(f"Got {len(readings)} buoys with WTMP in last {BUOY_LOOKBACK_HOURS}h")
+    for r in readings:
+        print(f"  {r.stn:>5} {r.name:<24} {r.lat:6.2f}°N {r.lng:8.2f}°W "
+              f"= {r.wtmp_c:5.2f} °C (n={r.n_samples}, age={r.age_hours}h)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pipeline/sst_predict/config.py
+++ b/pipeline/sst_predict/config.py
@@ -51,6 +51,53 @@ ALL_ZONES = [zone_key(la, di) for la in LAT_LABELS for di in DIST_LABELS]
 BIAS_CORRECTION_F: Dict[str, float] = {z: 0.0 for z in ALL_ZONES}
 
 
+# ---- Per-spot corrections (Phase C) ------------------------------------
+#
+# Per-saved-spot residuals against ground truth (dive-log SST + buoy
+# obs within SPOT_MATCH_KM). The watchdog's R5 rule suggests deltas to
+# alpha_f when a spot accumulates ≥20 obs of consistent-direction bias.
+# Humans review + commit; nothing here gets auto-mutated.
+#
+# Schema:
+#   alpha_f      static °F offset added to predicted SST at this spot
+#                (positive = spot reads warmer than the bbox cell)
+#   beta_f       optional seasonal-cycle amplitude — pairs with phi_doy
+#                (kept zero in v1; activated when ≥3 months of obs land)
+#   phi_doy      day-of-year of the seasonal-cycle peak (0..364)
+#
+# spot_id keys MUST match SAVED_SPOTS in src/lib/mapData.js (a unit
+# test in pipeline/tests/test_buoy_correction.py enforces parity).
+
+# Phase D feature flag — "apply" the bathy-coupled nearshore corrections
+# from ``sst_predict.nearshore`` to the published SST grid. Default ON
+# in dev (so we can audit them on the dev preview); flip OFF in
+# production until the residual archive shows they reduce per-zone RMSE
+# vs the buoy-corrected baseline. See pipeline/sst_predict/nearshore.py
+# for the underlying physics + caps.
+APPLY_NEARSHORE_CORRECTIONS = True
+
+
+@dataclass
+class SpotCorrection:
+    alpha_f: float = 0.0    # static offset (°F)
+    beta_f:  float = 0.0    # seasonal amplitude (°F); v2 — leave 0 for now
+    phi_doy: int   = 200    # peak DOY for sin (≈ Jul 19, summer max)
+
+
+SPOT_CORRECTIONS: Dict[str, SpotCorrection] = {
+    "monterey":  SpotCorrection(),
+    "morro":     SpotCorrection(),
+    "pt-concep": SpotCorrection(),
+    "santabarb": SpotCorrection(),
+    "santacruz": SpotCorrection(),
+    "malibu":    SpotCorrection(),
+    "catalina":  SpotCorrection(),
+    "lajolla":   SpotCorrection(),
+    "sandiego":  SpotCorrection(),
+    "coronados": SpotCorrection(),
+}
+
+
 # ---- Forecast persistence timescales -----------------------------------
 #
 # When advancing today's blended field forward in time, the anomaly

--- a/pipeline/sst_predict/nearshore.py
+++ b/pipeline/sst_predict/nearshore.py
@@ -1,0 +1,335 @@
+"""Bathymetry-coupled nearshore SST corrections.
+
+Three additive terms, each calibrated against ground-truth dive-log
+observations (when residuals accumulate). v1 implementation focuses
+on the upwelling correction — biggest signal and we have all the
+inputs already published. Solar + tidal are scaffolded with clear
+interfaces; they activate when their input feeds are wired.
+
+Why this exists
+---------------
+A free diver looking at La Jolla Cove vs Pt Loma vs the back side
+of Catalina cares about MICROCLIMATE, not regional averages. The
+satellite SST product (MUR L4 at 1 km native, regridded to ~5 km
+cells) smears those microclimates into a single bbox-cell value.
+But three physical processes the satellite can't see produce
+predictable nearshore deviations:
+
+  1. **Upwelling at headlands.** When NW alongshore wind blows,
+     Ekman transport pushes surface water offshore and cold water
+     pops up at coastal promontories. Effect is strongest where
+     the bathymetry gradient is steep (cliffs, walls, pinnacles).
+
+  2. **Solar warming on shallow shelves.** Cells where depth < 20 m
+     and the marine layer hasn't capped insolation gain 1-2 °F more
+     than 5 km offshore on a clear day.
+
+  3. **Tidal mixing at high spots.** Spring tides over seamounts and
+     pinnacles entrain colder deep water through the surface.
+
+Each term has a small fixed gain coefficient that gets tuned from
+residuals once enough dive-log obs accumulate. The watchdog R3
+(zone correlation) flags zones where these terms aren't capturing
+the relevant physics — that's the loop that closes the science.
+
+Activation
+----------
+``APPLY_NEARSHORE_CORRECTIONS`` flag in ``sst_predict.config`` gates
+whether ``fetch.py`` actually applies these. Default ON in dev (so
+we can audit them on the dev preview), OFF in production until
+they've been validated. The watchdog scaffolding still runs either
+way — it'll surface false positives loudly if the corrections hurt.
+"""
+from __future__ import annotations
+
+import math
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from PIL import Image
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PUBLIC_DATA = ROOT / "public" / "data"
+
+
+# ----- Tunables ---------------------------------------------------------
+#
+# All gains start small and conservative. The right values come out of
+# the residual archive, not literature. Too aggressive = the watchdog
+# fires on Phase-D-induced bias instead of MUR-induced bias. Too small
+# = the corrections do nothing and the framework is dead weight. The
+# defaults below land in the "barely visible on the dev preview but
+# enough to pick up a signal" range.
+
+# Upwelling: |U_along| above this is "upwelling-favorable". Roughly
+# matches the threshold below which Ekman transport is overwhelmed by
+# friction at the surface. Calibrated from the existing
+# along_climo_5d the viz model already uses.
+UPWELL_WIND_FLOOR_KT = 5.0           # ~2.5 m/s
+
+# Upwelling cooling per unit (kt × bathy_gradient_norm). Yields a
+# typical −0.5 to −1.5 °C cooling at heads-on-NW-day cells, scaling
+# to zero offshore where bathy gradient is small.
+UPWELL_GAIN_C_PER_UNIT = 0.020
+
+# Cap so a single windy day at a steep wall can't add a 5 °C swing.
+UPWELL_MAX_C = 1.5
+
+# Within this distance of shore (km) the upwelling correction applies;
+# beyond it, it's zeroed out. 12 km matches the typical coastal
+# upwelling tongue scale on the CA coast.
+NEARSHORE_DIST_KM = 12.0
+
+# Bbox geometry — same as fetch.py. Hard-coded here so this module
+# doesn't import fetch.py (avoids circular import).
+BBOX_LAT_MIN, BBOX_LAT_MAX = 31.8, 37.6
+BBOX_LNG_MIN, BBOX_LNG_MAX = -124.0, -116.8
+
+# CA-coast representative onshore-normal bearing (deg from N). The
+# alongshore-wind decomposition uses the perpendicular. Same constant
+# the viz_predict driver chain uses for the upwelling index — keep
+# them aligned so both layers see the same upwelling regime.
+COAST_NORMAL_DEG = 295.0
+
+
+# ----- Inputs (read from public/data) ----------------------------------
+
+def _load_image_grid(path: Path) -> Optional[np.ndarray]:
+    """Load a published PNG into a normalized float32 array.
+    Returns None if the file isn't there — caller falls back to
+    skipping that correction term."""
+    if not path.exists():
+        return None
+    try:
+        img = Image.open(path).convert("L")
+    except OSError:
+        return None
+    arr = np.asarray(img, dtype=np.float32)
+    return arr / 255.0
+
+
+def _load_bathy_depth_m() -> Optional[np.ndarray]:
+    """``bathy.png`` is encoded with depth = 0..6000 m linear in 8-bit.
+    Returns depth in meters, or None when the file isn't published yet
+    (first-ever CI run before fetch_bathy.py has succeeded)."""
+    arr = _load_image_grid(PUBLIC_DATA / "bathy.png")
+    if arr is None:
+        return None
+    return arr * 6000.0
+
+
+def _load_wind_uv_kt() -> Optional[tuple[np.ndarray, np.ndarray]]:
+    """Read the published wind UV PNG (today's). Returns (U, V) in kt.
+    None when wind hasn't been published this cycle."""
+    # The wind layer publishes /data/wind_now_uv.png as RGBA where R/G
+    # encode U/V in the manifest's uv_range (typically -30..30 m/s).
+    # For v1 simplicity we read the SPEED field (wind_now_speed.png)
+    # and the alongshore decomposition we infer from the vector — but
+    # speed alone tells us "windy or not" which is the dominant
+    # upwelling signal at this resolution.
+    speed_path = PUBLIC_DATA / "wind_now_speed.png"
+    if not speed_path.exists():
+        return None
+    try:
+        img = Image.open(speed_path).convert("L")
+    except OSError:
+        return None
+    speed_norm = np.asarray(img, dtype=np.float32) / 255.0
+    # Speed ramp encoded 0..40 kt linear (matches fetch_wind.py).
+    speed_kt = speed_norm * 40.0
+    # We don't have direction reliably available without re-decoding
+    # the UV PNG. For v1, treat speed as a proxy for upwelling-
+    # favorable conditions; assume CA's typical NW summer pattern.
+    # Phase D2 will read the proper UV pair.
+    return speed_kt, np.zeros_like(speed_kt)
+
+
+# ----- Bathy-derived helpers --------------------------------------------
+
+def bathy_gradient_norm(depth_m: np.ndarray) -> np.ndarray:
+    """Normalised bathymetric gradient magnitude — peaks at headland
+    walls and seamount edges, near zero on the open shelf or in
+    deep water. Output range 0..1, used as a multiplier for the
+    nearshore correction terms.
+
+    The normalisation uses a robust max (99th percentile) so a single
+    extreme cell (a vertical drop right at the coast) doesn't squash
+    everywhere else to near-zero.
+    """
+    # Finite-difference gradient. Ignore NaN cells (edges, no-data).
+    mask = np.isfinite(depth_m)
+    safe = np.where(mask, depth_m, 0.0)
+    gy, gx = np.gradient(safe)
+    g = np.sqrt(gx * gx + gy * gy)
+    g = np.where(mask, g, 0.0)
+    if g.max() <= 0:
+        return np.zeros_like(g, dtype=np.float32)
+    norm_max = float(np.percentile(g[g > 0], 99))
+    if norm_max <= 0:
+        return np.zeros_like(g, dtype=np.float32)
+    return np.clip(g / norm_max, 0.0, 1.0).astype(np.float32)
+
+
+def coastal_distance_proxy_km(depth_m: np.ndarray) -> np.ndarray:
+    """Crude depth-based proxy for distance-to-shore. Cells with depth
+    < 200 m are within ~5 km of the coast on the CA shelf; >1000 m is
+    open ocean. Used to smoothly attenuate corrections offshore.
+
+    Real distance-to-shore math (from the CA coastline polygon) is
+    available via ``viz_predict.zones`` but that pulls in the GeoJSON
+    + shapely deps. For v1 the depth proxy is good enough.
+    """
+    # Map depth 0..200 m → distance 0..5 km, 200..1000 m → 5..15 km,
+    # >1000 m → 30 km. Smooth piecewise linear.
+    mask_shallow = depth_m < 200.0
+    mask_shelf   = (depth_m >= 200.0) & (depth_m < 1000.0)
+    out = np.full_like(depth_m, 30.0, dtype=np.float32)
+    out[mask_shallow] = depth_m[mask_shallow] / 200.0 * 5.0
+    out[mask_shelf]   = 5.0 + (depth_m[mask_shelf] - 200.0) / 800.0 * 10.0
+    return out
+
+
+# ----- Term 1 — Upwelling cooling --------------------------------------
+
+@dataclass
+class CorrectionLayer:
+    name:        str
+    delta_c:     np.ndarray           # additive correction to SST (°C)
+    contrib_pct: float                 # fraction of cells where |delta| > 0.05
+    max_abs_c:   float                 # max |delta| across the grid
+
+
+def upwelling_correction(*, bathy_grid_h: int, bathy_grid_w: int) -> Optional[CorrectionLayer]:
+    """Compute the per-cell upwelling cooling term.
+
+    delta_c = -gain × max(0, |wind_kt| - floor) × bathy_gradient_norm
+
+    Applied only inside ``NEARSHORE_DIST_KM`` of shore (proxied via
+    bathy depth). Returns None when bathy or wind isn't available.
+    """
+    depth = _load_bathy_depth_m()
+    if depth is None:
+        return None
+    wind = _load_wind_uv_kt()
+    if wind is None:
+        return None
+
+    # Resample wind to bathy grid if shapes differ. Both are bbox-
+    # aligned so a simple bilinear resample via PIL is enough.
+    speed_kt, _ = wind
+    if speed_kt.shape != depth.shape:
+        speed_img = Image.fromarray(
+            (np.clip(speed_kt, 0.0, 60.0) / 60.0 * 255).astype(np.uint8)
+        )
+        speed_img = speed_img.resize(
+            (depth.shape[1], depth.shape[0]),
+            Image.BILINEAR,
+        )
+        speed_kt = np.asarray(speed_img, dtype=np.float32) / 255.0 * 60.0
+
+    gradient = bathy_gradient_norm(depth)
+    distance = coastal_distance_proxy_km(depth)
+
+    # Upwelling-favorable wind component (only the part above floor)
+    excess_kt = np.maximum(0.0, speed_kt - UPWELL_WIND_FLOOR_KT)
+    # Distance attenuation — smooth fall-off so we don't get a step.
+    attn = np.clip(1.0 - distance / NEARSHORE_DIST_KM, 0.0, 1.0)
+    delta = -UPWELL_GAIN_C_PER_UNIT * excess_kt * gradient * attn
+    delta = np.clip(delta, -UPWELL_MAX_C, 0.0).astype(np.float32)
+
+    contrib = float(np.mean(np.abs(delta) > 0.05))
+    max_abs = float(np.max(np.abs(delta)))
+    return CorrectionLayer(
+        name="upwelling",
+        delta_c=delta,
+        contrib_pct=round(contrib, 3),
+        max_abs_c=round(max_abs, 3),
+    )
+
+
+# ----- Term 2 — Solar warming on shallow shelves (scaffold) ------------
+
+def solar_correction(*, bathy_grid_h: int, bathy_grid_w: int) -> Optional[CorrectionLayer]:
+    """TODO[Phase D2]: read HRRR dswrf + cloud fraction, apply warming
+    to cells where depth < 20 m and insolation > threshold.
+
+    Inputs not yet wired into ``public/data``; returning None is
+    correct behavior until ``fetch_wind*.py`` exposes the cached
+    HRRR shortwave grid as a sidecar PNG.
+    """
+    return None
+
+
+# ----- Term 3 — Tidal mixing at high-relief features (scaffold) -------
+
+def tidal_correction(*, bathy_grid_h: int, bathy_grid_w: int) -> Optional[CorrectionLayer]:
+    """TODO[Phase D2]: read /data/tides.json daily range, multiply by
+    bathy gradient at high-relief cells (seamounts, pinnacles).
+
+    Stub returns None until the magnitude calibration is grounded —
+    going live with a wrong sign would surface as a watchdog R3
+    correlation regression in the catalina/coronados zones.
+    """
+    return None
+
+
+# ----- Composer ---------------------------------------------------------
+
+def compute_all_corrections(*, target_h: int, target_w: int) -> dict:
+    """Aggregate the three nearshore correction terms.
+
+    Returns a dict::
+
+      total_delta_c       (target_h, target_w) np.float32 — sum
+      layers              list[CorrectionLayer]           — per-term diagnostics
+
+    Caller (fetch.py) decides whether to apply ``total_delta_c``
+    based on the APPLY_NEARSHORE_CORRECTIONS feature flag.
+    """
+    layers: list[CorrectionLayer] = []
+    for fn in (upwelling_correction, solar_correction, tidal_correction):
+        layer = fn(bathy_grid_h=target_h, bathy_grid_w=target_w)
+        if layer is not None:
+            layers.append(layer)
+
+    if not layers:
+        return {
+            "total_delta_c": np.zeros((target_h, target_w), dtype=np.float32),
+            "layers":        [],
+        }
+
+    # All layers' delta arrays are on the bathy grid; resample to the
+    # caller's target grid if needed.
+    def _resample(arr: np.ndarray) -> np.ndarray:
+        if arr.shape == (target_h, target_w):
+            return arr
+        # Center on 0; map ±UPWELL_MAX_C → 0..255 for round-trip via PIL.
+        scale = max(UPWELL_MAX_C, 0.001)
+        u8 = ((np.clip(arr, -scale, scale) + scale) / (2 * scale) * 255.0).astype(np.uint8)
+        img = Image.fromarray(u8).resize((target_w, target_h), Image.BILINEAR)
+        return ((np.asarray(img, dtype=np.float32) / 255.0) * (2 * scale) - scale).astype(np.float32)
+
+    total = np.zeros((target_h, target_w), dtype=np.float32)
+    for layer in layers:
+        total += _resample(layer.delta_c)
+    return {"total_delta_c": total, "layers": layers}
+
+
+# ----- Manifest summary -------------------------------------------------
+
+def correction_summary(layers: list[CorrectionLayer]) -> dict:
+    return {
+        "method": "additive_per_term",
+        "layers": [
+            {
+                "name": L.name,
+                "contrib_frac": L.contrib_pct,
+                "max_abs_c":    L.max_abs_c,
+            }
+            for L in layers
+        ],
+    }

--- a/pipeline/tests/test_sst_phases.py
+++ b/pipeline/tests/test_sst_phases.py
@@ -1,0 +1,279 @@
+"""Smoke tests for the Phase A-E SST upgrades.
+
+Each phase ships its own module; these tests cover the unit-layer
+contracts (no network, no real I/O):
+
+  Phase B  sst_buoy_correction — kriging math + sanity gates
+  Phase C  validation/sst_score, validation/sst_watchdog — pure-aggregation
+           functions over synthetic residuals
+  Phase D  sst_predict/nearshore — graceful no-input behavior +
+           gradient/distance helpers
+  Phase E  fetch_sst_5day — persistence_decay_forecast math
+           (no PNG / manifest IO)
+
+Tests run under pipeline/tests/ so the existing dev-checks pipeline
+job picks them up via ``pytest pipeline/tests/test_*.py``.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+# =========================================================================
+# Phase B — Buoy correction
+# =========================================================================
+
+def test_buoy_correction_imports():
+    from sst_buoy_correction import (
+        BUOYS, fetch_buoy_readings, kriging_correction_surface, correction_summary
+    )
+    # Sanity: registry not empty, every entry has the expected keys.
+    assert len(BUOYS) > 0
+    for b in BUOYS:
+        assert {"stn", "name", "lat", "lng"} <= set(b.keys())
+
+
+def test_buoy_correction_zero_anchors_returns_zero_grid():
+    """No anchors == no correction, full bbox stays untouched."""
+    from sst_buoy_correction import kriging_correction_surface
+    H, W = 20, 30
+    sst = np.full((H, W), 16.0, dtype=np.float32)
+    lats = np.linspace(37.6, 31.8, H)
+    lngs = np.linspace(-124.0, -116.8, W)
+    correction, anchors = kriging_correction_surface(
+        sst_grid_c=sst, lats=lats, lngs=lngs, buoys=[],
+    )
+    assert correction.shape == sst.shape
+    assert np.all(correction == 0.0)
+    assert anchors == []
+
+
+def test_buoy_correction_single_anchor_centers_at_residual():
+    """One anchor at the center → kernel-weighted correction peaks at
+    the residual value at that location and decays outward."""
+    from sst_buoy_correction import kriging_correction_surface, BuoyReading
+    H, W = 30, 40
+    lats = np.linspace(37.6, 31.8, H)
+    lngs = np.linspace(-124.0, -116.8, W)
+    sst = np.full((H, W), 16.0, dtype=np.float32)
+    # Place a single buoy at the bbox centroid; observed = 17 °C.
+    buoy = BuoyReading(
+        stn="x", name="test",
+        lat=float(lats[H // 2]), lng=float(lngs[W // 2]),
+        wtmp_c=17.0, n_samples=24, age_hours=1.0,
+    )
+    correction, anchors = kriging_correction_surface(
+        sst_grid_c=sst, lats=lats, lngs=lngs, buoys=[buoy],
+    )
+    assert anchors[0]["residual_c"] == pytest.approx(1.0)
+    # Center of bbox should see ~+1.0 °C correction; far corner less.
+    center = correction[H // 2, W // 2]
+    corner = correction[0, 0]
+    assert center > 0.7   # close to 1.0, kernel makes it slightly less
+    assert corner >= 0.0  # always toward the residual sign here
+    assert center > corner
+
+
+def test_buoy_correction_clamps_extreme_residual():
+    """A bogus 10°C residual gets dropped from the anchor set, not
+    propagated through the surface."""
+    from sst_buoy_correction import (
+        kriging_correction_surface, BuoyReading, RESIDUAL_SANITY_BOUND_C,
+    )
+    H, W = 20, 30
+    lats = np.linspace(37.6, 31.8, H)
+    lngs = np.linspace(-124.0, -116.8, W)
+    sst = np.full((H, W), 16.0, dtype=np.float32)
+    bogus = BuoyReading(
+        stn="bogus", name="bogus",
+        lat=float(lats[H // 2]), lng=float(lngs[W // 2]),
+        wtmp_c=16.0 + RESIDUAL_SANITY_BOUND_C + 5.0,
+        n_samples=24, age_hours=1.0,
+    )
+    correction, anchors = kriging_correction_surface(
+        sst_grid_c=sst, lats=lats, lngs=lngs, buoys=[bogus],
+    )
+    assert anchors[0].get("skipped"), "bogus anchor was kept"
+    assert np.all(correction == 0.0), "bogus anchor leaked into correction"
+
+
+# =========================================================================
+# Phase C — sst_score + sst_watchdog
+# =========================================================================
+
+def test_sst_score_imports():
+    from validation import sst_score
+    # Surface check: all the expected helpers exist.
+    assert callable(sst_score.score_all_observations)
+    assert callable(sst_score.per_zone_metrics)
+    assert callable(sst_score.per_spot_metrics)
+    assert callable(sst_score._haversine_km)
+    assert callable(sst_score._nearest_spot)
+
+
+def test_sst_score_per_zone_metrics_shape():
+    """Synthetic residuals across two zones — verify aggregation."""
+    from validation import sst_score
+    residuals = [
+        {"residual_f": 2.0, "residual_c": 1.11, "zone": "bight_nearshore",
+         "predicted_c": 16.5, "observed_c": 15.4, "source_confidence": 0.9},
+        {"residual_f": 1.0, "residual_c": 0.55, "zone": "bight_nearshore",
+         "predicted_c": 17.0, "observed_c": 16.4, "source_confidence": 0.9},
+        {"residual_f": -0.5, "residual_c": -0.28, "zone": "central_offshore",
+         "predicted_c": 14.0, "observed_c": 14.3, "source_confidence": 0.9},
+    ]
+    out = sst_score.per_zone_metrics(residuals)
+    assert "bight_nearshore" in out
+    assert out["bight_nearshore"]["n"] == 2
+    assert out["bight_nearshore"]["bias_f"] == pytest.approx(1.5)
+
+
+def test_sst_score_per_spot_metrics_includes_alpha_suggestion():
+    from validation import sst_score
+    residuals = [
+        {"residual_f":  1.6, "residual_c":  0.89, "zone": "bight_nearshore",
+         "spot_id": "lajolla", "predicted_c": 16.5, "observed_c": 15.6,
+         "source_confidence": 0.9},
+        {"residual_f":  1.4, "residual_c":  0.78, "zone": "bight_nearshore",
+         "spot_id": "lajolla", "predicted_c": 17.0, "observed_c": 16.2,
+         "source_confidence": 0.9},
+    ]
+    out = sst_score.per_spot_metrics(residuals)
+    assert out["lajolla"]["n"] == 2
+    assert out["lajolla"]["bias_f"] == pytest.approx(1.5)
+    # α delta should flip sign — to correct +1.5 bias we subtract 1.5.
+    assert out["lajolla"]["suggested_alpha_delta_f"] == pytest.approx(-1.5)
+
+
+def test_sst_watchdog_rules_run_on_synthetic_metrics():
+    from validation import sst_watchdog
+    zone_metrics = {
+        "bight_nearshore": {
+            "n": 40, "bias_f": 2.1, "rmse_f": 2.4, "pearson_r": 0.85,
+        },
+    }
+    spot_metrics = {
+        "lajolla": {
+            "name": "La Jolla", "n": 25, "bias_f": -1.8, "rmse_f": 2.0,
+            "pearson_r": 0.8, "suggested_alpha_delta_f": 1.8,
+        },
+    }
+    f1 = sst_watchdog.rule_zone_bias(zone_metrics)
+    f5 = sst_watchdog.rule_spot_bias(spot_metrics)
+    assert any(f["rule"] == "R1" for f in f1)
+    assert any(f["rule"] == "R5" for f in f5)
+
+
+# =========================================================================
+# Phase D — Nearshore enhancement
+# =========================================================================
+
+def test_nearshore_imports():
+    from sst_predict import nearshore
+    assert callable(nearshore.compute_all_corrections)
+    assert callable(nearshore.upwelling_correction)
+
+
+def test_nearshore_no_inputs_returns_empty_layers(tmp_path, monkeypatch):
+    """When neither bathy.png nor wind PNGs are published, the module
+    returns no layers and a zero correction grid — fetch.py treats
+    that as 'don't apply', layer ships normally."""
+    from sst_predict import nearshore
+    monkeypatch.setattr(nearshore, "PUBLIC_DATA", tmp_path)
+    result = nearshore.compute_all_corrections(target_h=20, target_w=30)
+    assert result["layers"] == []
+    assert result["total_delta_c"].shape == (20, 30)
+    assert np.all(result["total_delta_c"] == 0.0)
+
+
+def test_nearshore_bathy_gradient_norm():
+    from sst_predict.nearshore import bathy_gradient_norm
+    # A simple ramp — gradient should be uniform (= one finite value
+    # everywhere); after normalization that's a constant 1.0.
+    depth = np.tile(np.linspace(0, 1000, 20).reshape(1, -1), (15, 1)).astype(np.float32)
+    g = bathy_gradient_norm(depth)
+    assert g.shape == depth.shape
+    assert g.min() >= 0 and g.max() <= 1.0
+    # The interior of the ramp has uniform gradient → normalised to 1.0.
+    assert g[5, 10] == pytest.approx(1.0, abs=0.01)
+
+
+def test_nearshore_coastal_distance_proxy():
+    from sst_predict.nearshore import coastal_distance_proxy_km
+    depth = np.array([[0, 100, 200, 600, 1500]], dtype=np.float32)
+    d = coastal_distance_proxy_km(depth)
+    # 0 m → 0 km, 100 m → 2.5 km, 200 m → 5 km, 600 m → 10 km, 1500 m → 30 km
+    assert d[0, 0] == pytest.approx(0.0,  abs=0.1)
+    assert d[0, 1] == pytest.approx(2.5,  abs=0.1)
+    assert d[0, 2] == pytest.approx(5.0,  abs=0.1)
+    assert d[0, 3] == pytest.approx(10.0, abs=0.5)
+    assert d[0, 4] == pytest.approx(30.0, abs=0.1)
+
+
+# =========================================================================
+# Phase E — Persistence-decay forecast
+# =========================================================================
+
+def test_forecast_imports():
+    # Importing fetch_sst_5day at module top-level pulls sst_predict.config
+    # which is enough to verify the top-level constants are still wired.
+    import fetch_sst_5day
+    assert fetch_sst_5day.HORIZON_DAYS == 7
+    assert callable(fetch_sst_5day.persistence_decay_forecast)
+
+
+def test_forecast_day_0_equals_nowcast():
+    """At lead 0, forecast must equal today's SST exactly. Sanity check
+    that the math doesn't quietly drift the 'today' frame."""
+    from fetch_sst_5day import persistence_decay_forecast
+    H, W = 5, 7
+    sst_now   = np.full((H, W), 17.0, dtype=np.float32)
+    sst_climo = np.full((H, W), 16.0, dtype=np.float32)  # cold prior
+    tau       = np.full((H, W), 10.0, dtype=np.float32)
+    fc = persistence_decay_forecast(
+        sst_now_c=sst_now, sst_climo_c=sst_climo,
+        tau_days=tau, horizon_days=7,
+    )
+    assert fc.shape == (7, H, W)
+    np.testing.assert_array_almost_equal(fc[0], sst_now, decimal=3)
+
+
+def test_forecast_decays_toward_climatology():
+    """At long lead, forecast must converge toward climatology."""
+    from fetch_sst_5day import persistence_decay_forecast
+    H, W = 4, 6
+    sst_now   = np.full((H, W), 17.0, dtype=np.float32)
+    sst_climo = np.full((H, W), 16.0, dtype=np.float32)
+    tau       = np.full((H, W), 2.0, dtype=np.float32)   # short τ for fast decay
+    fc = persistence_decay_forecast(
+        sst_now_c=sst_now, sst_climo_c=sst_climo,
+        tau_days=tau, horizon_days=7,
+    )
+    # By day 6 with τ=2, anomaly should be down by exp(-3)=5%, leaving
+    # ~+0.05 °C above climatology (16.05 °C). Tolerance 0.1.
+    assert fc[6].mean() == pytest.approx(16.05, abs=0.1)
+
+
+def test_forecast_zero_anomaly_stays_at_climatology():
+    """If today already equals climatology, forecast is flat at climatology
+    for every lead — anomaly is 0, exp(-d/τ)*0 = 0."""
+    from fetch_sst_5day import persistence_decay_forecast
+    H, W = 3, 4
+    val = 15.0
+    sst_now   = np.full((H, W), val, dtype=np.float32)
+    sst_climo = np.full((H, W), val, dtype=np.float32)
+    tau       = np.full((H, W), 5.0, dtype=np.float32)
+    fc = persistence_decay_forecast(
+        sst_now_c=sst_now, sst_climo_c=sst_climo,
+        tau_days=tau, horizon_days=7,
+    )
+    np.testing.assert_array_almost_equal(fc, np.full((7, H, W), val), decimal=3)

--- a/pipeline/validation/sst_score.py
+++ b/pipeline/validation/sst_score.py
@@ -1,70 +1,337 @@
-"""Hindcast scoring for sst_predict — same pattern as score.py (viz).
+"""Hindcast scoring for SST predictions.
 
-For every observation in observations.jsonl with
-``observed_sst_f`` set, find the nearest grid cell in the matching
-day's archive snapshot, compute the SST residual, aggregate per zone.
+Joins observations.jsonl rows with ``observed_sst_f`` set against
+each day's SST archive snapshot, computes per-cell residuals, and
+aggregates by zone AND by saved-spot. Same loop pattern as ``score.py``
+(visibility); the two writers run in the same workflow but output to
+distinct file pairs so each watchdog reads its own signal cleanly.
+
+Dual aggregation
+----------------
+Per-zone bias is the existing pattern: 9 zones (3 lat × 3 dist), each
+zone gets one bias / RMSE / calibration / r row. That's the right
+granularity for "the sat-vs-buoy bias regime in the SoCal Bight is
++0.4 °F" but too coarse for "La Jolla Cove specifically tends to be
+1.5 °F cooler than its bbox cell".
+
+So we ALSO aggregate per saved-spot. The watchdog R5 rule reads from
+that aggregation and suggests a per-spot α delta when residuals
+accumulate.
 
 Inputs (all already produced by existing pipeline pieces):
-  pipeline/validation/data/observations.jsonl    — buoy + dive log obs
-  pipeline/validation/data/archive/*.jsonl.gz    — per-cell predictions
+  observations.jsonl              — buoy + dive log obs (existing)
+  archive/{YYYY}/{MM}/{DD}.jsonl.gz — per-cell predictions (existing)
 
-Outputs (mirror the viz versions exactly):
-  pipeline/validation/data/sst_residuals.jsonl       — per-obs rows
-  pipeline/validation/data/sst_per_zone_metrics.json — aggregated stats
-
-The SST residual rows feed sst_watchdog.py — separate from the
-visibility watchdog so the two axes triage independently. Both
-watchdogs read from the same observations file (a single dive log
-post often reports both `observed_secchi_ft` and `observed_sst_f`,
-and we want both to count toward their respective metrics without
-double-handling).
-
-Status: framework. Implementation in phase 2.
-
-The implementation can almost literally copy ``score.py``:
-  - Same ``_load_archive_for_date`` helper
-  - Same ``_haversine_km`` / ``_nearest_cell``
-  - Replace ``observed_secchi_ft`` filter with ``observed_sst_f``
-  - Replace ``viz_p50_ft`` predicted-field key with ``sst_p50_c`` (then
-    convert to °F for the residual since obs are reported in °F)
-  - Same per-zone aggregation (n, rmse, bias, mae, calibration_pct,
-    pearson_r) — the metric definitions are universal
+Outputs:
+  sst_residuals.jsonl              — one row per scored obs
+  sst_per_zone_metrics.json        — 9 zones × {n, rmse, bias, mae, cal, r}
+  sst_per_spot_metrics.json        — one row per saved-spot ID
 """
 from __future__ import annotations
 
+import gzip
+import json
+import math
 import pathlib
+import sys
+from collections import defaultdict
+from datetime import date, datetime, timedelta, timezone
+from typing import Iterable
 
-# ---- Paths --------------------------------------------------------------
+import numpy as np
+
+
+# Make ``viz_predict`` zone helpers + sst_predict spot list importable.
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 
 HERE = pathlib.Path(__file__).resolve().parent
-DATA_DIR = HERE / "data"
-RESIDUALS_PATH = DATA_DIR / "sst_residuals.jsonl"
-METRICS_PATH   = DATA_DIR / "sst_per_zone_metrics.json"
-BASELINE_PATH  = DATA_DIR / "sst_per_zone_baseline.json"   # promoted by hand
+DATA_DIR        = HERE / "data"
+ARCHIVE_ROOT    = DATA_DIR / "archive"
+OBS_PATH        = DATA_DIR / "observations.jsonl"
+RESIDUALS_PATH  = DATA_DIR / "sst_residuals.jsonl"
+ZONE_METRICS    = DATA_DIR / "sst_per_zone_metrics.json"
+SPOT_METRICS    = DATA_DIR / "sst_per_spot_metrics.json"
+
+LOOKBACK_DAYS = 2   # mirror score.py — same archive lifetime constraint
 
 
-LOOKBACK_DAYS = 2  # same as score.py — bounded by ephemeral archive lifetime
+# ---- Saved-spot list ---------------------------------------------------
+# Lifted from src/lib/mapData.js. Hand-keep in sync; a unit test in
+# pipeline/tests/ enforces the two arrays match exactly. Per-spot
+# scoring rolls every observation within MAX_DIST_KM of the spot
+# centroid into that spot's bin (same threshold as the cell-nearest
+# match used by score.py — observations farther than 25 km from the
+# nearest spot are aggregated into "other" only).
+SAVED_SPOTS: list[dict] = [
+    {"id": "monterey",  "name": "Monterey",       "lat": 36.62, "lng": -121.92},
+    {"id": "morro",     "name": "Morro Bay",      "lat": 35.36, "lng": -120.88},
+    {"id": "pt-concep", "name": "Pt. Conception", "lat": 34.45, "lng": -120.47},
+    {"id": "santabarb", "name": "Santa Barbara",  "lat": 34.40, "lng": -119.70},
+    {"id": "santacruz", "name": "Santa Cruz I.",  "lat": 34.05, "lng": -119.75},
+    {"id": "malibu",    "name": "Malibu",         "lat": 34.02, "lng": -118.78},
+    {"id": "catalina",  "name": "Catalina",       "lat": 33.39, "lng": -118.45},
+    {"id": "lajolla",   "name": "La Jolla",       "lat": 32.85, "lng": -117.28},
+    {"id": "sandiego",  "name": "San Diego",      "lat": 32.70, "lng": -117.18},
+    {"id": "coronados", "name": "Coronados",      "lat": 32.40, "lng": -117.27},
+]
+
+SPOT_MATCH_KM = 12.0   # tighter than zone-cell match (25 km) — per-spot
+                       # bias only meaningful when the obs is plausibly
+                       # AT that spot, not "in the same zone".
+
+
+# ---- Load helpers (mirror score.py) ------------------------------------
+
+def _load_archive_for_date(d: date) -> list[dict] | None:
+    p = ARCHIVE_ROOT / f"{d.year:04d}/{d.month:02d}/{d.day:02d}.jsonl.gz"
+    if not p.exists():
+        return None
+    rows: list[dict] = []
+    with gzip.open(p, "rt", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return rows or None
+
+
+def _haversine_km(lat1, lng1, lat2, lng2) -> float:
+    R = 6371.0
+    p1 = math.radians(lat1)
+    p2 = math.radians(lat2)
+    dp = p2 - p1
+    dl = math.radians(lng2 - lng1)
+    a = math.sin(dp / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dl / 2) ** 2
+    return 2 * R * math.asin(math.sqrt(a))
+
+
+def _nearest_cell(rows: list[dict], lat: float, lng: float, max_km: float = 25.0) -> dict | None:
+    best, best_d = None, float("inf")
+    for r in rows:
+        d = _haversine_km(lat, lng, r["lat"], r["lng"])
+        if d < best_d:
+            best, best_d = r, d
+    if best is None or best_d > max_km:
+        return None
+    return best
+
+
+def _nearest_spot(lat: float, lng: float, max_km: float = SPOT_MATCH_KM) -> str | None:
+    best, best_d = None, float("inf")
+    for s in SAVED_SPOTS:
+        d = _haversine_km(lat, lng, s["lat"], s["lng"])
+        if d < best_d:
+            best, best_d = s, d
+    if best is None or best_d > max_km:
+        return None
+    return best["id"]
+
+
+def _iter_recent_observations(lookback_days: int) -> Iterable[dict]:
+    if not OBS_PATH.exists():
+        return
+    cutoff = datetime.now(timezone.utc) - timedelta(days=lookback_days)
+    with OBS_PATH.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                o = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            ts_str = o.get("timestamp_utc")
+            if not ts_str:
+                continue
+            try:
+                ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            if ts < cutoff:
+                continue
+            yield o
+
+
+# ---- SST residual scoring ----------------------------------------------
+
+def _to_celsius(value: float, unit: str | None) -> float:
+    """observed_sst_f is the canonical column but ingest scrapers
+    sometimes set observed_sst_c (CDIP / NDBC are SI). Tolerate both."""
+    if unit == "C" or unit == "c":
+        return float(value)
+    return (float(value) - 32.0) * 5.0 / 9.0
+
+
+def score_all_observations() -> list[dict]:
+    archive_by_date: dict[date, list[dict] | None] = {}
+    residuals: list[dict] = []
+
+    for o in _iter_recent_observations(LOOKBACK_DAYS):
+        # Pull whichever SST field is present; observation schemas
+        # differ across ingest sources.
+        sst_f = o.get("observed_sst_f")
+        sst_c = o.get("observed_sst_c")
+        if sst_f is None and sst_c is None:
+            continue
+        if sst_c is not None:
+            observed_c = float(sst_c)
+        else:
+            observed_c = _to_celsius(sst_f, "F")
+
+        ts = datetime.fromisoformat(o["timestamp_utc"].replace("Z", "+00:00"))
+        d = ts.date()
+        if d not in archive_by_date:
+            archive_by_date[d] = _load_archive_for_date(d)
+        rows = archive_by_date[d]
+        if not rows:
+            continue
+        cell = _nearest_cell(rows, float(o["lat"]), float(o["lng"]))
+        if cell is None:
+            continue
+
+        # The visibility archive carries `sst_today_c` as a driver.
+        # That's what we score against — it's the model's sample of
+        # today's SST at this cell. When sst_predict is wired (Phase E),
+        # it'll add `sst_p50_c` etc. We score whichever is available,
+        # preferring the prediction over the raw input.
+        predicted_c = (
+            cell.get("sst_p50_c")
+            if cell.get("sst_p50_c") is not None
+            else cell.get("sst_today_c")
+        )
+        if predicted_c is None:
+            continue
+        residual_c = float(predicted_c) - float(observed_c)
+
+        residuals.append({
+            "obs_id":            o["obs_id"],
+            "scored_at":         datetime.now(timezone.utc)
+                                     .isoformat(timespec="seconds")
+                                     .replace("+00:00", "Z"),
+            "predicted_c":       round(float(predicted_c), 2),
+            "observed_c":        round(float(observed_c), 2),
+            "residual_c":        round(residual_c, 2),
+            "residual_f":        round(residual_c * 9 / 5, 2),
+            "zone":              cell.get("zone"),
+            "spot_id":           _nearest_spot(float(o["lat"]), float(o["lng"])),
+            "lat":               float(o["lat"]),
+            "lng":               float(o["lng"]),
+            "source":            o.get("source"),
+            "source_confidence": float(o.get("source_confidence", 0.5)),
+            "coeff_hash":        cell.get("coeff_hash"),
+        })
+
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    with RESIDUALS_PATH.open("w", encoding="utf-8") as f:
+        for r in residuals:
+            f.write(json.dumps(r) + "\n")
+    print(f"sst_score: wrote {len(residuals)} residuals to {RESIDUALS_PATH}")
+    return residuals
+
+
+# ---- Aggregation -------------------------------------------------------
+
+def _agg_metrics(rows: list[dict]) -> dict:
+    """Same metric set as score.py:per_zone_metrics, in °F units."""
+    if not rows:
+        return {"n": 0}
+    weights = np.array([float(r.get("source_confidence", 0.5)) for r in rows])
+    residual_arr_f = np.array([float(r["residual_f"]) for r in rows])
+
+    wmean_sq = float(np.average(residual_arr_f ** 2, weights=weights))
+    rmse = float(math.sqrt(max(0.0, wmean_sq)))
+    bias = float(np.average(residual_arr_f, weights=weights))
+    mae  = float(np.average(np.abs(residual_arr_f), weights=weights))
+
+    if len(rows) >= 2:
+        preds = np.array([float(r["predicted_c"]) for r in rows])
+        obs   = np.array([float(r["observed_c"]) for r in rows])
+        r_p = (
+            float(np.corrcoef(preds, obs)[0, 1])
+            if preds.std() > 0 and obs.std() > 0 else None
+        )
+    else:
+        r_p = None
+
+    return {
+        "n":           len(rows),
+        "rmse_f":      round(rmse, 2),
+        "bias_f":      round(bias, 2),
+        "mae_f":       round(mae, 2),
+        "pearson_r":   None if r_p is None else round(r_p, 3),
+    }
+
+
+def per_zone_metrics(residuals: list[dict]) -> dict:
+    by_zone: dict[str, list[dict]] = defaultdict(list)
+    for r in residuals:
+        by_zone[r.get("zone") or "unknown"].append(r)
+    return {z: _agg_metrics(rows) for z, rows in sorted(by_zone.items()) if rows}
+
+
+def per_spot_metrics(residuals: list[dict]) -> dict:
+    by_spot: dict[str, list[dict]] = defaultdict(list)
+    for r in residuals:
+        sid = r.get("spot_id")
+        if sid:
+            by_spot[sid].append(r)
+    out: dict = {}
+    for spot in SAVED_SPOTS:
+        sid = spot["id"]
+        rows = by_spot.get(sid, [])
+        if not rows:
+            out[sid] = {"name": spot["name"], "n": 0}
+            continue
+        m = _agg_metrics(rows)
+        m["name"] = spot["name"]
+        m["lat"] = spot["lat"]
+        m["lng"] = spot["lng"]
+        # Suggested per-spot α delta (in °F). The watchdog R5 picks this
+        # up; humans review + commit. Bias is "predicted − observed", so
+        # to correct we SUBTRACT bias from predictions ⇒ α_delta = -bias.
+        m["suggested_alpha_delta_f"] = round(-m["bias_f"], 2)
+        out[sid] = m
+    return out
+
+
+def write_metrics(zone_metrics: dict, spot_metrics: dict) -> None:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    ZONE_METRICS.write_text(json.dumps({
+        "computed_at": now,
+        "lookback_days": LOOKBACK_DAYS,
+        "zones": zone_metrics,
+    }, indent=2))
+    SPOT_METRICS.write_text(json.dumps({
+        "computed_at": now,
+        "lookback_days": LOOKBACK_DAYS,
+        "spots": spot_metrics,
+    }, indent=2))
+    print(f"sst_score: wrote per-zone → {ZONE_METRICS}")
+    print(f"sst_score: wrote per-spot → {SPOT_METRICS}")
+    for zone, m in zone_metrics.items():
+        if m.get("n"):
+            print(f"  zone {zone:24s}  n={m['n']:3d}  rmse={m['rmse_f']:5.2f} °F  "
+                  f"bias={m['bias_f']:+5.2f} °F  r={m['pearson_r']!s}")
+    for sid, m in spot_metrics.items():
+        if m.get("n"):
+            print(f"  spot {sid:12s}  n={m['n']:3d}  rmse={m['rmse_f']:5.2f} °F  "
+                  f"bias={m['bias_f']:+5.2f} °F  Δα={m['suggested_alpha_delta_f']:+.2f}")
 
 
 def main() -> int:
-    """Score today's archived predictions vs ground-truth obs.
-
-    Phase-2 implementation:
-      1. Walk observations.jsonl, filter rows with observed_sst_f
-      2. For each obs, find the nearest cell in the matching day's
-         archive snapshot via _haversine_km
-      3. Compute residual_f = observed_sst_f - predicted_sst_f
-      4. Tag each row with the obs's zone (already in the archive cell)
-      5. Aggregate per zone: n, rmse, bias, mae, calibration_pct, pearson_r
-      6. Write sst_residuals.jsonl (one row per obs) and
-         sst_per_zone_metrics.json (one row per zone)
-
-    Exit 0 on success. Errors propagate up so the surrounding workflow
-    step's failure is visible (this should NOT be continue-on-error
-    when wired in phase 4 — we WANT to know if scoring breaks).
-    """
-    raise NotImplementedError(
-        "phase-2: copy score.py:main, swap observed_secchi_ft for observed_sst_f")
+    residuals = score_all_observations()
+    zone = per_zone_metrics(residuals)
+    spot = per_spot_metrics(residuals)
+    write_metrics(zone, spot)
+    return 0
 
 
 if __name__ == "__main__":

--- a/pipeline/validation/sst_watchdog.py
+++ b/pipeline/validation/sst_watchdog.py
@@ -1,134 +1,295 @@
-"""Automated review of SST prediction accuracy after every refresh.
+"""SST watchdog — same R1 / R3 pattern as watchdog.py, plus a per-spot rule.
 
-Mirror of validation/watchdog.py for the SST axis. Reads
-sst_per_zone_metrics.json + sst_residuals.jsonl, runs four rule checks,
-writes a markdown summary, exits 1 when any rule fired (so the
-surrounding workflow can open / update a rolling Issue tagged
-``sst-watchdog``).
+Reads ``sst_per_zone_metrics.json`` + ``sst_per_spot_metrics.json``,
+runs the rules, writes ``sst_watchdog_summary.md``, exits 1 when any
+rule fires so the surrounding workflow can open / update a rolling
+GitHub Issue tagged ``sst-watchdog``.
 
-The watchdog is the SELF-ADJUSTMENT mechanism the user asked for:
-every finding suggests a concrete coefficient delta in
-``pipeline/sst_predict/config.py`` that a human reviews and commits.
-The watchdog never auto-edits coefficients itself — same humans-in-
-the-loop discipline as the visibility watchdog. v2 adds a
-``--auto-apply`` mode for stable-bias zones (R1 firing same-direction
-≥7 consecutive days).
+Rules
+-----
+R1  Zone systematic bias.
+      |bias_F| > 1.5 °F and n >= 30 → suggest a delta to
+      ``sst_predict.config.BIAS_CORRECTION_F[zone]``. The watchdog
+      never edits config; the suggestion is in the issue body and a
+      human commits it.
 
-Rules:
-  R1  Zone systematic bias (over- or under-prediction)
-        threshold: |bias_F| > BIAS_THRESHOLD_F (1.5°F)
-        min n:     MIN_N_BIAS (30)
-        suggests:  config.BIAS_CORRECTION_F[zone] += -bias_F
-                   (sign flipped — we want to CORRECT the bias)
+R3  Zone correlation.
+      pearson_r < 0.5 and n >= 50 → structural finding. No automated
+      coefficient suggestion — low correlation means the model is
+      missing a driver for this zone (kelp shading, river plume,
+      seamount upwelling, etc).
 
-  R2  Zone interval calibration (p10–p90 too narrow / too wide)
-        threshold: calibration_pct outside [CAL_LOW, CAL_HIGH]
-        min n:     MIN_N_BIAS (30)
-        suggests:  config.SIGMA_SST_BY_LEAD[zone][0] *= (target/actual)
+R5  Per-spot bias.
+      Same logic as R1 but evaluated at saved-spot granularity.
+      n >= 20 (lower than the zone threshold; per-spot residuals
+      accumulate slower because each obs has to be within
+      SPOT_MATCH_KM of the spot centroid). Suggests a delta to
+      ``SPOT_CORRECTIONS[spot_id].alpha_f``.
 
-  R3  Zone correlation (model captures relative differences)
-        threshold: pearson_r < CORR_LOW (0.5)
-        min n:     MIN_N_CORR (50)
-        suggests:  structural — investigate whether forecast.py is
-                   missing a driver for this zone (e.g. nearshore
-                   upwelling not captured by 9km RTOFS, kelp shading
-                   in shallow zones, river-mouth thermal plumes)
+Calibration (R2) is deferred until ``sst_predict`` writes p10/p90
+into the archive (Phase E). Data-flow (R4) is covered by the existing
+``watchdog.py`` — SST obs ride along on the same observations.jsonl
+volume gate.
 
-  R4  Data-flow health (sources running)
-        threshold: <12 SST obs in last 24h OR a satellite source
-                   stays red across 3+ consecutive check_published
-                   runs
-        suggests:  investigate refresh-data.yml or check_feeds.yml
-
-Status: framework. Implementation in phase 4 (after enough residual
-signal has accumulated to make rule outputs meaningful).
+Output
+------
+sst_watchdog_summary.md — markdown body the workflow uploads as the
+GitHub Issue body. Same template as watchdog.render so reviewers see
+a consistent format across the two axes.
 """
 from __future__ import annotations
 
+import json
 import pathlib
+import sys
+from datetime import datetime, timezone
 
-# ---- Paths --------------------------------------------------------------
 
 HERE = pathlib.Path(__file__).resolve().parent
 DATA_DIR = HERE / "data"
 
-METRICS_PATH      = DATA_DIR / "sst_per_zone_metrics.json"
-RESIDUALS_PATH    = DATA_DIR / "sst_residuals.jsonl"
-OBSERVATIONS_PATH = DATA_DIR / "observations.jsonl"          # shared with viz watchdog
+ZONE_METRICS_PATH = DATA_DIR / "sst_per_zone_metrics.json"
+SPOT_METRICS_PATH = DATA_DIR / "sst_per_spot_metrics.json"
 SUMMARY_PATH      = DATA_DIR / "sst_watchdog_summary.md"
 
 
+# ----- Thresholds (mirror config in pipeline/sst_predict/config.py) ----
+# Kept here as plain constants so this module can run without dragging
+# in the sst_predict package — keeps the watchdog as a pure scoring
+# consumer that doesn't need the predictor's runtime deps.
+
+BIAS_THRESHOLD_F = 1.5    # R1, R5
+CORR_LOW         = 0.5    # R3
+MIN_N_BIAS_ZONE  = 30
+MIN_N_BIAS_SPOT  = 20
+MIN_N_CORR       = 50
+
+
+# ----- Loaders ----------------------------------------------------------
+
+def _load_json(path: pathlib.Path) -> dict | None:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+# ----- Rules ------------------------------------------------------------
+
 def rule_zone_bias(zones: dict) -> list[dict]:
-    """R1: |bias_F| > 1.5°F, n >= 30.
-
-    For each zone where the metric exceeds threshold, suggests
-    a delta to BIAS_CORRECTION_F[zone] sized to close the bias
-    1:1 (the simplest correction). When the residuals later show
-    the correction overshot, R1 fires the OTHER direction at the
-    next refresh and the human walks it back. Convergence is
-    typically 2-3 iterations.
-    """
-    raise NotImplementedError(
-        "phase-4: literally watchdog.rule_zone_bias with sst units")
-
-
-def rule_zone_calibration(zones: dict) -> list[dict]:
-    """R2: calibration_pct outside [0.60, 0.95], n >= 30.
-
-    For too-narrow intervals: SIGMA_SST_BY_LEAD[zone] *= 1.5
-    For too-wide:             SIGMA_SST_BY_LEAD[zone] *= 0.7
-    The asymmetry is intentional — too-narrow is more dangerous
-    because users see the predicted band as a confidence claim, so
-    we widen aggressively and tighten cautiously.
-    """
-    raise NotImplementedError("phase-4 stub")
+    """R1: |bias_F| > 1.5, n >= 30 — zone-level systematic bias."""
+    out: list[dict] = []
+    for zone, m in sorted(zones.items()):
+        n = int(m.get("n") or 0)
+        bias = m.get("bias_f")
+        if n < MIN_N_BIAS_ZONE or bias is None:
+            continue
+        bias = float(bias)
+        if abs(bias) <= BIAS_THRESHOLD_F:
+            continue
+        # Closing the bias 1:1 — same heuristic the viz watchdog uses.
+        # Sign flips because BIAS_CORRECTION_F is added to predictions.
+        delta = round(-bias, 2)
+        out.append({
+            "rule":     "R1",
+            "severity": "high",
+            "zone":     zone,
+            "n":        n,
+            "bias_f":   round(bias, 2),
+            "rmse_f":   m.get("rmse_f"),
+            "title":    f"Zone `{zone}` SST bias is {bias:+.2f} °F (n={n})",
+            "what":     (
+                f"Predictions in this zone are systematically "
+                f"{'over' if bias > 0 else 'under'}-shooting observations "
+                f"by ~{abs(bias):.1f} °F."
+            ),
+            "action":   (
+                f"Adjust `BIAS_CORRECTION_F[{zone!r}]` by `{delta:+.2f}`. "
+                f"File: `pipeline/sst_predict/config.py`. Re-evaluate after "
+                f"the next ~30 obs accumulate."
+            ),
+        })
+    return out
 
 
 def rule_zone_correlation(zones: dict) -> list[dict]:
-    """R3: pearson_r < 0.5, n >= 50.
+    """R3: pearson_r < 0.5, n >= 50."""
+    out: list[dict] = []
+    for zone, m in sorted(zones.items()):
+        n = int(m.get("n") or 0)
+        r = m.get("pearson_r")
+        if r is None or n < MIN_N_CORR:
+            continue
+        try:
+            r = float(r)
+        except (TypeError, ValueError):
+            continue
+        if r >= CORR_LOW:
+            continue
+        out.append({
+            "rule":     "R3",
+            "severity": "structural",
+            "zone":     zone,
+            "n":        n,
+            "pearson_r": r,
+            "title":    f"Zone `{zone}` SST correlation r={r:.2f} (n={n})",
+            "what":     (
+                "Even after subtracting the bias, the model isn't tracking "
+                "relative day-over-day differences in this zone. Likely "
+                "missing physics: nearshore upwelling, kelp shading, "
+                "estuarine outflow, or a high-relief mixing pattern."
+            ),
+            "action":   (
+                f"Investigate Phase D corrections for `{zone}` — bathymetry-"
+                f"coupled upwelling index, solar warming on shallow shelves, "
+                f"or tidal mixing at high-relief features. File: "
+                f"`pipeline/sst_predict/nearshore.py` (when implemented)."
+            ),
+        })
+    return out
 
-    No automated coefficient suggestion — low correlation is a
-    structural signal that needs human investigation. The summary
-    points to candidate causes (the zone-specific physics that the
-    forecast model might be under-representing).
-    """
-    raise NotImplementedError("phase-4 stub")
+
+def rule_spot_bias(spots: dict) -> list[dict]:
+    """R5: per-spot |bias_F| > 1.5, n >= 20 — spot-specific microclimate."""
+    out: list[dict] = []
+    for spot_id, m in sorted(spots.items()):
+        n = int(m.get("n") or 0)
+        bias = m.get("bias_f")
+        if n < MIN_N_BIAS_SPOT or bias is None:
+            continue
+        bias = float(bias)
+        if abs(bias) <= BIAS_THRESHOLD_F:
+            continue
+        delta = round(-bias, 2)
+        out.append({
+            "rule":     "R5",
+            "severity": "medium",
+            "spot_id":  spot_id,
+            "spot_name": m.get("name", spot_id),
+            "n":        n,
+            "bias_f":   round(bias, 2),
+            "title":    (
+                f"Spot `{m.get('name', spot_id)}` has SST bias "
+                f"{bias:+.2f} °F (n={n})"
+            ),
+            "what":     (
+                f"This dive site systematically reads "
+                f"{abs(bias):.1f} °F {'colder' if bias > 0 else 'warmer'} "
+                f"than the bbox cell average — typical for spots dominated "
+                f"by local microclimate (upwelling at headlands, sun-trap "
+                f"coves, river-mouth mixing)."
+            ),
+            "action":   (
+                f"Add or update `SPOT_CORRECTIONS[{spot_id!r}].alpha_f` "
+                f"by `{delta:+.2f}`. File: `pipeline/sst_predict/config.py`. "
+                f"This adjusts the per-spot prediction the saved-spots panel "
+                f"shows; the bbox grid is unaffected."
+            ),
+        })
+    return out
 
 
-def rule_data_flow(observations: list[dict], feed_health: dict) -> list[dict]:
-    """R4: scrapers running + satellite feeds healthy.
+# ----- Markdown rendering ----------------------------------------------
 
-    Counts SST obs in observations.jsonl from the last 24h. Cross-
-    references with feed_health.json to flag the (rare) case where
-    obs are flowing but the satellite feeds for the predictor are
-    red — that's a "validation works, prediction broken" state worth
-    surfacing prominently.
-    """
-    raise NotImplementedError("phase-4 stub")
+def _section(findings: list[dict], heading: str) -> str:
+    if not findings:
+        return ""
+    lines = [f"## {heading}", ""]
+    for f in findings:
+        sev = f.get("severity", "medium")
+        title = f.get("title", "(no title)")
+        lines.append(f"### {title} _({sev})_")
+        lines.append("")
+        if f.get("what"):
+            lines.append(f.get("what"))
+            lines.append("")
+        if f.get("action"):
+            lines.append(f"**Action:** {f.get('action')}")
+            lines.append("")
+    return "\n".join(lines)
 
 
-def render_summary_markdown(findings: list[dict]) -> str:
-    """Format rule findings into a GitHub Issue body.
+def render(zones: dict, spots: dict, findings: list[dict]) -> str:
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    lines = [
+        "# SST watchdog",
+        "",
+        f"_Computed {now}._",
+        "",
+        f"**Findings:** {len(findings)}",
+        "",
+    ]
+    if not findings:
+        lines.append("All zone + per-spot SST checks pass.")
+    by_rule: dict[str, list[dict]] = {}
+    for f in findings:
+        by_rule.setdefault(f.get("rule", "?"), []).append(f)
+    for rule_id, group in sorted(by_rule.items()):
+        heading = {
+            "R1": "Zone bias (R1)",
+            "R3": "Zone correlation (R3)",
+            "R5": "Per-spot bias (R5)",
+        }.get(rule_id, f"Rule {rule_id}")
+        section = _section(group, heading)
+        if section:
+            lines.append("")
+            lines.append(section)
 
-    Same template as watchdog.render_summary_markdown. Each finding
-    section has:
-      - Title (zone + violation)
-      - What (user-readable explanation)
-      - Action (concrete coefficient change to copy-paste)
-      - Confidence (n + how recent + how stable across runs)
-    """
-    raise NotImplementedError("phase-4 stub")
+    # Always include the metrics tables for an at-a-glance view.
+    if zones:
+        lines.append("")
+        lines.append("## Zone metrics")
+        lines.append("")
+        lines.append("| Zone | n | bias_f | rmse_f | pearson_r |")
+        lines.append("|------|---|--------|--------|-----------|")
+        for z, m in sorted(zones.items()):
+            if not m.get("n"):
+                continue
+            lines.append(
+                f"| `{z}` | {m['n']} | {m['bias_f']:+.2f} | "
+                f"{m['rmse_f']:.2f} | {m.get('pearson_r')!s} |"
+            )
+    if spots:
+        non_empty = {sid: m for sid, m in spots.items() if m.get("n")}
+        if non_empty:
+            lines.append("")
+            lines.append("## Per-spot metrics")
+            lines.append("")
+            lines.append("| Spot | n | bias_f | rmse_f | suggested Δα |")
+            lines.append("|------|---|--------|--------|--------------|")
+            for sid, m in sorted(non_empty.items()):
+                lines.append(
+                    f"| {m.get('name', sid)} | {m['n']} | {m['bias_f']:+.2f} | "
+                    f"{m['rmse_f']:.2f} | {m.get('suggested_alpha_delta_f', 0):+.2f} |"
+                )
+    return "\n".join(lines)
 
+
+# ----- Main -------------------------------------------------------------
 
 def main() -> int:
-    """Run all four rules; write summary; exit 1 on any finding.
+    zone_doc = _load_json(ZONE_METRICS_PATH)
+    spot_doc = _load_json(SPOT_METRICS_PATH)
+    zones = (zone_doc or {}).get("zones") or {}
+    spots = (spot_doc or {}).get("spots") or {}
 
-    Workflow integration (phase-4) mirrors the viz watchdog block in
-    refresh-data.yml — open / update a rolling Issue tagged
-    ``sst-watchdog`` on findings, close it when clear.
-    """
-    raise NotImplementedError(
-        "phase-4: orchestrate rules + render + exit code")
+    findings: list[dict] = []
+    findings.extend(rule_zone_bias(zones))
+    findings.extend(rule_zone_correlation(zones))
+    findings.extend(rule_spot_bias(spots))
+
+    body = render(zones, spots, findings)
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    SUMMARY_PATH.write_text(body, encoding="utf-8")
+    print(f"sst_watchdog: wrote {SUMMARY_PATH} ({len(findings)} findings)")
+    for f in findings:
+        sev = f.get("severity", "medium")
+        print(f"  [{sev:>10}] {f.get('rule')}: {f.get('title')}")
+
+    # Exit 1 on any finding so the workflow opens/updates the issue.
+    return 1 if findings else 0
 
 
 if __name__ == "__main__":

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -62,6 +62,7 @@ import SstTimeline, {
   sstSelectionHasData,
   sstSelToSlotKey,
 } from "./components/SstTimeline.jsx";
+import { SstTrendChip, SstSparkline } from "./components/SstTrendBits.jsx";
 import { MoonWidget } from "./components/MoonIcon.jsx";
 import {
   getSwell5dSummary,
@@ -564,6 +565,14 @@ function DesktopView({ layer, setLayer, composite, setComposite, sstMode, setSst
     : layer === "swell" ? selToSlotKey(swellSel, getSwell5dSummary())
     : layer === "current" ? currentSelToSlotKey(currentSel, getCurrent5dSummary())
     : composite;
+  // Map-render layer override: keep `layer` state at "sst" everywhere
+  // else so panels / pickers / saved-spots logic is unchanged, but
+  // hand DataOverlay the synthetic "sst-trend" / "sst5d" layer when
+  // those modes are active. Cheap, isolated, easy to revert.
+  const renderLayer =
+    layer === "sst" && sstViewMode === "trend"    ? "sst-trend"
+    : layer === "sst" && sstViewMode === "forecast" ? "sst5d"
+    : layer;
   const isMobile = useIsMobile();
 
   const stageRef = useRef(null);
@@ -1047,11 +1056,14 @@ function DesktopView({ layer, setLayer, composite, setComposite, sstMode, setSst
                 pointerEvents="none"
               />
 
-              {/* Data overlay (positions itself inside the fitted box). */}
+              {/* Data overlay (positions itself inside the fitted box).
+                  renderLayer is `layer` for normal modes and "sst-trend"
+                  when the trend toggle is on — so the diverging palette
+                  paints without any panel/UI thinking the layer changed. */}
               <DataOverlay
                 width={size.w}
                 height={size.h}
-                layer={layer}
+                layer={renderLayer}
                 composite={activeComposite}
                 opacity={opacity}
                 dataReady={dataState?.ready}
@@ -1667,6 +1679,15 @@ function DesktopView({ layer, setLayer, composite, setComposite, sstMode, setSst
                     <div className="spot-meta mono">
                       {s.lat.toFixed(2)}°N {Math.abs(s.lng).toFixed(2)}°W
                     </div>
+                    {/* Trend pill + sparkline only for SST. Both fall
+                        back to null when history isn't loaded yet, so
+                        non-SST layers and first-paint stay clean. */}
+                    {layer === "sst" && (
+                      <div className="spot-trend">
+                        <SstTrendChip lng={s.lng} lat={s.lat} units={units} />
+                        <SstSparkline lng={s.lng} lat={s.lat} units={units} />
+                      </div>
+                    )}
                   </div>
                   <div className="spot-val mono">
                     {valTxt}

--- a/src/components/DataOverlay.jsx
+++ b/src/components/DataOverlay.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { sstColor, chlColor, getFitted } from "../lib/mapData.js";
+import { sstColor, sstTrendColor, chlColor, getFitted } from "../lib/mapData.js";
 import { getLayerGrid } from "../lib/dataSource.js";
 
 // Beaufort-aligned wind ramp (knots → [r,g,b]); same stops as the legend.
@@ -170,6 +170,8 @@ export default function DataOverlay({ width, height, layer, composite, opacity, 
       }
       let rgb;
       if (layer === "sst") rgb = rgbStrToArr(sstColor(v));
+      else if (layer === "sst5d") rgb = rgbStrToArr(sstColor(v));
+      else if (layer === "sst-trend") rgb = rgbStrToArr(sstTrendColor(v));
       else if (layer === "chl") rgb = rgbStrToArr(chlColor(v));
       else if (layer === "wind") rgb = windColorRGBArr(v);
       else if (layer === "current") rgb = currentColorRGBArr(v);

--- a/src/components/MobileSheet.jsx
+++ b/src/components/MobileSheet.jsx
@@ -18,6 +18,7 @@
 
 import { useState } from "react";
 import { sstColor, chlColor, SAVED_SPOTS } from "../lib/mapData.js";
+import { SstTrendChip } from "./SstTrendBits.jsx";
 import {
   getSST,
   getChl,
@@ -456,6 +457,12 @@ function SpotsList({ layer, composite, units, activeSpot, setActiveSpot }) {
           >
             <span className="ms-spot-pin" style={{ color: col }}></span>
             <span className="ms-spot-name">{s.name}</span>
+            {/* SST mobile rows get the trend chip inline so direction
+                reads at a glance without crowding. Sparkline omitted on
+                mobile — too small to be readable in this row height. */}
+            {layer === "sst" && (
+              <SstTrendChip lng={s.lng} lat={s.lat} units={units} />
+            )}
             <span className="ms-spot-val mono">
               {valTxt}<span className="unit">{unit}</span>
             </span>

--- a/src/components/SstTrendBits.jsx
+++ b/src/components/SstTrendBits.jsx
@@ -1,0 +1,127 @@
+// Small read-only widgets shown next to each saved-spot row when the
+// SST layer is active. Both render off the d-N..d0 grids the
+// fetch.py history pipeline already publishes — no new fetches.
+//
+//   <SstTrendChip lng={...} lat={...} units="F"/>
+//     A compact pill: "▲ 1.2°F / 3d" green or "▼ 0.8°F / 3d" blue.
+//     Returns null when there isn't enough history to compute.
+//
+//   <SstSparkline lng={...} lat={...} units="F"/>
+//     7 tiny dots colored by SST_TREND palette, anchored to the per-cell
+//     ΔT vs the 7-day mean. Hovering reads the day + value out via
+//     a native <title>.
+
+import { sstTrendColor, SST_TREND_RANGE_C } from "../lib/mapData.js";
+import {
+  getSstTrend,
+  getSstSparkline,
+  getSstHistorySummary,
+  SST_TREND_DAYS,
+} from "../lib/dataSource.js";
+
+
+/** °C → display unit (°F or °C) for the chip. */
+function dispDelta(deltaC, units) {
+  return units === "F" ? deltaC * 9 / 5 : deltaC;
+}
+
+function dispUnit(units) {
+  return units === "F" ? "°F" : "°C";
+}
+
+
+/** "▲ 1.2°F / 3d" — colored green warming / blue cooling / grey steady. */
+export function SstTrendChip({ lng, lat, units = "F", days = SST_TREND_DAYS }) {
+  const { deltaC } = getSstTrend(lng, lat, days);
+  if (!Number.isFinite(deltaC)) return null;
+
+  // Below the noise floor — show "steady" rather than tiny noise readings.
+  // 0.2 °C ≈ 0.36 °F, slightly looser than typical satellite per-pixel
+  // accuracy so a real ±0.5 °F trend still reads as a direction.
+  const NOISE_FLOOR_C = 0.2;
+  const isSteady = Math.abs(deltaC) < NOISE_FLOOR_C;
+
+  const arrow = isSteady ? "·" : (deltaC > 0 ? "▲" : "▼");
+  const v = dispDelta(deltaC, units);
+  const u = dispUnit(units);
+  const sign = isSteady ? "" : (v > 0 ? "+" : "");
+  const text = `${arrow} ${sign}${v.toFixed(1)}${u} / ${days}d`;
+
+  // Use the same diverging palette as the map for visual consistency.
+  // The chip also uses background + foreground to read on every theme.
+  const bg = isSteady
+    ? "color-mix(in srgb, var(--ink-3) 22%, transparent)"
+    : sstTrendColor(deltaC);
+
+  return (
+    <span
+      className="sst-trend-chip mono"
+      style={{
+        background: bg,
+        color: isSteady ? "var(--ink-2)" : "rgba(15, 23, 42, 0.92)",
+      }}
+      title={isSteady
+        ? `Within ±${(NOISE_FLOOR_C * (units === "F" ? 9 / 5 : 1)).toFixed(1)}${u} of ${days}-day baseline`
+        : `Now − ${days} days ago: ${sign}${v.toFixed(2)}${u}`}
+    >
+      {text}
+    </span>
+  );
+}
+
+
+/** 7 tiny circles arrayed left-to-right, color-coded by ΔT vs the 7-day
+ *  mean at this cell. NaN slots render dimmed grey so a coverage gap
+ *  reads as "no satellite that day", not "missing component". */
+export function SstSparkline({ lng, lat, units = "F", width = 56, height = 12 }) {
+  const summary = getSstHistorySummary();
+  const samples = getSstSparkline(lng, lat);
+  if (!summary?.days?.length || !samples?.length) return null;
+
+  // Anchor coloring to the local 7-day mean so each spot's sparkline
+  // is read against ITS OWN baseline (rather than the bbox average,
+  // which would make low-temp Monterey look "always cold" + high-temp
+  // Coronados look "always warm"). Effect: a flat sparkline reads as
+  // "stable for this spot," matching the chip's read.
+  const valid = samples.filter((v) => Number.isFinite(v));
+  if (valid.length < 2) return null;
+  const mean = valid.reduce((s, v) => s + v, 0) / valid.length;
+
+  const N = samples.length;
+  const r = Math.min(width / N / 2.4, height / 2.4);
+  const cy = height / 2;
+
+  return (
+    <svg
+      className="sst-sparkline"
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      role="img"
+      aria-label={`SST trend over ${N} days`}
+    >
+      {samples.map((v, i) => {
+        // Distribute centers evenly with a half-step inset so the
+        // first/last dots aren't clipped by the SVG edge.
+        const cx = ((i + 0.5) / N) * width;
+        if (!Number.isFinite(v)) {
+          return (
+            <circle key={i} cx={cx} cy={cy} r={r * 0.6}
+                    fill="rgb(180,180,180)" opacity="0.35">
+              <title>{summary.days[i]?.date}: no data</title>
+            </circle>
+          );
+        }
+        const fill = sstTrendColor(v - mean);
+        const dispV = units === "F" ? v * 9 / 5 + 32 : v;
+        return (
+          <circle key={i} cx={cx} cy={cy} r={r} fill={fill}>
+            <title>
+              {summary.days[i]?.date}: {dispV.toFixed(1)}{dispUnit(units)}
+            </title>
+          </circle>
+        );
+      })}
+    </svg>
+  );
+}

--- a/src/lib/dataSource.js
+++ b/src/lib/dataSource.js
@@ -189,7 +189,43 @@ export async function loadManifest() {
     state.manifest = manifest;
     for (const [layer, info] of Object.entries(manifest.layers || {})) {
       state.layers[layer] = layer === "sst" ? (state.layers.sst || {}) : {};
-      if (layer === "sst7d") {
+      if (layer === "sst5d") {
+        // Phase E — 7-day SST forecast. Same shape as sst7d (per-day
+        // PNG + summary.json) so the loader is structurally identical;
+        // separate state slot keeps the forecast and the history from
+        // stomping each other when both ship.
+        try {
+          const sres = await fetch(info.summary_url, { cache: "no-cache" });
+          if (!sres.ok) throw new Error(`sst5d summary ${info.summary_url} ${sres.status}`);
+          const summary = await sres.json();
+          state.layers.sst5d = { summary };
+          const scale = info.scale || summary.scale || "linear";
+          const range = info.range_c || summary.range_c;
+          if (!range) throw new Error("sst5d has no range");
+          const tasks = [];
+          for (const d of summary.days || []) {
+            if (!d?.url) continue;
+            const slot = `f${d.offset ?? 0}`;     // forecast slot, namespaced
+                                                  // away from the sst7d "d-N"
+                                                  // keys to avoid collisions.
+            tasks.push(
+              decodePng(d.url, scale, range)
+                .then((decoded) => {
+                  state.layers.sst5d[slot] = {
+                    ...decoded,
+                    dates: d.date ? [d.date] : [],
+                    forecast: true,
+                    stats: d,
+                  };
+                })
+                .catch((e) => console.warn(`sst5d ${slot} failed`, e))
+            );
+          }
+          await Promise.all(tasks);
+        } catch (e) {
+          console.warn("dataSource: sst5d summary load failed", e);
+        }
+      } else if (layer === "sst7d") {
         try {
           const sres = await fetch(info.summary_url, { cache: "no-cache" });
           if (!sres.ok) throw new Error(`sst summary ${info.summary_url} ${sres.status}`);
@@ -564,6 +600,78 @@ export function getSstHistoryStats(slotKeyStr) {
   return summary.days?.find((d) => d.slot === slotKeyStr) || null;
 }
 
+// ---- 3-day trend (Phase A) ---------------------------------------------
+//
+// The 7-day history pipeline writes one PNG per day into
+// state.layers.sst[d-6 .. d0]. These helpers compute trend signals
+// directly off those grids — no new fetches, no pipeline changes.
+
+// Number of days back the "trend" view compares. Picked to match the
+// time-window of physical ocean processes a free diver cares about
+// (a typical upwelling event spins up over 2-3 days). Configurable
+// in case we want a "1-day" sub-mode later.
+export const SST_TREND_DAYS = 3;
+
+/** Per-cell ΔT (today − N days ago) as a derived grid. Cached on first
+ *  call and invalidated whenever a fresh manifest lands (notify()).
+ *  Cells where either day is NaN come out NaN — DataOverlay treats
+ *  those as transparent, which is exactly what we want for stale tiles.
+ */
+let _trendGridCache = null;
+subscribers.add(() => { _trendGridCache = null; });
+
+export function getSstTrendGrid(daysBack = SST_TREND_DAYS) {
+  if (_trendGridCache && _trendGridCache.daysBack === daysBack) {
+    return _trendGridCache.grid;
+  }
+  const today = state.layers.sst?.["d0"];
+  const then  = state.layers.sst?.[`d-${daysBack}`];
+  if (!today || !then) return null;
+  if (today.width !== then.width || today.height !== then.height) return null;
+  const N = today.data.length;
+  const out = new Float32Array(N);
+  for (let i = 0; i < N; i++) {
+    const a = today.data[i];
+    const b = then.data[i];
+    out[i] = (Number.isFinite(a) && Number.isFinite(b)) ? (a - b) : NaN;
+  }
+  const grid = { data: out, width: today.width, height: today.height };
+  _trendGridCache = { daysBack, grid };
+  return grid;
+}
+
+/** Per-spot trend at (lng, lat). Returns °C numbers (caller converts).
+ *  `now`  = today's value
+ *  `then` = N days ago value
+ *  `deltaC` = now - then
+ *  All three may be NaN when the satellite missed that cell.
+ */
+export function getSstTrend(lng, lat, daysBack = SST_TREND_DAYS) {
+  const now  = bilinear(state.layers.sst?.["d0"],  lng, lat);
+  const then = bilinear(state.layers.sst?.[`d-${daysBack}`], lng, lat);
+  const deltaC = (Number.isFinite(now) && Number.isFinite(then)) ? now - then : NaN;
+  return { now, then, deltaC };
+}
+
+/** Per-spot 7-day sparkline values at (lng, lat). Returns an array of
+ *  °C samples in order [d-6, d-5, ..., d-1, d0]. NaN slots ride along
+ *  for the renderer to skip / dim. */
+export function getSstSparkline(lng, lat) {
+  const summary = getSstHistorySummary();
+  if (!summary?.days?.length) return null;
+  // Use the summary's `days` array order (already chronological) so
+  // we don't re-derive the slot list locally.
+  return summary.days.map((d) => bilinear(state.layers.sst?.[d.slot], lng, lat));
+}
+
+
+// ---- 5-day forecast (Phase E) ------------------------------------------
+//
+// Mirror of the sst7d helpers. Each day's forecast lands in
+// state.layers.sst5d.f{0..6} (slot key namespace distinct from the
+// d-N history keys). Summary stats live in state.layers.sst5d.summary.
+
+/** Live forecast summary or null if not loaded. */
 export function getSstForecastSummary() {
   return state.layers.sst5d?.summary || null;
 }
@@ -572,6 +680,22 @@ export function getSstForecastStats(slotKeyStr) {
   const summary = getSstForecastSummary();
   if (!summary) return null;
   return summary.days?.find((d) => d.slot === slotKeyStr) || null;
+}
+
+/** Forecast SST °C at (lng, lat) for a given lead day (0..6). */
+export function getSstForecast(lng, lat, leadDay = 0) {
+  return bilinear(state.layers.sst5d?.[`f${leadDay}`], lng, lat);
+}
+
+/** Forecast horizon line for a single spot — a 7-day sparkline-like
+ *  array, °C per lead day in order [f0, f1, ..., f6]. NaN slots
+ *  ride through. */
+export function getSstForecastSparkline(lng, lat) {
+  const summary = getSstForecastSummary();
+  if (!summary?.days?.length) return null;
+  return summary.days.map((d) =>
+    bilinear(state.layers.sst5d?.[`f${d.offset ?? 0}`], lng, lat)
+  );
 }
 
 export function getChl(lng, lat, composite = 1) {
@@ -595,6 +719,26 @@ export function getVizFt(lng, lat, composite = 1) {
 // that bilinear() reads from. Lets DataOverlay render at native grid resolution
 // (one canvas pixel per source cell) and let the browser scale up smoothly.
 export function getLayerGrid(layer, composite) {
+  // Synthetic "sst-trend" pseudo-layer: derived from sst d0 vs d-N grids,
+  // rendered with the diverging ΔT colormap. Composite carries the days-back
+  // (integer); falls back to the SST_TREND_DAYS default when it's not numeric.
+  if (layer === "sst-trend") {
+    const days = Number.isInteger(composite) ? composite : SST_TREND_DAYS;
+    return getSstTrendGrid(days);
+  }
+  // 5-day SST forecast layer. composite is the lead-day integer (0..6)
+  // OR a string "f3"-style slot key. Reuses the SST color ramp via
+  // DataOverlay's "sst" branch — so we present the forecast as a
+  // separate `layer="sst5d"` value the panel can switch into without
+  // re-using the sst-trend palette.
+  if (layer === "sst5d") {
+    const slot = typeof composite === "string"
+      ? composite
+      : `f${Number.isInteger(composite) ? composite : 0}`;
+    const w = state.layers.sst5d?.[slot];
+    if (!w) return null;
+    return { data: w.data, width: w.width, height: w.height };
+  }
   // Wind / Swell: a string composite is a 5-day slot key (e.g. "d2_morning").
   if (layer === "wind" && typeof composite === "string") {
     const w = wind5dEntry(composite);

--- a/src/lib/mapData.js
+++ b/src/lib/mapData.js
@@ -162,6 +162,49 @@ export const SST_STOPS = [
 ];
 export const SST_RANGE = [9, 25]; // °C
 
+// ---- ΔT trend ramp (Phase A) -----------------------------------------
+// Diverging palette for the 3-day SST trend view. Centered at 0 °C
+// delta = neutral. Saturates at ±2 °C — a typical upwelling event
+// shifts coastal SST by 1-2 °C within 3 days, so saturation falls just
+// past the meaningful upper end and a "deep red plume / band of cold
+// blue" reads at-a-glance rather than blending.
+//
+// Stops chosen to:
+//   * keep ±0.2 °C visually neutral (under noise floor / averaging error)
+//   * cool side: cyan → blue → deep navy (matches the existing SST cold
+//     end so the visual idiom stays "cold = blue")
+//   * warm side: warm orange → red (matches the SST hot end)
+export const SST_TREND_RANGE_C = [-2.0, 2.0];   // saturation endpoints
+export const SST_TREND_STOPS = [
+  { d: -2.0, c: [12,  38, 130] },  // saturated cooling
+  { d: -1.0, c: [40, 130, 210] },  // strong cooling
+  { d: -0.4, c: [120, 200, 240] }, // mild cooling
+  { d: -0.2, c: [220, 230, 240] }, // near-neutral cool
+  { d:  0.0, c: [240, 240, 240] }, // neutral / under noise floor
+  { d:  0.2, c: [240, 230, 220] }, // near-neutral warm
+  { d:  0.4, c: [240, 200, 140] }, // mild warming
+  { d:  1.0, c: [230, 110,  60] }, // strong warming
+  { d:  2.0, c: [170,  20,  35] }, // saturated warming
+];
+
+export function sstTrendColor(deltaC) {
+  if (!Number.isFinite(deltaC)) return "rgba(0,0,0,0)";
+  // Clamp to the saturated endpoints — anything past ±2 °C ramps no further.
+  const d = Math.max(SST_TREND_RANGE_C[0], Math.min(SST_TREND_RANGE_C[1], deltaC));
+  for (let i = 0; i < SST_TREND_STOPS.length - 1; i++) {
+    const a = SST_TREND_STOPS[i], b = SST_TREND_STOPS[i + 1];
+    if (d >= a.d && d <= b.d) {
+      const span = b.d - a.d;
+      const t = span > 0 ? (d - a.d) / span : 0;
+      const r = Math.round(a.c[0] + t * (b.c[0] - a.c[0]));
+      const g = Math.round(a.c[1] + t * (b.c[1] - a.c[1]));
+      const bl = Math.round(a.c[2] + t * (b.c[2] - a.c[2]));
+      return `rgb(${r},${g},${bl})`;
+    }
+  }
+  return "rgb(120,120,120)";
+}
+
 // Value-anchored chl stops (the v2 prototype). Anchored at the diving-
 // relevant 0.1–5 mg/m³ range so the coastal upwelling band (~0.5–3 mg/m³)
 // gets the full color spectrum instead of being squashed into the bottom

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -608,6 +608,99 @@ body {
 }
 .spot-val .unit { color: var(--ink-3); font-weight: 400; font-size: 10px; margin-left: 1px; }
 
+/* Phase A — SST trend chip + sparkline + mode toggle.
+   The chip uses the same diverging palette as the map; the sparkline
+   re-uses it anchored to each spot's local 7-day mean so the row reads
+   "this place's trend" rather than "global trend at this place". */
+.spot-trend {
+  margin-left: 14px;
+  margin-top: 3px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.sst-trend-chip {
+  display: inline-flex;
+  align-items: center;
+  font-size: 10px;
+  line-height: 1;
+  padding: 3px 6px;
+  border-radius: 999px;
+  white-space: nowrap;
+  letter-spacing: 0.01em;
+}
+.sst-sparkline {
+  display: inline-block;
+  vertical-align: middle;
+  flex-shrink: 0;
+}
+.sst-mode-toggle {
+  display: inline-flex;
+  margin-top: 8px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 2px;
+  background: var(--bg-sunken);
+}
+.sst-mode-toggle button {
+  background: transparent;
+  border: 0;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--ink-2);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.sst-mode-toggle button:hover { color: var(--ink); }
+.sst-mode-toggle button.active {
+  background: var(--bg-panel-solid);
+  color: var(--ink);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.06);
+}
+
+/* Phase E — forecast lead-day picker. Lives directly beneath the
+   mode toggle when "Forecast" is active. Tighter than the mode
+   toggle since 7 days × 8 px font = a row that just barely fits the
+   panel width. */
+.sst-lead-picker {
+  display: flex;
+  margin-top: 6px;
+  gap: 2px;
+}
+.sst-lead-picker button {
+  flex: 1;
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 3px 0;
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--ink-2);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.sst-lead-picker button:hover {
+  border-color: var(--ink-3);
+  color: var(--ink);
+}
+.sst-lead-picker button.active {
+  background: var(--accent);
+  color: rgb(15, 23, 42);
+  border-color: var(--accent);
+}
+
+/* Mobile spot row — inline chip variant. The grid template needs one
+   extra "auto" column to seat the chip without pushing the value off
+   the right edge. */
+.ms-spot { /* defined elsewhere; we just relax the column template here */ }
+.ms-spot .sst-trend-chip {
+  font-size: 9.5px;
+  padding: 2px 5px;
+  margin-left: 6px;
+}
+
 /* Legend — bottom-right */
 .legend-br {
   bottom: 12px;


### PR DESCRIPTION
## Summary

All five SST upgrade phases, rebased onto current main and integrated
with the parallel SST work that landed via codex.

- **Phase A** — `SstTrendBits.jsx` (per-spot trend chip + 7-day sparkline in saved-spots), diverging ΔT palette in `mapData.js`. The desktop mode-toggle / lead-day picker dropped here in favor of the existing `SstModeToggle` on main.
- **Phase B** — `pipeline/sst_buoy_correction.py` (new). 6-buoy NDBC fetcher, ±5 °C sanity gate, Gaussian-kernel kriging (60 km), ±1.5 °C clamp. Hooked into `fetch.py` via `_apply_sst_buoy_correction`. Manifest carries per-anchor diagnostics.
- **Phase C** — `validation/sst_score.py` + `validation/sst_watchdog.py` go from scaffolds to functional. Per-zone AND per-spot residual aggregation, R1 zone bias, R3 correlation, R5 per-spot bias rules. New `SPOT_CORRECTIONS` dict in `sst_predict/config.py`.
- **Phase D** — `pipeline/sst_predict/nearshore.py` (new). Upwelling cooling (wind × bathy_grad × distance attenuation); solar warming + tidal mixing scaffolded for Phase D2. `APPLY_NEARSHORE_CORRECTIONS` feature flag (default ON).
- **Phase E** — `pipeline/fetch_sst_5day.py` (new). Persistence + climatology decay forecast at the per-zone τ from `sst_predict.config`. Coexists with main's `build_sst_forecast` / `sst5d` UI.
- 12 unit tests in `pipeline/tests/test_sst_phases.py`.

This intentionally does NOT touch the existing `sstMode` UI on main —
the sst-trend palette mode is a follow-up once the two SST mode systems
merge cleanly.

## Test plan

- [ ] dev-checks all 5 jobs green (firing via this PR's `pull_request` trigger)
- [ ] Spot-check fetch.py runs locally (skip — no python on this host)
- [ ] User reviews dev preview after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)