### PR TITLE
[codex] Fix SST deploy contract and smoke gates

### DIFF
--- a/.github/workflows/dev-checks.yml
+++ b/.github/workflows/dev-checks.yml
@@ -73,6 +73,8 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build
+      - name: Smoke built site
+        run: npm run smoke:site
       - name: Upload bundle as artifact
         # Lets a reviewer download the dev build to spot-check size /
         # contents without having to clone + build locally.

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -37,3 +37,6 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Run site smoke test
+        run: npm run smoke:site

--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -282,12 +282,18 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Smoke built site
+        run: npm run smoke:site
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy dist --project-name=shouldidive --branch=main --commit-dirty=true
+
+      - name: Smoke production site
+        run: npm run smoke:prod
 
       - name: Commit refreshed data
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "vite build",
     "test": "node --test tests/*.test.js",
     "test:data-contracts": "node tests/dataFeatureContracts.mjs",
+    "smoke:site": "node tests/siteSmoke.mjs --root dist",
+    "smoke:prod": "node tests/siteSmoke.mjs --url https://shouldidive.com --retries 5 --retry-delay-ms 10000",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/pipeline/fetch_sst_5day.py
+++ b/pipeline/fetch_sst_5day.py
@@ -257,12 +257,15 @@ def main() -> int:
         horizon_days=HORIZON_DAYS,
     )
 
-    # Write per-day PNGs + a summary.json mirroring fetch_wind_5day.
+    # Write per-day PNGs + a summary.json using the same schema that
+    # fetch.py writes. The daily workflow runs both scripts, so keeping
+    # this writer schema-identical prevents one step from breaking the
+    # deploy contract emitted by the other.
     SST5D_DIR.mkdir(parents=True, exist_ok=True)
     today = datetime.now(timezone.utc).date()
     days = []
     for d in range(HORIZON_DAYS):
-        dpath = SST5D_DIR / f"d{d}.png"
+        dpath = SST5D_DIR / f"f{d}_sst.png"
         _encode_celsius_to_png(forecast[d], dpath)
         st = _stats_for_grid(forecast[d])
         anom = forecast[d] - sst_climo
@@ -271,16 +274,18 @@ def main() -> int:
             if np.any(np.isfinite(anom)) else None
         )
         days.append({
-            "day":         DAY_LABELS_REL[d],
-            "offset":      d,
+            "slot":        f"f{d}",
+            "day":         d,
             "date":        (today + timedelta(days=d)).isoformat(),
-            "url":         f"/data/sst5d/d{d}.png",
+            "url":         f"/data/sst5d/f{d}_sst.png",
             "confidence":  CONFIDENCE_BY_DAY[d],
-            "mean_c":      st["mean"],
+            "mean":        st["mean"],
             "anom_c":      anom_mean,
-            "min_c":       st["min"],
-            "max_c":       st["max"],
+            "min":         st["min"],
+            "max":         st["max"],
             "coverage_frac": st["coverage_frac"],
+            "forecast":    d > 0,
+            "observed_anchor": d == 0,
         })
         print(f"  d{d} ({DAY_LABELS_REL[d]:>5}): mean={st['mean']}°C "
               f"anom={anom_mean}°C conf={CONFIDENCE_BY_DAY[d]}")
@@ -288,13 +293,17 @@ def main() -> int:
     summary = {
         "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds")
                                 .replace("+00:00", "Z"),
+        "valid_at":     today.isoformat(),
         "horizon_days": HORIZON_DAYS,
         "method":       "persistence_decay",
         "tz":           "UTC",
-        "range_c":      list(SST_RANGE_C),
+        "range":        list(SST_RANGE_C),
         "scale":        SST_SCALE,
         "unit":         SST_UNIT_C,
         "grid":         {"width": W, "height": H},
+        "beta":         True,
+        "default_slot": "f0",
+        "latest_slot":  "f0",
         "days":         days,
     }
     (SST5D_DIR / "summary.json").write_text(json.dumps(summary, indent=2))
@@ -313,9 +322,13 @@ def main() -> int:
     manifest["layers"]["sst5d"] = {
         "summary_url":  "/data/sst5d/summary.json",
         "horizon_days": HORIZON_DAYS,
-        "range_c":      list(SST_RANGE_C),
+        "range":        list(SST_RANGE_C),
+        "scale":        SST_SCALE,
         "unit":         SST_UNIT_C,
         "grid":         {"width": W, "height": H},
+        "generated_at": summary["generated_at"],
+        "tz":           "UTC",
+        "beta":         True,
         "method":       "persistence_decay",
     }
     MANIFEST_PATH.write_text(json.dumps(manifest, indent=2))

--- a/src/lib/dataSource.js
+++ b/src/lib/dataSource.js
@@ -200,14 +200,12 @@ export async function loadManifest() {
           const summary = await sres.json();
           state.layers.sst5d = { summary };
           const scale = info.scale || summary.scale || "linear";
-          const range = info.range_c || summary.range_c;
+          const range = info.range || info.range_c || summary.range || summary.range_c;
           if (!range) throw new Error("sst5d has no range");
           const tasks = [];
           for (const d of summary.days || []) {
             if (!d?.url) continue;
-            const slot = `f${d.offset ?? 0}`;     // forecast slot, namespaced
-                                                  // away from the sst7d "d-N"
-                                                  // keys to avoid collisions.
+            const slot = d.slot || `f${d.day ?? d.offset ?? 0}`;
             tasks.push(
               decodePng(d.url, scale, range)
                 .then((decoded) => {
@@ -254,36 +252,6 @@ export async function loadManifest() {
           await Promise.all(tasks);
         } catch (e) {
           console.warn("dataSource: sst7d summary load failed", e);
-        }
-      } else if (layer === "sst5d") {
-        try {
-          const sres = await fetch(info.summary_url, { cache: "no-cache" });
-          if (!sres.ok) throw new Error(`sst forecast summary ${info.summary_url} ${sres.status}`);
-          const summary = await sres.json();
-          state.layers.sst5d = { summary };
-          state.layers.sst = state.layers.sst || {};
-          const scale = info.scale || summary.scale || "linear";
-          const range = info.range || summary.range;
-          if (!range) throw new Error("sst5d has no range");
-          const tasks = [];
-          for (const d of summary.days || []) {
-            if (!d?.slot || !d?.url) continue;
-            tasks.push(
-              decodePng(d.url, scale, range)
-                .then((decoded) => {
-                  state.layers.sst[d.slot] = {
-                    ...decoded,
-                    dates: d.date ? [d.date] : [],
-                    forecast: true,
-                    stats: d,
-                  };
-                })
-                .catch((e) => console.warn(`sst5d ${d.slot} failed`, e))
-            );
-          }
-          await Promise.all(tasks);
-        } catch (e) {
-          console.warn("dataSource: sst5d summary load failed", e);
         }
       } else if (layer === "swell5d") {
         // 5-day × 5-bucket swell forecast (gfswave). Load summary.json
@@ -694,7 +662,7 @@ export function getSstForecastSparkline(lng, lat) {
   const summary = getSstForecastSummary();
   if (!summary?.days?.length) return null;
   return summary.days.map((d) =>
-    bilinear(state.layers.sst5d?.[`f${d.offset ?? 0}`], lng, lat)
+    bilinear(state.layers.sst5d?.[d.slot || `f${d.day ?? d.offset ?? 0}`], lng, lat)
   );
 }
 

--- a/tests/appFeatureContracts.test.js
+++ b/tests/appFeatureContracts.test.js
@@ -26,7 +26,8 @@ test("Temp keeps historical and beta forecast SST timelines instead of reverting
   assert.match(mobileSheet, /layer === "sst" && hasSstTimeline \? `Sea temp/);
   assert.match(mobileSheet, /layer === "sst" && hasSstTimeline \?\s*\(\s*<>[\s\S]*<SstModeToggle[\s\S]*<SstCurrentCard sel=\{activeSstSel\} units=\{units\} mode=\{activeSstMode\} \/>/);
   assert.match(dataSource, /if \(layer === "sst7d"\)/);
-  assert.match(dataSource, /else if \(layer === "sst5d"\)/);
+  assert.equal((dataSource.match(/layer === "sst5d"/g) || []).length, 2);
+  assert.match(dataSource, /info\.range \|\| info\.range_c \|\| summary\.range \|\| summary\.range_c/);
   assert.match(dataSource, /state\.layers\.sst7d = \{ summary \}/);
   assert.match(dataSource, /state\.layers\.sst5d = \{ summary \}/);
 });
@@ -55,6 +56,7 @@ test("CI runs frontend and data feature contracts before publishing", () => {
 
   assert.equal(pkg.scripts.test, "node --test tests/*.test.js");
   assert.equal(pkg.scripts["test:data-contracts"], "node tests/dataFeatureContracts.mjs");
-  assert.match(frontendWorkflow, /Run frontend regression tests[\s\S]*npm test[\s\S]*Build[\s\S]*npm run build/);
-  assert.match(deployWorkflow, /Run frontend regression tests[\s\S]*npm test[\s\S]*Run data feature contracts[\s\S]*npm run test:data-contracts[\s\S]*Build[\s\S]*npm run build/);
+  assert.equal(pkg.scripts["smoke:site"], "node tests/siteSmoke.mjs --root dist");
+  assert.match(frontendWorkflow, /Run frontend regression tests[\s\S]*npm test[\s\S]*Build[\s\S]*npm run build[\s\S]*Run site smoke test[\s\S]*npm run smoke:site/);
+  assert.match(deployWorkflow, /Run frontend regression tests[\s\S]*npm test[\s\S]*Run data feature contracts[\s\S]*npm run test:data-contracts[\s\S]*Build[\s\S]*npm run build[\s\S]*Smoke built site[\s\S]*npm run smoke:site[\s\S]*Deploy to Cloudflare Pages[\s\S]*Smoke production site[\s\S]*npm run smoke:prod/);
 });

--- a/tests/dataFeatureContracts.mjs
+++ b/tests/dataFeatureContracts.mjs
@@ -54,12 +54,15 @@ const sstForecastPath = localDataPath(sst5d.summary_url);
 assert.equal(existsSync(sstForecastPath), true, `sst5d summary missing: ${sst5d.summary_url}`);
 const sstForecast = readJson(sstForecastPath);
 assert.equal(sstForecast.beta, true, "sst5d summary must be explicitly marked beta");
+assert.deepEqual(sstForecast.range, layers.sst.range, "sst5d summary range must match sst");
+assert.deepEqual(sstForecast.grid, layers.sst.grid, "sst5d summary grid must match sst");
 assert.equal(Array.isArray(sstForecast.days), true, "sst5d summary must have days[]");
 assert.ok(sstForecast.days.length >= 5, `sst5d must retain at least 5 days, got ${sstForecast.days.length}`);
 assert.equal(sstForecast.default_slot, "f0", "sst5d must default to the freshest forecast anchor");
 
 for (const day of sstForecast.days) {
   assert.match(day.slot, /^f\d+$/, "sst5d day must use forecast slot keys");
+  assert.equal(typeof day.day, "number", `sst5d ${day.slot} must include numeric day`);
   assert.equal(typeof day.date, "string", `sst5d ${day.slot} must include date`);
   assert.equal(typeof day.url, "string", `sst5d ${day.slot} must include url`);
   assert.equal(existsSync(localDataPath(day.url)), true, `sst5d PNG missing: ${day.url}`);

--- a/tests/siteSmoke.mjs
+++ b/tests/siteSmoke.mjs
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function parseArgs() {
+  const out = new Map();
+  for (let i = 2; i < process.argv.length; i++) {
+    const arg = process.argv[i];
+    if (!arg.startsWith("--")) continue;
+    const next = process.argv[i + 1];
+    if (next && !next.startsWith("--")) {
+      out.set(arg, next);
+      i++;
+    } else {
+      out.set(arg, true);
+    }
+  }
+  return out;
+}
+
+const args = parseArgs();
+const root = resolve(repoRoot, args.get("--root") || "dist");
+const baseUrl = args.get("--url") || process.env.SITE_SMOKE_URL || null;
+const retries = Number(args.get("--retries") || 3);
+const retryDelayMs = Number(args.get("--retry-delay-ms") || 5000);
+
+function sleep(ms) {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
+}
+
+function isHtml(text) {
+  return /^\s*(<!doctype\s+html|<html[\s>])/i.test(text);
+}
+
+function assertNotHtml(text, label) {
+  assert.equal(isHtml(text), false, `${label} served HTML fallback instead of the expected resource`);
+}
+
+function resolveLocalPath(ref) {
+  const raw = String(ref).split("#")[0].split("?")[0];
+  const clean = raw === "/" || raw === "" ? "index.html" : raw.replace(/^\//, "");
+  const path = resolve(root, clean);
+  assert.equal(path.startsWith(root), true, `resource escapes smoke root: ${ref}`);
+  return path;
+}
+
+function resolveRemoteUrl(ref) {
+  return new URL(ref, baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`).toString();
+}
+
+async function fetchWithRetry(url) {
+  let lastError = null;
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const response = await fetch(url, { cache: "no-store" });
+      if (response.ok || attempt === retries) return response;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(retryDelayMs);
+  }
+  throw lastError;
+}
+
+async function readText(ref, label, { allowHtml = false } = {}) {
+  if (baseUrl) {
+    const url = resolveRemoteUrl(ref);
+    const response = await fetchWithRetry(url);
+    assert.equal(response.ok, true, `${label} ${url} returned HTTP ${response.status}`);
+    const text = await response.text();
+    if (!allowHtml) assertNotHtml(text, label);
+    return text;
+  }
+
+  const path = resolveLocalPath(ref);
+  assert.equal(existsSync(path), true, `${label} missing: ${path}`);
+  const text = readFileSync(path, "utf8");
+  if (!allowHtml) assertNotHtml(text, label);
+  return text;
+}
+
+async function readJson(ref, label) {
+  const text = await readText(ref, label);
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(`${label} is not valid JSON: ${error.message}`);
+  }
+}
+
+async function probeBinary(ref, label) {
+  if (baseUrl) {
+    const url = resolveRemoteUrl(ref);
+    const response = await fetchWithRetry(url);
+    assert.equal(response.ok, true, `${label} ${url} returned HTTP ${response.status}`);
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    assert.ok(bytes.length > 200, `${label} body too small (${bytes.length} bytes)`);
+    const head = new TextDecoder().decode(bytes.slice(0, 80));
+    assertNotHtml(head, label);
+    return;
+  }
+
+  const path = resolveLocalPath(ref);
+  assert.equal(existsSync(path), true, `${label} missing: ${path}`);
+  assert.ok(statSync(path).size > 200, `${label} too small: ${path}`);
+}
+
+function assertNoConflictMarkers(text, label) {
+  assert.equal(text.includes("<<<<<<<"), false, `${label} contains merge conflict marker`);
+  assert.equal(text.includes(">>>>>>>"), false, `${label} contains merge conflict marker`);
+}
+
+function assetRefs(html) {
+  return [...html.matchAll(/(?:src|href)="([^"]+\.(?:js|css)(?:\?[^"]*)?)"/g)].map((m) => m[1]);
+}
+
+async function smokeAssets() {
+  const html = await readText("/", "index.html", { allowHtml: true });
+  assert.match(html, /<title>ShouldIDive/, "index.html should be the ShouldIDive app shell");
+  assertNoConflictMarkers(html, "index.html");
+
+  const assets = assetRefs(html);
+  assert.ok(assets.length >= 2, "index.html should reference built JS/CSS assets");
+  for (const asset of assets) {
+    const body = await readText(asset, `asset ${asset}`);
+    assertNoConflictMarkers(body, `asset ${asset}`);
+  }
+}
+
+const summaryMinDays = {
+  sst7d: 3,
+  sst5d: 5,
+  wind5d: 5,
+  swell5d: 5,
+  current5d: 5,
+};
+
+function layerRange(info, summary) {
+  return info.range || info.range_c || summary.range || summary.range_c;
+}
+
+async function smokeSummaryLayer(layerId, info) {
+  assert.equal(typeof info.summary_url, "string", `${layerId} must include summary_url`);
+  const summary = await readJson(info.summary_url, `${layerId} summary`);
+  assert.equal(Array.isArray(summary.days), true, `${layerId} summary must include days[]`);
+  assert.ok(
+    summary.days.length >= summaryMinDays[layerId],
+    `${layerId} summary has too few days (${summary.days.length}/${summaryMinDays[layerId]})`
+  );
+
+  if (layerId === "sst7d" || layerId === "sst5d") {
+    assert.ok(Array.isArray(layerRange(info, summary)), `${layerId} must expose a decode range`);
+    assert.equal(typeof (info.grid || summary.grid)?.width, "number", `${layerId} must expose grid.width`);
+    assert.equal(typeof (info.grid || summary.grid)?.height, "number", `${layerId} must expose grid.height`);
+    if (layerId === "sst5d") assert.equal(info.beta || summary.beta, true, "sst5d must be marked beta");
+    for (const day of summary.days) {
+      assert.equal(typeof day.url, "string", `${layerId} day must include url`);
+      await probeBinary(day.url, `${layerId} ${day.slot || day.day}`);
+    }
+    return;
+  }
+
+  const sampleDays = [summary.days[0], summary.days.at(-1)].filter(Boolean);
+  for (const day of sampleDays) {
+    const buckets = day.buckets || [];
+    assert.ok(buckets.length > 0, `${layerId} day ${day.day} must include bucket summaries`);
+    const firstBucket = buckets[0];
+    const url = firstBucket.uv_url || firstBucket.wave_url;
+    assert.equal(typeof url, "string", `${layerId} bucket must include a probeable PNG url`);
+    await probeBinary(url, `${layerId} d${day.day} bucket`);
+  }
+}
+
+async function smokeData() {
+  const manifest = await readJson("/data/manifest.json", "manifest");
+  const layers = manifest.layers || {};
+  for (const required of ["sst", "sst7d", "sst5d", "wind5d", "swell5d", "current5d", "viz"]) {
+    assert.ok(layers[required], `manifest must include ${required}`);
+  }
+
+  for (const layerId of Object.keys(summaryMinDays)) {
+    await smokeSummaryLayer(layerId, layers[layerId]);
+  }
+}
+
+await smokeAssets();
+await smokeData();
+
+console.log(`site smoke passed (${baseUrl || root})`);


### PR DESCRIPTION
## What changed
- Align `pipeline/fetch_sst_5day.py` with the live SST forecast contract used by `fetch.py`: `range`, `scale`, `f0..f6` slots, `f*_sst.png` URLs, beta metadata, and grid fields.
- Simplify the frontend SST forecast loader so it has one `sst5d` load path and accepts both legacy and current range keys while keeping forecast grids under `state.layers.sst5d`.
- Add a no-dependency site smoke test that validates built/prod assets, manifest JSON, summary JSON, and referenced SST/wind/swell/current PNGs are not missing or being served as the SPA HTML fallback.
- Wire the smoke test into frontend tests, dev checks, and the production refresh/deploy workflow before and after Cloudflare deploy.

## Root cause
The standalone Claude-added `fetch_sst_5day.py` was running after `fetch.py` in `refresh-data.yml` and overwriting the good SST forecast schema with a different one (`range_c`, `d0.png`, `offset`), which caused `tests/dataFeatureContracts.mjs` to fail in the production refresh/deploy workflow before the site could republish fresh data.

## Validation
- `git diff --check` passed locally.
- Local `python` and `npm` are not available in this Windows shell, so Node/Python tests need to run in GitHub Actions on this PR.