### PR TITLE
ops: split fast code-deploy from slow data-refresh

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,86 @@
+name: Deploy production (code-only fast path)
+
+# Fast path for code-only changes. Triggered on every push to main —
+# typically a UI / pipeline / config change that doesn't need a fresh
+# data refresh. Total time: ~2 min (install → build → CF Pages).
+#
+# When this exists alongside refresh-data.yml:
+#   - push to main         → deploy-prod.yml only (this file)
+#   - schedule (daily 06z) → refresh-data.yml (data + build + deploy)
+#   - workflow_dispatch    → either, on demand
+#
+# Architectural rationale:
+# Until 2026-05-08 every push to main triggered the full
+# refresh-data.yml workflow, which runs ~12 upstream HTTP fetches
+# (NOAA / NASA / NOMADS / USGS / etc.) BEFORE the build + deploy step.
+# The data fetches are gated by `continue-on-error: true` but they
+# still consume their full time budget — and a single hung fetch
+# stranded code-only deploys for 25-30 min on the worst day. There's
+# no reason a UI change has to wait for NOAA to respond before going
+# live; the previously-committed PNGs in public/data/ are good enough
+# for the new bundle to read.
+#
+# This workflow is the orthogonal half: "ship the code, leave the
+# data alone." Build reads whatever PNGs were last committed (which
+# refresh-data.yml + refresh-wind.yml are already updating on their
+# own schedules), and pushes a new bundle to Cloudflare Pages.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# A push that arrives mid-deploy supersedes the in-flight one — we
+# only ever want the latest commit live. The old run is cancelled
+# automatically by GitHub.
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # Hard cap on the whole job. Build typically lands in ~90 s; if
+    # we're past 5 min something's wrong (CF Pages hung etc.) and
+    # we'd rather fail fast than strand the deploy.
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install
+        # `npm install` rather than `npm ci` until the lockfile is
+        # regenerated locally. Same drift-tolerance every other web
+        # job in the repo currently uses.
+        run: npm install --no-audit --no-fund
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # --branch=main marks this deploy as production. CF Pages
+          # routes it to shouldidive.com (the production custom domain).
+          command: pages deploy dist --project-name=shouldidive --branch=main --commit-dirty=true
+
+      - name: Annotate run summary
+        run: |
+          {
+            echo "## Code-only deploy"
+            echo
+            echo "Bundle built and pushed to Cloudflare Pages production."
+            echo "Commit: \`${{ github.sha }}\`"
+            echo
+            echo "Data PNGs in \`public/data/\` were NOT refreshed by this workflow —"
+            echo "the daily \`refresh-data.yml\` cron handles that on its own schedule."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-verify.yml
+++ b/.github/workflows/deploy-verify.yml
@@ -24,7 +24,15 @@ on:
     # `types: [completed]` includes both success + failure; we gate
     # explicitly on conclusion below so we don't probe a deploy that
     # didn't actually happen.
-    workflows: ["Refresh ocean data + deploy", "Refresh wind + deploy"]
+    #
+    # The three workflows that produce a production CF Pages deploy:
+    #   - Deploy production (code-only fast path)  — push-to-main
+    #   - Refresh ocean data + deploy              — daily cron + dispatch
+    #   - Refresh wind + deploy                    — wind-only schedule
+    workflows:
+      - "Deploy production (code-only fast path)"
+      - "Refresh ocean data + deploy"
+      - "Refresh wind + deploy"
     types: [completed]
   schedule:
     # Continuous monitoring — every 4 hours, independent of deploys.

--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -3,13 +3,18 @@ name: Refresh ocean data + deploy
 # Pulls fresh SST + chl from NOAA CoastWatch ERDDAP, builds the site,
 # and direct-uploads to Cloudflare Pages via wrangler. Also commits the
 # refreshed data files so the repo + git history stay in sync.
+#
+# 2026-05-08 split: previously this workflow ALSO ran on push to main,
+# which meant every code-only change had to wait through ~12 upstream
+# HTTP fetches before deploying. The new deploy-prod.yml workflow
+# handles push-to-main as a fast code-only deploy (~2 min); this
+# workflow now runs ONLY on schedule + workflow_dispatch, so it does
+# the heavy data work without blocking hotfix deploys.
 
 on:
   schedule:
     # 06:00 UTC daily (~23:00 PT prior day) — after MUR L4 typically publishes.
     - cron: "0 6 * * *"
-  push:
-    branches: [main]
   workflow_dispatch: # manual run from the Actions tab
 
 jobs:

--- a/public/_headers
+++ b/public/_headers
@@ -87,9 +87,12 @@
 /data/*/*.json
   Cache-Control: public, max-age=300, must-revalidate
 
-# ---- Default for anything not matched above ------------------------
-# Conservative: tells the browser "you can cache, but check with us
-# first." Avoids the 4-hour CF default + the indefinite browser
-# default for unknown content.
-/*
-  Cache-Control: public, max-age=0, must-revalidate
+# Catch-all `/*` rule REMOVED 2026-05-08:
+# Cloudflare Pages MERGES every matching `_headers` rule into a
+# single response, so a fallback /* combined with the more specific
+# rules above produced ugly duplicate Cache-Control directives:
+#   `Cache-Control: public, max-age=60, must-revalidate, public, max-age=0, must-revalidate`
+# Browsers handle that fine (RFC 9111 takes the first max-age) but
+# the response headers were unreadable. Letting CF use its built-in
+# default (4 h browser TTL) for any URL not matched above is fine —
+# the explicit rules above cover every path that actually matters.


### PR DESCRIPTION
Fixes the user-facing problem: code-only pushes were waiting through ~12 NOAA/NASA/NOMADS fetches before deploying, ~10-15 min path to ship a CSS tweak.

- **deploy-prod.yml** (NEW): push-to-main fast path. npm install + build + Cloudflare Pages. ~2 min, hard-capped at 5 min total.
- **refresh-data.yml**: removed `push: branches: [main]` trigger. Now schedule + workflow_dispatch only.
- **deploy-verify.yml**: now fires after all three production deploy paths.

Once merged, this PR's own merge will demo the new fast path.