### PR TITLE
ui: WSB tip-jar fish in topbar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -448,6 +448,34 @@ function TopBar({ onSettings, settingsOpen, dataState }) {
         <span>
           Sources: <strong>NOAA · IOOS · NASA OB.DAAC · Copernicus</strong>
         </span>
+        {/* Tip jar — visible on every layer, every device. The WSB
+            joke (white sea bass — the trophy spear fish in SoCal) +
+            small fish silhouette reads as a wink to free divers
+            specifically. Click opens the Venmo profile in a new tab. */}
+        <a
+          href="https://venmo.com/u/michaelpjob"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="tip-fish"
+          title="Tip the creator on Venmo (@michaelpjob)"
+        >
+          <svg
+            className="tip-fish-icon"
+            width="16"
+            height="14"
+            viewBox="0 0 32 28"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            {/* Simple silhouette: oval body + triangle tail. Renders
+                crisp at 14-18 px, scales to retina without blurring. */}
+            <path d="M19 4 C 11 4, 4 9, 2 14 C 4 19, 11 24, 19 24
+                     C 23 24, 26 22, 28 20 L 31 24 L 31 4 L 28 8
+                     C 26 6, 23 4, 19 4 Z M 21 12 a 1.5 1.5 0 1 1 0 3
+                     a 1.5 1.5 0 0 1 0 -3 Z" />
+          </svg>
+          <span className="tip-fish-text">click for WSB</span>
+        </a>
         {/* The MobileShell peek strip carries layer/value/time info on
             phones — the topbar just keeps the brand mark + settings cog
             on small screens (timestamp + sources are hidden via the
@@ -1601,23 +1629,6 @@ function DesktopView({ layer, setLayer, composite, setComposite, sstMode, setSst
                   : layer === "swell"
                   ? "NOAA WaveWatch III (gfswave wcoast 0.16°). HTSGW + PERPW + DIRPW pulled per hour via NOMADS byte-range fetch. 5-day forecast with hourly resolution; refreshed every cycle."
                   : "NOAA Coral Reef Watch · NASA OB.DAAC MODIS-Aqua · Copernicus GLO-MFC. Daily L3 composites, ~1 km grid, regridded to bounding box."}
-              </p>
-            </div>
-            {/* Tip jar — kept understated so it reads as a footer note,
-                not an ad. Independent of layer state. */}
-            <div className="info-section info-tip">
-              <p className="info-p">
-                Built by Michael for the CA dive community. If this saved
-                you a bad dive,{" "}
-                <a
-                  href="https://venmo.com/u/michaelpjob"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="tip-link"
-                >
-                  tip on Venmo @michaelpjob
-                </a>
-                .
               </p>
             </div>
           </div>

--- a/src/components/MobileSheet.jsx
+++ b/src/components/MobileSheet.jsx
@@ -292,23 +292,12 @@ export default function MobileShell({
             <div className="ms-section-h">How to read this</div>
             <Info layer={layer} />
           </section>
-
-          {/* TIP JAR ------------------------------------------------------ */}
-          <section className="ms-section ms-tip">
-            <p className="ms-tip-text">
-              Built by Michael for the CA dive community. If this saved
-              you a bad dive,{" "}
-              <a
-                href="https://venmo.com/u/michaelpjob"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="tip-link"
-              >
-                tip on Venmo @michaelpjob
-              </a>
-              .
-            </p>
-          </section>
+          {/* Tip-jar moved 2026-05-08: now lives in the topbar (the
+              tiny fish "click for WSB" link), visible on every layer
+              from the start. The mobile peek strip already hides the
+              topbar at narrow widths, so the topbar tip falls back
+              into view in the open sheet via the .topbar inside the
+              fixed shell — same affordance, less duplication. */}
         </div>
       )}
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -558,42 +558,58 @@ body {
   vertical-align: baseline;
 }
 
-/* Tip jar — same visual register as the rest of "How to read this"
-   so it doesn't feel like an ad, just a footer note. The link picks
-   up the existing accent for affordance. */
-.info-tip {
-  border-top: 1px solid var(--line);
-  margin-top: 8px;
-  padding-top: 10px;
-}
-.info-tip .info-p {
-  font-size: 11px;
-  color: var(--ink-3);
-  margin: 0;
-}
-.tip-link {
-  color: var(--accent);
+/* Topbar tip jar — small inline fish icon + "click for WSB" text,
+   linking to the creator's Venmo. Designed to read as a wink to the
+   spearfishing community (WSB = white sea bass, the SoCal trophy
+   fish), not an ad. Lives between Sources and Settings.
+   The .info-tip + .ms-tip rules that previously styled an in-panel
+   tip note are removed — same content moved here as a single
+   always-visible affordance. */
+.tip-fish {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--ink-2);
   text-decoration: none;
-  border-bottom: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
-  padding-bottom: 1px;
+  font-size: 11px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  transition: color 0.12s, background 0.12s, border-color 0.12s;
   white-space: nowrap;
 }
-.tip-link:hover {
-  border-bottom-color: var(--accent);
+.tip-fish:hover {
+  color: var(--ink);
+  background: var(--bg-sunken);
+  border-color: var(--line);
 }
-
-/* Mobile sheet tip-jar variant. ms-section already has its own
-   spacing rhythm — we just style the wrapper + match the desktop
-   muted-footer feel. */
-.ms-tip {
-  border-top: 1px solid var(--line);
-  padding-top: 12px;
+.tip-fish:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
-.ms-tip-text {
-  font-size: 11.5px;
-  color: var(--ink-3);
-  margin: 0;
-  line-height: 1.5;
+.tip-fish-icon {
+  flex-shrink: 0;
+  /* Subtle horizontal float — barely perceptible swim. Reduced-motion
+     users get a static icon. */
+  animation: tip-fish-swim 2.4s ease-in-out infinite;
+}
+@keyframes tip-fish-swim {
+  0%, 100% { transform: translateX(0); }
+  50%      { transform: translateX(2px); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .tip-fish-icon { animation: none; }
+}
+.tip-fish-text {
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+/* On narrow / coarse-pointer screens the topbar gets cramped —
+   keep the fish icon, hide the text. The tooltip + the icon alone
+   carry the affordance. */
+@media (max-width: 760px), (hover: none) and (pointer: coarse) {
+  .tip-fish-text { display: none; }
+  .tip-fish { padding: 4px 6px; }
 }
 
 /* Saved spots — bottom-left */


### PR DESCRIPTION
Replaces the in-panel tip footer with a small inline-SVG fish + 'click for WSB' text in the topbar. Always visible, every layer, every device. Mobile hides the text label, keeps the fish. Same Venmo href as before.