### PR TITLE
arch: Tier-1 follow-up — dataSource.js loader split

### DIFF
--- a/src/lib/dataSource.js
+++ b/src/lib/dataSource.js
@@ -2,9 +2,21 @@
 // (lng, lat, window) → value lookups. Returns NaN where the satellite
 // didn't capture data — callers must handle "no data" explicitly. We
 // intentionally do NOT synthesize fake data; correctness over completeness.
+//
+// 2026-05-09: the per-layer load logic that used to live inline in
+// loadManifest() (a 250-line if/else if chain) was carved out into
+// src/lib/loaders/. loadManifest is now a registry dispatch — each
+// new layer = one new file under loaders/, no more giant chain.
 
 import { BBOX } from "./mapData.js";
-import { buildLandMask, loadLandGeoJSON } from "./landMask.js";
+import {
+  LAYER_LOADERS,
+  decodeUVPng,
+  decodeWavePng,
+  computeSpeedKt,
+  bucketKey,
+  hourKey,
+} from "./loaders/index.js";
 
 const state = {
   ready: false,
@@ -13,7 +25,6 @@ const state = {
 };
 
 const subscribers = new Set();
-const currentSampleMasks = new Map();
 
 export function subscribe(cb) {
   subscribers.add(cb);
@@ -28,153 +39,10 @@ export function getDataState() {
   return state;
 }
 
-function loadImage(url) {
-  return new Promise((resolve, reject) => {
-    const img = new Image();
-    img.onload = () => resolve(img);
-    img.onerror = () => reject(new Error(`failed to load ${url}`));
-    img.src = url;
-  });
-}
-
-// Iterative dilation: each pass replaces NaN cells with the mean of
-// their finite 8-neighbours. K passes propagate valid data K cells
-// outward — fills small holes (cloud-shadowed satellite pixels) and
-// smears valid SoCal coverage into the marine-layer gaps that wipe out
-// the viz model otherwise. Mutates the grid in place.
-function fillNearestInPlace(grid, maxIters = 8) {
-  const { data, width, height } = grid;
-  for (let iter = 0; iter < maxIters; iter++) {
-    let changed = 0;
-    const snapshot = new Float32Array(data);
-    for (let y = 0; y < height; y++) {
-      for (let x = 0; x < width; x++) {
-        const i = y * width + x;
-        if (Number.isFinite(snapshot[i])) continue;
-        let sum = 0, n = 0;
-        for (let dy = -1; dy <= 1; dy++) {
-          for (let dx = -1; dx <= 1; dx++) {
-            if (dx === 0 && dy === 0) continue;
-            const nx = x + dx, ny = y + dy;
-            if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
-            const v = snapshot[ny * width + nx];
-            if (Number.isFinite(v)) { sum += v; n++; }
-          }
-        }
-        if (n > 0) { data[i] = sum / n; changed++; }
-      }
-    }
-    if (changed === 0) break;
-  }
-}
-
-async function decodePng(url, scale, range) {
-  const img = await loadImage(url);
-  const c = document.createElement("canvas");
-  c.width = img.naturalWidth;
-  c.height = img.naturalHeight;
-  const ctx = c.getContext("2d", { willReadFrequently: true });
-  ctx.drawImage(img, 0, 0);
-  const id = ctx.getImageData(0, 0, c.width, c.height);
-  const out = new Float32Array(c.width * c.height);
-  const [lo, hi] = range;
-  if (scale === "log10") {
-    const llo = Math.log10(lo);
-    const lhi = Math.log10(hi);
-    for (let i = 0; i < out.length; i++) {
-      const px = id.data[i * 4];
-      out[i] = px === 0 ? NaN : Math.pow(10, llo + ((px - 1) / 254) * (lhi - llo));
-    }
-  } else {
-    for (let i = 0; i < out.length; i++) {
-      const px = id.data[i * 4];
-      out[i] = px === 0 ? NaN : lo + ((px - 1) / 254) * (hi - lo);
-    }
-  }
-  return { data: out, width: c.width, height: c.height };
-}
-
-async function decodeWavePng(url, heightRange, periodRange) {
-  // RGBA: R=Hs (m), G=Tp (s), B=Dp (deg), A=valid.
-  const img = await loadImage(url);
-  const c = document.createElement("canvas");
-  c.width = img.naturalWidth;
-  c.height = img.naturalHeight;
-  const ctx = c.getContext("2d", { willReadFrequently: true });
-  ctx.drawImage(img, 0, 0);
-  const id = ctx.getImageData(0, 0, c.width, c.height);
-  const N = c.width * c.height;
-  const hs = new Float32Array(N);
-  const tp = new Float32Array(N);
-  const dp = new Float32Array(N);
-  const speed = new Float32Array(N); // alias for `data` so DataOverlay's
-                                     // generic getLayerGrid path still works.
-  const [hLo, hHi] = heightRange;
-  const [pLo, pHi] = periodRange;
-  for (let i = 0; i < N; i++) {
-    const a = id.data[i * 4 + 3];
-    if (a === 0) {
-      hs[i] = NaN; tp[i] = NaN; dp[i] = NaN; speed[i] = NaN;
-    } else {
-      hs[i] = hLo + (id.data[i * 4]     / 255) * (hHi - hLo);
-      tp[i] = pLo + (id.data[i * 4 + 1] / 255) * (pHi - pLo);
-      dp[i] = (id.data[i * 4 + 2] / 255) * 360.0;
-      speed[i] = hs[i]; // Hs in metres drives the heatmap layer.
-    }
-  }
-  return {
-    hs, tp, dp,
-    width: c.width, height: c.height,
-    data: speed, // .data is what bilinear() / getLayerGrid() reads
-  };
-}
-
-async function decodeUVPng(url, uvRange) {
-  const img = await loadImage(url);
-  const c = document.createElement("canvas");
-  c.width = img.naturalWidth;
-  c.height = img.naturalHeight;
-  const ctx = c.getContext("2d", { willReadFrequently: true });
-  ctx.drawImage(img, 0, 0);
-  const id = ctx.getImageData(0, 0, c.width, c.height);
-  const u = new Float32Array(c.width * c.height);
-  const v = new Float32Array(c.width * c.height);
-  const [lo, hi] = uvRange;
-  const span = hi - lo;
-  for (let i = 0; i < u.length; i++) {
-    const a = id.data[i * 4 + 3];
-    if (a === 0) {
-      u[i] = NaN;
-      v[i] = NaN;
-    } else {
-      u[i] = lo + (id.data[i * 4] / 255) * span;
-      v[i] = lo + (id.data[i * 4 + 1] / 255) * span;
-    }
-  }
-  return { u, v, width: c.width, height: c.height };
-}
-
-async function currentSampleMask(width, height) {
-  const key = `${width}x${height}`;
-  if (currentSampleMasks.has(key)) return currentSampleMasks.get(key);
-  const maskPromise = loadLandGeoJSON().then((fc) => buildLandMask(fc?.features, width, height));
-  currentSampleMasks.set(key, maskPromise);
-  return maskPromise;
-}
-
-function landMaskedCurrentSample(uv, mask) {
-  const u = new Float32Array(uv.u);
-  const v = new Float32Array(uv.v);
-  if (mask) {
-    for (let i = 0; i < mask.length; i++) {
-      if (mask[i] === 1) {
-        u[i] = NaN;
-        v[i] = NaN;
-      }
-    }
-  }
-  return { u, v, width: uv.width, height: uv.height };
-}
+// Re-export bucketKey / hourKey for the timeline components
+// (CurrentTimeline.jsx, WindDayGrid.jsx) that still import them from
+// here. Keeps the public API stable across the loader-split refactor.
+export { bucketKey, hourKey };
 
 export async function loadManifest() {
   try {
@@ -188,258 +56,20 @@ export async function loadManifest() {
     const manifest = await res.json();
     state.manifest = manifest;
     for (const [layer, info] of Object.entries(manifest.layers || {})) {
+      // The init line: for every layer EXCEPT sst, zero out any
+      // existing slot map. For sst, preserve it so the sst7d/sst5d
+      // loaders (which write into state.layers.sst[<slot>]) can
+      // accumulate even when sst's own iteration runs first.
       state.layers[layer] = layer === "sst" ? (state.layers.sst || {}) : {};
-      if (layer === "sst7d") {
-        try {
-          const sres = await fetch(info.summary_url, { cache: "no-cache" });
-          if (!sres.ok) throw new Error(`sst summary ${info.summary_url} ${sres.status}`);
-          const summary = await sres.json();
-          state.layers.sst7d = { summary };
-          state.layers.sst = state.layers.sst || {};
-          const scale = info.scale || summary.scale || "linear";
-          const range = info.range || summary.range;
-          if (!range) throw new Error("sst7d has no range");
-          const tasks = [];
-          for (const d of summary.days || []) {
-            if (!d?.slot || !d?.url) continue;
-            tasks.push(
-              decodePng(d.url, scale, range)
-                .then((decoded) => {
-                  state.layers.sst[d.slot] = {
-                    ...decoded,
-                    dates: d.date ? [d.date] : [],
-                    history: true,
-                    stats: d,
-                  };
-                })
-                .catch((e) => console.warn(`sst7d ${d.slot} failed`, e))
-            );
-          }
-          await Promise.all(tasks);
-        } catch (e) {
-          console.warn("dataSource: sst7d summary load failed", e);
-        }
-      } else if (layer === "sst5d") {
-        try {
-          const sres = await fetch(info.summary_url, { cache: "no-cache" });
-          if (!sres.ok) throw new Error(`sst forecast summary ${info.summary_url} ${sres.status}`);
-          const summary = await sres.json();
-          state.layers.sst5d = { summary };
-          state.layers.sst = state.layers.sst || {};
-          const scale = info.scale || summary.scale || "linear";
-          const range = info.range || summary.range;
-          if (!range) throw new Error("sst5d has no range");
-          const tasks = [];
-          for (const d of summary.days || []) {
-            if (!d?.slot || !d?.url) continue;
-            tasks.push(
-              decodePng(d.url, scale, range)
-                .then((decoded) => {
-                  state.layers.sst[d.slot] = {
-                    ...decoded,
-                    dates: d.date ? [d.date] : [],
-                    forecast: true,
-                    stats: d,
-                  };
-                })
-                .catch((e) => console.warn(`sst5d ${d.slot} failed`, e))
-            );
-          }
-          await Promise.all(tasks);
-        } catch (e) {
-          console.warn("dataSource: sst5d summary load failed", e);
-        }
-      } else if (layer === "swell5d") {
-        // 5-day × 5-bucket swell forecast (gfswave). Load summary.json
-        // first; bucket + hourly wave PNGs (RGBA Hs/Tp/Dp) load in
-        // parallel with per-task error-tolerance.
-        try {
-          const sres = await fetch(info.summary_url, { cache: "no-cache" });
-          if (!sres.ok) throw new Error(`swell summary ${info.summary_url} ${sres.status}`);
-          const summary = await sres.json();
-          state.layers.swell5d = {
-            summary,
-            heightRange: info.height_range_m,
-            periodRange: info.period_range_s,
-            buckets:     {},
-            hourly:      {},
-            hourlyLoading: {},
-          };
-          const tasks = [];
-          for (const day of summary.days) {
-            for (const b of day.buckets) {
-              const key = bucketKey(day.day, b.bucket);
-              tasks.push(
-                decodeWavePng(b.wave_url, info.height_range_m, info.period_range_s)
-                  .then((wv) => {
-                    state.layers.swell5d.buckets[key] = wv;
-                  })
-                  .catch((e) => console.warn(`swell5d bucket ${key} failed`, e))
-              );
-            }
-          }
-          await Promise.all(tasks);
-        } catch (e) {
-          console.warn("dataSource: swell5d summary load failed", e);
-        }
-      } else if (layer === "wind5d") {
-        // 5-day × 5-bucket forecast (new wind UI). Pull summary.json first
-        // — keep the summary even if individual bucket PNGs fail to decode
-        // so the day grid still renders with whatever data we have.
-        try {
-          const sres = await fetch(info.summary_url, { cache: "no-cache" });
-          if (!sres.ok) throw new Error(`summary ${info.summary_url} ${sres.status}`);
-          const summary = await sres.json();
-          state.layers.wind5d = {
-            summary,
-            uvRange:    info.uv_range,
-            speedRange: info.speed_range,
-            buckets:    {},
-            hourly:     {},
-            hourlyLoading: {},
-          };
-          // Load every bucket UV in parallel. CRUCIAL: each task swallows
-          // its own error so one bad PNG can't take down the whole forecast.
-          const tasks = [];
-          let failed = 0;
-          let loaded = 0;
-          for (const day of summary.days) {
-            for (const b of day.buckets) {
-              const key = bucketKey(day.day, b.bucket);
-              tasks.push(
-                decodeUVPng(b.uv_url, info.uv_range)
-                  .then((uv) => {
-                    const speed = computeSpeedKt(uv);
-                    state.layers.wind5d.buckets[key] = {
-                      uvU: uv.u, uvV: uv.v,
-                      width: uv.width, height: uv.height,
-                      data: speed, speedKt: speed,
-                    };
-                    loaded++;
-                  })
-                  .catch((e) => {
-                    failed++;
-                    console.warn(`wind5d bucket ${key} failed`, e);
-                  })
-              );
-            }
-          }
-          await Promise.all(tasks);
-          if (failed) {
-            console.warn(`wind5d: ${loaded} buckets loaded, ${failed} failed`);
-          }
-        } catch (e) {
-          console.warn("dataSource: wind5d summary load failed", e);
-          // Don't null out — leave whatever summary did parse so the UI
-          // can show the day labels even if the heatmap is missing.
-        }
-      } else if (layer === "current5d") {
-        try {
-          const sres = await fetch(info.summary_url, { cache: "no-cache" });
-          if (!sres.ok) throw new Error(`currents summary ${info.summary_url} ${sres.status}`);
-          const summary = await sres.json();
-          state.layers.current5d = {
-            summary,
-            uvRange: info.uv_range,
-            speedRange: info.speed_range,
-            buckets: {},
-          };
-          const tasks = [];
-          let failed = 0;
-          let loaded = 0;
-          for (const day of summary.days || []) {
-            for (const b of day.buckets || []) {
-              const key = bucketKey(day.day, b.bucket);
-              tasks.push(
-                decodeUVPng(b.uv_url, info.uv_range)
-                  .then((uv) => {
-                    const maskPromise = currentSampleMask(uv.width, uv.height);
-                    return maskPromise.then((landMask) => ({ uv, landMask }));
-                  })
-                  .then(({ uv, landMask }) => {
-                    const speed = computeSpeedKt(uv);
-                    const sample = landMaskedCurrentSample(uv, landMask);
-                    const sampleSpeed = computeSpeedKt(sample);
-                    state.layers.current5d.buckets[key] = {
-                      uvU: sample.u, uvV: sample.v,
-                      visualUvU: uv.u, visualUvV: uv.v,
-                      width: uv.width, height: uv.height,
-                      data: speed, speedKt: speed,
-                      sampleData: sampleSpeed, sampleSpeedKt: sampleSpeed,
-                    };
-                    loaded++;
-                  })
-                  .catch((e) => {
-                    failed++;
-                    console.warn(`current5d bucket ${key} failed`, e);
-                  })
-              );
-            }
-          }
-          await Promise.all(tasks);
-          if (failed) {
-            console.warn(`current5d: ${loaded} buckets loaded, ${failed} failed`);
-          }
-        } catch (e) {
-          console.warn("dataSource: current5d summary load failed", e);
-        }
-      } else if (layer === "wind") {
-        const speedRange = info.speed_range;
-        const uvRange = info.uv_range;
-        for (const [slot, w] of Object.entries(info.windows || {})) {
-          const speed = await decodePng(w.speed_url, "linear", speedRange);
-          const uv = await decodeUVPng(w.uv_url, uvRange);
-          state.layers.wind[slot] = {
-            ...speed,           // .data, .width, .height for speed
-            uvU: uv.u,
-            uvV: uv.v,
-            valid_at: w.valid_at,
-            fcst_hour: w.fcst_hour,
-            source: w.source || null,  // "HRRR" / "GFS" — for the legend
-          };
-        }
-      } else if (layer === "viz") {
-        const range = info.range_ft;
-        for (const [slot, w] of Object.entries(info.windows || {})) {
-          const decoded = await decodePng(w.url, "linear", range);
-          // SoCal coverage is patchy: chl-a satellite passes get nuked
-          // by the marine layer over Catalina/SD/Coronados most cycles,
-          // and the viz model returns NaN wherever any input is missing.
-          // Smear valid neighbours into NaN cells (BFS-style up to 30
-          // iterations) so the user actually sees a colored map instead
-          // of a hatched bight. 8 iterations was leaving La Jolla and
-          // San Diego still NaN on heavy-marine-layer days; 30 reaches
-          // convergence on every cycle we've seen so far. LandBasemap
-          // paints over the land cells filled by the same pass, so
-          // coastline accuracy is unaffected.
-          fillNearestInPlace(decoded, 30);
-          state.layers.viz[slot] = { ...decoded, valid_at: w.valid_at };
-        }
-      } else if (layer === "sst" || layer === "chl") {
-        // Only the layers the frontend actually renders go through the
-        // generic decoder. wave + precip live in the manifest as inputs
-        // to the visibility pipeline (server-side); the frontend has no
-        // wave/precip overlays to paint, so trying to decode them would
-        // just throw on the missing `range` field and take down the
-        // entire loader's outer try/catch — which is exactly the bug
-        // that nuked every layer including wind5d.
-        const scale = info.scale || "linear";
-        const range = info.range;
-        if (!range) {
-          console.warn(`dataSource: ${layer} has no range, skipping`);
-        } else {
-          for (const [win, w] of Object.entries(info.windows || {})) {
-            try {
-              const decoded = await decodePng(w.url, scale, range);
-              state.layers[layer][win] = { ...decoded, dates: w.dates || [] };
-            } catch (e) {
-              console.warn(`dataSource: ${layer}/${win} decode failed`, e);
-            }
-          }
-        }
+
+      const loader = LAYER_LOADERS[layer];
+      if (loader) {
+        await loader(info, state);
       }
-      // Anything else (wave, precip, future server-only inputs) is ignored
-      // by the frontend on purpose.
+      // Layers absent from LAYER_LOADERS (wave, precip, kd490 today)
+      // are silently skipped — they're pipeline inputs the frontend
+      // doesn't render. Adding one in the future = drop a new file
+      // in src/lib/loaders/ and register it in loaders/index.js.
     }
   } catch (e) {
     console.warn("dataSource: manifest load failed, using mock data", e);
@@ -526,28 +156,11 @@ function slotKey(layer, composite) {
   return COMPOSITE_KEY[composite] || "1d";
 }
 
-// Bucket / hour slot key conventions used across the wind5d state.
-export function bucketKey(day, bucket) {
-  return `d${day}_${bucket}`;
-}
-export function hourKey(day, hour) {
-  return `d${day}_h${String(hour).padStart(2, "0")}`;
-}
-
-// Speed (kt) array derived from u/v components. Keeps DataOverlay rendering
-// the same kind of scalar grid the legacy wind layer used.
-function computeSpeedKt({ u, v, width, height }) {
-  const out = new Float32Array(width * height);
-  for (let i = 0; i < out.length; i++) {
-    const uu = u[i], vv = v[i];
-    if (Number.isFinite(uu) && Number.isFinite(vv)) {
-      out[i] = Math.sqrt(uu * uu + vv * vv) * 1.94384;  // m/s → kt
-    } else {
-      out[i] = NaN;
-    }
-  }
-  return out;
-}
+// Bucket / hour slot key conventions live in src/lib/loaders/decoders.js.
+// They're re-exported at the top of this file (`export { bucketKey,
+// hourKey }`) so existing call sites
+// (CurrentTimeline.jsx, WindDayGrid.jsx, etc.) keep importing them
+// from "./dataSource.js" without churn.
 
 export function getSST(lng, lat, composite = 1) {
   // Returns °C, or NaN if the satellite didn't capture this cell.

--- a/src/lib/loaders/current5d.js
+++ b/src/lib/loaders/current5d.js
@@ -1,0 +1,68 @@
+// 5-day × 5-bucket surface-current forecast loader. Decodes the
+// uv_url for each bucket, then applies the cached land-mask to drop
+// land-cell samples (HFR + the inland-extension blend can paint into
+// land otherwise — visually fine for the streamlines, wrong for the
+// scalar speed sample under the cursor).
+//
+// Carved out of dataSource.js loadManifest's if/else if chain on
+// 2026-05-09 (Tier-1 follow-up).
+
+import {
+  decodeUVPng,
+  computeSpeedKt,
+  bucketKey,
+  currentSampleMask,
+  landMaskedCurrentSample,
+} from "./decoders.js";
+
+export async function loadCurrent5d(info, state) {
+  try {
+    const sres = await fetch(info.summary_url, { cache: "no-cache" });
+    if (!sres.ok) throw new Error(`currents summary ${info.summary_url} ${sres.status}`);
+    const summary = await sres.json();
+    state.layers.current5d = {
+      summary,
+      uvRange: info.uv_range,
+      speedRange: info.speed_range,
+      buckets: {},
+    };
+    const tasks = [];
+    let failed = 0;
+    let loaded = 0;
+    for (const day of summary.days || []) {
+      for (const b of day.buckets || []) {
+        const key = bucketKey(day.day, b.bucket);
+        tasks.push(
+          decodeUVPng(b.uv_url, info.uv_range)
+            .then((uv) => {
+              const maskPromise = currentSampleMask(uv.width, uv.height);
+              return maskPromise.then((landMask) => ({ uv, landMask }));
+            })
+            .then(({ uv, landMask }) => {
+              const speed = computeSpeedKt(uv);
+              const sample = landMaskedCurrentSample(uv, landMask);
+              const sampleSpeed = computeSpeedKt(sample);
+              state.layers.current5d.buckets[key] = {
+                uvU: sample.u, uvV: sample.v,
+                visualUvU: uv.u, visualUvV: uv.v,
+                width: uv.width, height: uv.height,
+                data: speed, speedKt: speed,
+                sampleData: sampleSpeed, sampleSpeedKt: sampleSpeed,
+              };
+              loaded++;
+            })
+            .catch((e) => {
+              failed++;
+              console.warn(`current5d bucket ${key} failed`, e);
+            })
+        );
+      }
+    }
+    await Promise.all(tasks);
+    if (failed) {
+      console.warn(`current5d: ${loaded} buckets loaded, ${failed} failed`);
+    }
+  } catch (e) {
+    console.warn("dataSource: current5d summary load failed", e);
+  }
+}

--- a/src/lib/loaders/decoders.js
+++ b/src/lib/loaders/decoders.js
@@ -1,0 +1,197 @@
+// Shared decode + bucketing helpers extracted from dataSource.js as
+// part of the 2026-05-09 Tier-1 follow-up (per-layer loader split).
+//
+// Why this lives in its own file:
+//   * Each per-layer loader under src/lib/loaders/ needs a subset of
+//     these helpers. Keeping them in dataSource.js + importing them
+//     into each loader would create a circular dependency
+//     (dataSource.js → loaders/sst7d.js → dataSource.js).
+//   * The remaining hourly-PNG fetchers in dataSource.js (loadSwell5dHourly,
+//     loadWind5dHourly) also need decodeUVPng / decodeWavePng. They
+//     import from here too — same module, no cycle.
+//   * `bucketKey` / `hourKey` are imported by CurrentTimeline.jsx +
+//     WindDayGrid.jsx. dataSource.js re-exports them for backward
+//     compatibility so the timeline components don't have to change.
+
+import { buildLandMask, loadLandGeoJSON } from "../landMask.js";
+
+const currentSampleMasks = new Map();
+
+function loadImage(url) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error(`failed to load ${url}`));
+    img.src = url;
+  });
+}
+
+// Iterative dilation: each pass replaces NaN cells with the mean of
+// their finite 8-neighbours. K passes propagate valid data K cells
+// outward — fills small holes (cloud-shadowed satellite pixels) and
+// smears valid SoCal coverage into the marine-layer gaps that wipe out
+// the viz model otherwise. Mutates the grid in place.
+export function fillNearestInPlace(grid, maxIters = 8) {
+  const { data, width, height } = grid;
+  for (let iter = 0; iter < maxIters; iter++) {
+    let changed = 0;
+    const snapshot = new Float32Array(data);
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const i = y * width + x;
+        if (Number.isFinite(snapshot[i])) continue;
+        let sum = 0, n = 0;
+        for (let dy = -1; dy <= 1; dy++) {
+          for (let dx = -1; dx <= 1; dx++) {
+            if (dx === 0 && dy === 0) continue;
+            const nx = x + dx, ny = y + dy;
+            if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
+            const v = snapshot[ny * width + nx];
+            if (Number.isFinite(v)) { sum += v; n++; }
+          }
+        }
+        if (n > 0) { data[i] = sum / n; changed++; }
+      }
+    }
+    if (changed === 0) break;
+  }
+}
+
+export async function decodePng(url, scale, range) {
+  const img = await loadImage(url);
+  const c = document.createElement("canvas");
+  c.width = img.naturalWidth;
+  c.height = img.naturalHeight;
+  const ctx = c.getContext("2d", { willReadFrequently: true });
+  ctx.drawImage(img, 0, 0);
+  const id = ctx.getImageData(0, 0, c.width, c.height);
+  const out = new Float32Array(c.width * c.height);
+  const [lo, hi] = range;
+  if (scale === "log10") {
+    const llo = Math.log10(lo);
+    const lhi = Math.log10(hi);
+    for (let i = 0; i < out.length; i++) {
+      const px = id.data[i * 4];
+      out[i] = px === 0 ? NaN : Math.pow(10, llo + ((px - 1) / 254) * (lhi - llo));
+    }
+  } else {
+    for (let i = 0; i < out.length; i++) {
+      const px = id.data[i * 4];
+      out[i] = px === 0 ? NaN : lo + ((px - 1) / 254) * (hi - lo);
+    }
+  }
+  return { data: out, width: c.width, height: c.height };
+}
+
+export async function decodeWavePng(url, heightRange, periodRange) {
+  // RGBA: R=Hs (m), G=Tp (s), B=Dp (deg), A=valid.
+  const img = await loadImage(url);
+  const c = document.createElement("canvas");
+  c.width = img.naturalWidth;
+  c.height = img.naturalHeight;
+  const ctx = c.getContext("2d", { willReadFrequently: true });
+  ctx.drawImage(img, 0, 0);
+  const id = ctx.getImageData(0, 0, c.width, c.height);
+  const N = c.width * c.height;
+  const hs = new Float32Array(N);
+  const tp = new Float32Array(N);
+  const dp = new Float32Array(N);
+  const speed = new Float32Array(N); // alias for `data` so DataOverlay's
+                                     // generic getLayerGrid path still works.
+  const [hLo, hHi] = heightRange;
+  const [pLo, pHi] = periodRange;
+  for (let i = 0; i < N; i++) {
+    const a = id.data[i * 4 + 3];
+    if (a === 0) {
+      hs[i] = NaN; tp[i] = NaN; dp[i] = NaN; speed[i] = NaN;
+    } else {
+      hs[i] = hLo + (id.data[i * 4]     / 255) * (hHi - hLo);
+      tp[i] = pLo + (id.data[i * 4 + 1] / 255) * (pHi - pLo);
+      dp[i] = (id.data[i * 4 + 2] / 255) * 360.0;
+      speed[i] = hs[i]; // Hs in metres drives the heatmap layer.
+    }
+  }
+  return {
+    hs, tp, dp,
+    width: c.width, height: c.height,
+    data: speed, // .data is what bilinear() / getLayerGrid() reads
+  };
+}
+
+export async function decodeUVPng(url, uvRange) {
+  const img = await loadImage(url);
+  const c = document.createElement("canvas");
+  c.width = img.naturalWidth;
+  c.height = img.naturalHeight;
+  const ctx = c.getContext("2d", { willReadFrequently: true });
+  ctx.drawImage(img, 0, 0);
+  const id = ctx.getImageData(0, 0, c.width, c.height);
+  const u = new Float32Array(c.width * c.height);
+  const v = new Float32Array(c.width * c.height);
+  const [lo, hi] = uvRange;
+  const span = hi - lo;
+  for (let i = 0; i < u.length; i++) {
+    const a = id.data[i * 4 + 3];
+    if (a === 0) {
+      u[i] = NaN;
+      v[i] = NaN;
+    } else {
+      u[i] = lo + (id.data[i * 4] / 255) * span;
+      v[i] = lo + (id.data[i * 4 + 1] / 255) * span;
+    }
+  }
+  return { u, v, width: c.width, height: c.height };
+}
+
+export async function currentSampleMask(width, height) {
+  const key = `${width}x${height}`;
+  if (currentSampleMasks.has(key)) return currentSampleMasks.get(key);
+  const maskPromise = loadLandGeoJSON().then((fc) => buildLandMask(fc?.features, width, height));
+  currentSampleMasks.set(key, maskPromise);
+  return maskPromise;
+}
+
+export function landMaskedCurrentSample(uv, mask) {
+  const u = new Float32Array(uv.u);
+  const v = new Float32Array(uv.v);
+  if (mask) {
+    for (let i = 0; i < mask.length; i++) {
+      if (mask[i] === 1) {
+        u[i] = NaN;
+        v[i] = NaN;
+      }
+    }
+  }
+  return { u, v, width: uv.width, height: uv.height };
+}
+
+// Speed (kt) array derived from u/v components. Keeps DataOverlay rendering
+// the same kind of scalar grid the legacy wind layer used.
+export function computeSpeedKt({ u, v, width, height }) {
+  const out = new Float32Array(width * height);
+  for (let i = 0; i < out.length; i++) {
+    const uu = u[i], vv = v[i];
+    if (Number.isFinite(uu) && Number.isFinite(vv)) {
+      out[i] = Math.sqrt(uu * uu + vv * vv) * 1.94384;  // m/s → kt
+    } else {
+      out[i] = NaN;
+    }
+  }
+  return out;
+}
+
+// Bucket key helpers — used by both the manifest loaders and the lazy
+// hourly fetchers. Tested at runtime by the bucket-aware timeline
+// components (CurrentTimeline.jsx, WindDayGrid.jsx) which import these
+// from dataSource.js (which re-exports from here).
+//
+// Format MUST match what fetch_swell_5day.py / fetch_wind_5day.py
+// emit in summary.json: `d{N}_{bucket}` and `d{N}_h{HH}`. A drift
+// here silently produces empty bucket lookups in the timeline UI.
+export function bucketKey(day, bucket) {
+  return `d${day}_${bucket}`;
+}
+
+export function hourKey(day, hour) {
+  return `d${day}_h${String(hour).padStart(2, "0")}`;
+}

--- a/src/lib/loaders/index.js
+++ b/src/lib/loaders/index.js
@@ -1,0 +1,59 @@
+// Per-layer loader registry. Replaces the giant if/else if chain that
+// used to live inside dataSource.js loadManifest.
+//
+// Adding a new layer in the future is now a 2-step diff:
+//   1. Create `src/lib/loaders/<layerName>.js` exporting
+//      `export async function load<LayerName>(info, state)`.
+//   2. Register it below.
+//
+// No more 50-line copy-paste of "fetch summary, decode PNGs, write
+// state.layers[name]". No more risk of duplicate `else if` branches
+// (which is the exact failure mode that ESLint's `no-dupe-else-if`
+// rule had to be load-bearing for after the 2026-05-07 incident).
+//
+// Layers absent from this map are silently skipped. wave + precip
+// fall in that bucket on purpose — they're pipeline inputs, not
+// frontend-rendered layers.
+
+import { loadSst7d } from "./sst7d.js";
+import { loadSst5d } from "./sst5d.js";
+import { loadSwell5d } from "./swell5d.js";
+import { loadWind5d } from "./wind5d.js";
+import { loadCurrent5d } from "./current5d.js";
+import { loadWind } from "./wind.js";
+import { loadViz } from "./viz.js";
+import { loadScalarPng } from "./scalarPng.js";
+
+// Each entry: layer name → (info, state) => Promise<void>.
+// scalarPng layers route through a single helper that takes the
+// layer name as the first arg, since they share identical logic.
+export const LAYER_LOADERS = {
+  sst7d:    (info, state) => loadSst7d(info, state),
+  sst5d:    (info, state) => loadSst5d(info, state),
+  swell5d:  (info, state) => loadSwell5d(info, state),
+  wind5d:   (info, state) => loadWind5d(info, state),
+  current5d:(info, state) => loadCurrent5d(info, state),
+  wind:     (info, state) => loadWind(info, state),
+  viz:      (info, state) => loadViz(info, state),
+  sst:      (info, state) => loadScalarPng("sst", info, state),
+  chl:      (info, state) => loadScalarPng("chl", info, state),
+  // kd490 has the same shape as chl. Wire it in once the frontend
+  // actually renders a kd490 overlay (today it's manifest-only).
+  // kd490: (info, state) => loadScalarPng("kd490", info, state),
+};
+
+// Re-export the helpers so callers that need them outside loadManifest
+// (loadSwell5dHourly, loadWind5dHourly inside dataSource.js, plus
+// CurrentTimeline / WindDayGrid via dataSource.js's re-export chain)
+// can import from one place.
+export {
+  decodePng,
+  decodeUVPng,
+  decodeWavePng,
+  fillNearestInPlace,
+  computeSpeedKt,
+  currentSampleMask,
+  landMaskedCurrentSample,
+  bucketKey,
+  hourKey,
+} from "./decoders.js";

--- a/src/lib/loaders/scalarPng.js
+++ b/src/lib/loaders/scalarPng.js
@@ -1,0 +1,34 @@
+// Generic scalar-PNG loader for layers that ship a plain `range` +
+// `scale` + `windows` map. Used by sst (legacy 1d/2d/3d composites)
+// and chl + kd490.
+//
+// Wave + precip live in the manifest as inputs to the visibility
+// pipeline (server-side); the frontend has no wave/precip overlays
+// to paint, so they are NOT in the loader registry — they get
+// silently skipped. (Trying to decode them would just throw on the
+// missing `range` field and take down the entire loader's outer
+// try/catch — exactly the bug that nuked every layer including
+// wind5d before the per-layer guards landed.)
+//
+// Carved out of dataSource.js loadManifest's if/else if chain on
+// 2026-05-09 (Tier-1 follow-up).
+
+import { decodePng } from "./decoders.js";
+
+export async function loadScalarPng(layer, info, state) {
+  state.layers[layer] = state.layers[layer] || {};
+  const scale = info.scale || "linear";
+  const range = info.range;
+  if (!range) {
+    console.warn(`dataSource: ${layer} has no range, skipping`);
+    return;
+  }
+  for (const [win, w] of Object.entries(info.windows || {})) {
+    try {
+      const decoded = await decodePng(w.url, scale, range);
+      state.layers[layer][win] = { ...decoded, dates: w.dates || [] };
+    } catch (e) {
+      console.warn(`dataSource: ${layer}/${win} decode failed`, e);
+    }
+  }
+}

--- a/src/lib/loaders/sst5d.js
+++ b/src/lib/loaders/sst5d.js
@@ -1,0 +1,41 @@
+// SST 5-day forecast loader. Same pattern as sst7d: fetch summary,
+// decode per-day PNGs in parallel, write into state.layers.sst[<slot>]
+// keyed by forecast slot (f0..f4) with history:false / forecast:true
+// to differentiate from history slots.
+//
+// Carved out of dataSource.js loadManifest's if/else if chain on
+// 2026-05-09 (Tier-1 follow-up).
+
+import { decodePng } from "./decoders.js";
+
+export async function loadSst5d(info, state) {
+  try {
+    const sres = await fetch(info.summary_url, { cache: "no-cache" });
+    if (!sres.ok) throw new Error(`sst forecast summary ${info.summary_url} ${sres.status}`);
+    const summary = await sres.json();
+    state.layers.sst5d = { summary };
+    state.layers.sst = state.layers.sst || {};
+    const scale = info.scale || summary.scale || "linear";
+    const range = info.range || summary.range;
+    if (!range) throw new Error("sst5d has no range");
+    const tasks = [];
+    for (const d of summary.days || []) {
+      if (!d?.slot || !d?.url) continue;
+      tasks.push(
+        decodePng(d.url, scale, range)
+          .then((decoded) => {
+            state.layers.sst[d.slot] = {
+              ...decoded,
+              dates: d.date ? [d.date] : [],
+              forecast: true,
+              stats: d,
+            };
+          })
+          .catch((e) => console.warn(`sst5d ${d.slot} failed`, e))
+      );
+    }
+    await Promise.all(tasks);
+  } catch (e) {
+    console.warn("dataSource: sst5d summary load failed", e);
+  }
+}

--- a/src/lib/loaders/sst7d.js
+++ b/src/lib/loaders/sst7d.js
@@ -1,0 +1,41 @@
+// SST 7-day history loader. Fetches summary.json then decodes each
+// daily PNG in parallel, writing into state.layers.sst[<slot>] keyed
+// by slot name (d0, d1, ..., d6).
+//
+// Carved out of dataSource.js loadManifest's if/else if chain on
+// 2026-05-09 (Tier-1 follow-up). Behaviour is byte-for-byte equivalent
+// to the original branch.
+
+import { decodePng } from "./decoders.js";
+
+export async function loadSst7d(info, state) {
+  try {
+    const sres = await fetch(info.summary_url, { cache: "no-cache" });
+    if (!sres.ok) throw new Error(`sst summary ${info.summary_url} ${sres.status}`);
+    const summary = await sres.json();
+    state.layers.sst7d = { summary };
+    state.layers.sst = state.layers.sst || {};
+    const scale = info.scale || summary.scale || "linear";
+    const range = info.range || summary.range;
+    if (!range) throw new Error("sst7d has no range");
+    const tasks = [];
+    for (const d of summary.days || []) {
+      if (!d?.slot || !d?.url) continue;
+      tasks.push(
+        decodePng(d.url, scale, range)
+          .then((decoded) => {
+            state.layers.sst[d.slot] = {
+              ...decoded,
+              dates: d.date ? [d.date] : [],
+              history: true,
+              stats: d,
+            };
+          })
+          .catch((e) => console.warn(`sst7d ${d.slot} failed`, e))
+      );
+    }
+    await Promise.all(tasks);
+  } catch (e) {
+    console.warn("dataSource: sst7d summary load failed", e);
+  }
+}

--- a/src/lib/loaders/swell5d.js
+++ b/src/lib/loaders/swell5d.js
@@ -1,0 +1,40 @@
+// 5-day × 5-bucket swell forecast (gfswave). Loads summary.json first;
+// bucket + hourly wave PNGs (RGBA Hs/Tp/Dp) load in parallel with
+// per-task error tolerance.
+//
+// Carved out of dataSource.js loadManifest's if/else if chain on
+// 2026-05-09 (Tier-1 follow-up).
+
+import { decodeWavePng, bucketKey } from "./decoders.js";
+
+export async function loadSwell5d(info, state) {
+  try {
+    const sres = await fetch(info.summary_url, { cache: "no-cache" });
+    if (!sres.ok) throw new Error(`swell summary ${info.summary_url} ${sres.status}`);
+    const summary = await sres.json();
+    state.layers.swell5d = {
+      summary,
+      heightRange: info.height_range_m,
+      periodRange: info.period_range_s,
+      buckets:     {},
+      hourly:      {},
+      hourlyLoading: {},
+    };
+    const tasks = [];
+    for (const day of summary.days) {
+      for (const b of day.buckets) {
+        const key = bucketKey(day.day, b.bucket);
+        tasks.push(
+          decodeWavePng(b.wave_url, info.height_range_m, info.period_range_s)
+            .then((wv) => {
+              state.layers.swell5d.buckets[key] = wv;
+            })
+            .catch((e) => console.warn(`swell5d bucket ${key} failed`, e))
+        );
+      }
+    }
+    await Promise.all(tasks);
+  } catch (e) {
+    console.warn("dataSource: swell5d summary load failed", e);
+  }
+}

--- a/src/lib/loaders/viz.js
+++ b/src/lib/loaders/viz.js
@@ -1,0 +1,24 @@
+// Predicted-visibility loader. The viz layer ships range_ft instead of
+// a generic range field, and runs fillNearestInPlace at 30 iterations
+// (much higher than the default 8) because SoCal coverage is patchy:
+// chl-a satellite passes get nuked by the marine layer over Catalina /
+// SD / Coronados most cycles, and the viz model returns NaN wherever
+// any input is missing. Smearing valid neighbours into NaN cells gets
+// the user a colored map instead of a hatched bight. LandBasemap
+// paints over the land cells filled by the same pass, so coastline
+// accuracy is unaffected.
+//
+// Carved out of dataSource.js loadManifest's if/else if chain on
+// 2026-05-09 (Tier-1 follow-up).
+
+import { decodePng, fillNearestInPlace } from "./decoders.js";
+
+export async function loadViz(info, state) {
+  state.layers.viz = state.layers.viz || {};
+  const range = info.range_ft;
+  for (const [slot, w] of Object.entries(info.windows || {})) {
+    const decoded = await decodePng(w.url, "linear", range);
+    fillNearestInPlace(decoded, 30);
+    state.layers.viz[slot] = { ...decoded, valid_at: w.valid_at };
+  }
+}

--- a/src/lib/loaders/wind.js
+++ b/src/lib/loaders/wind.js
@@ -1,0 +1,25 @@
+// Legacy 4-slot wind loader (now / +6h / +24h / +72h). Each slot has
+// a matching speed PNG (linear, m/s) and a uv PNG (signed components).
+//
+// Carved out of dataSource.js loadManifest's if/else if chain on
+// 2026-05-09 (Tier-1 follow-up).
+
+import { decodePng, decodeUVPng } from "./decoders.js";
+
+export async function loadWind(info, state) {
+  state.layers.wind = state.layers.wind || {};
+  const speedRange = info.speed_range;
+  const uvRange = info.uv_range;
+  for (const [slot, w] of Object.entries(info.windows || {})) {
+    const speed = await decodePng(w.speed_url, "linear", speedRange);
+    const uv = await decodeUVPng(w.uv_url, uvRange);
+    state.layers.wind[slot] = {
+      ...speed,           // .data, .width, .height for speed
+      uvU: uv.u,
+      uvV: uv.v,
+      valid_at: w.valid_at,
+      fcst_hour: w.fcst_hour,
+      source: w.source || null,  // "HRRR" / "GFS" — for the legend
+    };
+  }
+}

--- a/src/lib/loaders/wind5d.js
+++ b/src/lib/loaders/wind5d.js
@@ -1,0 +1,58 @@
+// 5-day × 5-bucket wind forecast loader. Pulls summary.json first —
+// keep the summary even if individual bucket PNGs fail to decode so
+// the day grid still renders with whatever data we have.
+//
+// Carved out of dataSource.js loadManifest's if/else if chain on
+// 2026-05-09 (Tier-1 follow-up).
+
+import { decodeUVPng, computeSpeedKt, bucketKey } from "./decoders.js";
+
+export async function loadWind5d(info, state) {
+  try {
+    const sres = await fetch(info.summary_url, { cache: "no-cache" });
+    if (!sres.ok) throw new Error(`summary ${info.summary_url} ${sres.status}`);
+    const summary = await sres.json();
+    state.layers.wind5d = {
+      summary,
+      uvRange:    info.uv_range,
+      speedRange: info.speed_range,
+      buckets:    {},
+      hourly:     {},
+      hourlyLoading: {},
+    };
+    // Load every bucket UV in parallel. CRUCIAL: each task swallows
+    // its own error so one bad PNG can't take down the whole forecast.
+    const tasks = [];
+    let failed = 0;
+    let loaded = 0;
+    for (const day of summary.days) {
+      for (const b of day.buckets) {
+        const key = bucketKey(day.day, b.bucket);
+        tasks.push(
+          decodeUVPng(b.uv_url, info.uv_range)
+            .then((uv) => {
+              const speed = computeSpeedKt(uv);
+              state.layers.wind5d.buckets[key] = {
+                uvU: uv.u, uvV: uv.v,
+                width: uv.width, height: uv.height,
+                data: speed, speedKt: speed,
+              };
+              loaded++;
+            })
+            .catch((e) => {
+              failed++;
+              console.warn(`wind5d bucket ${key} failed`, e);
+            })
+        );
+      }
+    }
+    await Promise.all(tasks);
+    if (failed) {
+      console.warn(`wind5d: ${loaded} buckets loaded, ${failed} failed`);
+    }
+  } catch (e) {
+    console.warn("dataSource: wind5d summary load failed", e);
+    // Don't null out — leave whatever summary did parse so the UI
+    // can show the day labels even if the heatmap is missing.
+  }
+}

--- a/tests/appFeatureContracts.test.js
+++ b/tests/appFeatureContracts.test.js
@@ -25,10 +25,20 @@ test("Temp keeps historical and beta forecast SST timelines instead of reverting
   assert.match(app, /layer === "sst" && hasSstTimeline \?\s*\(\s*<div className="composite wind-grid-host">[\s\S]*Sea temp forecast[\s\S]*<SstModeToggle[\s\S]*<SstCurrentCard sel=\{sstActiveSel\} units=\{units\} mode=\{activeSstMode\} \/>/);
   assert.match(mobileSheet, /layer === "sst" && hasSstTimeline \? `Sea temp/);
   assert.match(mobileSheet, /layer === "sst" && hasSstTimeline \?\s*\(\s*<>[\s\S]*<SstModeToggle[\s\S]*<SstCurrentCard sel=\{activeSstSel\} units=\{units\} mode=\{activeSstMode\} \/>/);
-  assert.match(dataSource, /if \(layer === "sst7d"\)/);
-  assert.match(dataSource, /else if \(layer === "sst5d"\)/);
-  assert.match(dataSource, /state\.layers\.sst7d = \{ summary \}/);
-  assert.match(dataSource, /state\.layers\.sst5d = \{ summary \}/);
+  // 2026-05-09: dataSource.js's loadManifest if/else if chain was split
+  // into per-layer files under src/lib/loaders/. The state.layers.sst7d /
+  // sst5d assignment lines now live in those files. Read them so the
+  // contract still pins the same data shape regardless of where in the
+  // codebase the assignment happens.
+  const sst7dLoader = read("src/lib/loaders/sst7d.js");
+  const sst5dLoader = read("src/lib/loaders/sst5d.js");
+  // Loader registry must dispatch to a per-layer loader, not run an
+  // inline if/else chain that's prone to duplicate-branch bugs.
+  assert.match(dataSource, /LAYER_LOADERS\[layer\]/);
+  assert.match(dataSource, /from "\.\/loaders\/index\.js"/);
+  // The actual sst7d/sst5d state writes now live in the per-layer files.
+  assert.match(sst7dLoader, /state\.layers\.sst7d = \{ summary \}/);
+  assert.match(sst5dLoader, /state\.layers\.sst5d = \{ summary \}/);
 });
 
 test("Current, swell, wind, and mobile overlay features remain wired", () => {


### PR DESCRIPTION
## Summary

Tier-1 follow-up from the architecture review: carve `dataSource.js` `loadManifest()` from a 250-line `if/else if` chain into a per-layer registry under `src/lib/loaders/`.

### Why

`loadManifest` used to have one branch per layer (sst7d, sst5d, swell5d, wind5d, current5d, wind, viz, sst, chl), each 30–50 lines of nearly-identical "fetch summary → decode PNGs → write state". That shape is exactly what made `no-dupe-else-if` load-bearing for the 2026-05-07 white-screen incident: my Phase E sst5d loader and main's parallel sst5d loader collided in the same chain, and ESLint caught a duplicate `else if (layer === "sst5d")` branch.

The audit called this out as **Tier 1 #3**: "Extract the dataSource per-layer loaders into `loaders/{sst,wind5d,swell5d,current5d,...}.js`. Each file owns its own decode + storage. The if/else chain becomes a registry: `LOADERS[layer](info, state)`."

### What changed

```
src/lib/loaders/
  decoders.js     # shared helpers (decodePng, decodeUVPng, decodeWavePng,
                  # fillNearestInPlace, computeSpeedKt, currentSampleMask,
                  # landMaskedCurrentSample, bucketKey, hourKey)
  sst7d.js        # loadSst7d(info, state)
  sst5d.js        # loadSst5d(info, state)
  swell5d.js      # loadSwell5d(info, state)
  wind5d.js       # loadWind5d(info, state)
  current5d.js    # loadCurrent5d(info, state)
  wind.js         # loadWind(info, state)
  viz.js          # loadViz(info, state)
  scalarPng.js    # loadScalarPng(layer, info, state) for sst/chl
  index.js        # LAYER_LOADERS registry + decoder re-exports
```

`dataSource.js` `loadManifest()` becomes:

```js
for (const [layer, info] of Object.entries(manifest.layers || {})) {
  state.layers[layer] = layer === "sst" ? (state.layers.sst || {}) : {};
  const loader = LAYER_LOADERS[layer];
  if (loader) await loader(info, state);
}
```

### Backward compatibility

`bucketKey` and `hourKey` moved to `decoders.js` but `dataSource.js` re-exports them, so `CurrentTimeline.jsx` + `WindDayGrid.jsx` don't need any change.

The remaining hourly loaders inside `dataSource.js` (`loadSwell5dHourly`, `loadWind5dHourly`) import `decodeWavePng`/`decodeUVPng`/`computeSpeedKt` from the same shared module.

### Behaviour

Byte-for-byte equivalent. Every loader function is the exact body of its old branch, lifted out. The only logical change is that `wave` + `precip` (which were silently unreachable in the old chain) now route through the registry's "no entry → skip" path — same effect.

### File sizes

```
dataSource.js     1,185 → 798 LOC (-32%)
9 new loader files  +587 LOC total
```

The +200 LOC overhead is import statements + per-file headers. Each loader is ~30–70 lines, reviewable in one screen.

## Test plan

- [x] All 9 dev-checks jobs green
- [ ] After merge, deploy-prod.yml ships
- [ ] After merge, deploy-verify.yml's `live-cp-render` confirms each layer still decodes + paints correctly

## Adding a new layer in the future

1. Drop `src/lib/loaders/<layer>.js` exporting `export async function loadX(info, state)`.
2. Register in `src/lib/loaders/index.js`'s `LAYER_LOADERS` map.

That's it. No more 50-line diff in the middle of a god-function. No more risk of duplicate `else if` branches.

## Out of scope

- DesktopView split out of App.jsx — separate Tier 1 follow-up PR
- Lazy-load non-active layers — separate Tier 1 follow-up (this PR puts the loaders in their own files; lazy-loading is the next step that uses the registry shape)
- fetch.py migration to `LAYER_SPECS` — separate Tier 2 follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
