### PR TITLE
arch: fetch.py reads range/scale from LAYER_SPECS (Tier-2 follow-up)

### DIFF
--- a/pipeline/fetch.py
+++ b/pipeline/fetch.py
@@ -29,6 +29,17 @@ import requests
 import xarray as xr
 from PIL import Image
 
+# Single source of truth for range / scale / unit per layer. Defined in
+# pipeline/lib/layer_spec.py; both this fetcher (encode side) and the
+# frontend's dataSource.js (decode side) look at the same numbers, so
+# a drift between the two is impossible.
+#
+# The merge below layers ENCODER-specific fields (dataset, variable,
+# host, stride, pre_xy_dims, fallbacks, emit_age_sidecar) on top of
+# the contract-specified fields. Changing a range or scale = edit
+# LAYER_SPECS, not this file.
+from pipeline.lib.layer_spec import LAYER_SPECS
+
 BBOX = dict(lat_min=31.8, lat_max=37.6, lng_min=-124.0, lng_max=-116.8)
 ERDDAP_BASE = "https://coastwatch.pfeg.noaa.gov/erddap/griddap"
 REQUEST_HEADERS = {
@@ -39,13 +50,38 @@ ROOT = Path(__file__).resolve().parents[1]
 OUT_DIR = ROOT / "public" / "data"
 CACHE_DIR = ROOT / "pipeline" / ".cache"
 
+
+def _layer_config(spec_name: str, encoder_extras: dict) -> dict:
+    """Build a LAYERS-dict entry by pulling range/scale/unit from
+    pipeline.lib.layer_spec.LAYER_SPECS[spec_name] and layering the
+    encoder-specific config on top.
+
+    Failing here at import time is the point — if the registry doesn't
+    have the layer, this fetcher cannot encode it correctly anyway.
+    """
+    spec = LAYER_SPECS[spec_name]
+    if spec.range is None:
+        raise ValueError(
+            f"fetch.py: LayerSpec for {spec_name!r} has no range — cannot "
+            f"encode a scalar PNG without one. Either fix the spec or move "
+            f"this layer to a fetcher that handles its payload type."
+        )
+    if spec.scale is None:
+        raise ValueError(
+            f"fetch.py: LayerSpec for {spec_name!r} has no scale"
+        )
+    return {
+        "range": tuple(spec.range),
+        "scale": spec.scale,
+        "unit": spec.unit,
+        **encoder_extras,
+    }
+
+
 LAYERS: dict[str, dict] = {
-    "sst": {
+    "sst": _layer_config("sst", {
         "dataset": "jplMURSST41",
         "variable": "analysed_sst",
-        "range": (9.0, 25.0),
-        "scale": "linear",
-        "unit": "degC",
         "stride": 2,
         "history_days": 7,
         "max_back": 10,
@@ -65,8 +101,8 @@ LAYERS: dict[str, dict] = {
                 "source_label": "NOAA Geo-polar blended SST",
             }
         ],
-    },
-    "chl": {
+    }),
+    "chl": _layer_config("chl", {
         # Source moved off the deprecating coastwatch.pfeg.noaa.gov mirror:
         # PFEG is now redirecting (302) to coastwatch.noaa.gov, where the
         # SNPP/N20 NRT gap-filled product lives under a different dataset
@@ -80,14 +116,11 @@ LAYERS: dict[str, dict] = {
         "host":    "https://coastwatch.noaa.gov/erddap/griddap",
         "dataset": "noaacwNPPN20VIIRSDINEOFDaily",
         "variable": "chlor_a",
-        "range": (0.05, 20.0),
-        "scale": "log10",
-        "unit": "mg/m^3",
         "stride": 1,
         # VIIRS gap-filled has a single-element altitude dim at index 0
         "pre_xy_dims": "[0]",
-    },
-    "kd490": {
+    }),
+    "kd490": _layer_config("kd490", {
         # Diffuse attenuation coefficient at 490 nm — direct light-penetration
         # measure, far closer to "what a diver sees" than chl alone. The model
         # (Phase 2) blends Secchi = 1.7/Kd_490 against the chl-derived path,
@@ -106,12 +139,6 @@ LAYERS: dict[str, dict] = {
         "host":    "https://coastwatch.noaa.gov/erddap/griddap",
         "dataset": "noaacwNPPN20S3AkdSCIDINEOF2kmDaily",
         "variable": "kd_490",
-        # Coastal CA: ~0.04 (clear offshore SoCal Bight ~40 m Secchi) to ~3
-        # (turbid river plumes ~0.6 m Secchi). 0.02–10 gives one bit of
-        # headroom on each end; log10 keeps quantization even across 500x.
-        "range": (0.02, 10.0),
-        "scale": "log10",
-        "unit": "m^-1",
         # 2 km native resolution gives ~290×290 pixels over our bbox.
         "stride": 1,
         # Same altitude length-1 axis as VIIRS chl.
@@ -122,7 +149,7 @@ LAYERS: dict[str, dict] = {
         # Mandatory for the Phase-2 model: age sidecar is consumed by
         # fetch_visibility.py to gate "today's Kd observation" on age==0.
         "emit_age_sidecar": True,
-    },
+    }),
 }
 
 

--- a/pipeline/tests/test_fetch_layer_spec_consistency.py
+++ b/pipeline/tests/test_fetch_layer_spec_consistency.py
@@ -1,0 +1,88 @@
+"""Pin fetch.py's LAYERS dict to the LayerSpec contract.
+
+fetch.py's LAYERS dict used to repeat range/scale/unit values inline,
+making it possible for one of the 12 fetcher scripts to drift from
+the contract in pipeline/lib/layer_spec.py without anyone noticing
+until a user reported wrong colors.
+
+Now `fetch.py` imports `LAYER_SPECS` and merges encoder-specific config
+on top via the `_layer_config()` helper. This test pins that wiring:
+the published values (range, scale, unit) inside fetch.py's LAYERS
+dict must equal the values in LAYER_SPECS.
+
+Run:
+    python -m pytest pipeline/tests/test_fetch_layer_spec_consistency.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# fetch.py uses `from pipeline.lib.layer_spec import LAYER_SPECS`,
+# which requires the REPO root on sys.path. The other tests in this
+# directory put pipeline/ on sys.path directly because they import
+# `from fetch import ...` (the top-level scripts as bare modules).
+# We do BOTH so this test file works whichever way pytest is launched.
+ROOT = Path(__file__).resolve().parents[1]   # pipeline/
+REPO_ROOT = ROOT.parent                      # repo root
+for p in (str(REPO_ROOT), str(ROOT)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from lib.layer_spec import LAYER_SPECS       # noqa: E402
+
+# Importing fetch has side effects (it parses argv when run as a script
+# through __main__, but as a module-level import it just defines the
+# LAYERS dict + helper functions). The xarray + pillow deps are listed
+# in pipeline/requirements.txt and installed by the dev-checks
+# pipeline-tests job.
+import fetch                                 # noqa: E402
+
+
+@pytest.mark.parametrize("name", ["sst", "chl", "kd490"])
+def test_fetch_layer_range_matches_spec(name):
+    """fetch.py's published `range` for each layer must equal the
+    LayerSpec contract's range. Drift here = encoder writes one
+    range, decoder reads another, colors silently wrong."""
+    encoder = fetch.LAYERS[name]
+    spec = LAYER_SPECS[name]
+    assert tuple(encoder["range"]) == tuple(spec.range), (
+        f"fetch.py LAYERS[{name!r}].range = {encoder['range']!r} but "
+        f"LayerSpec for {name!r} has range = {spec.range!r}. "
+        f"Update one or the other so the pipeline encoder and "
+        f"the frontend decoder agree."
+    )
+
+
+@pytest.mark.parametrize("name", ["sst", "chl", "kd490"])
+def test_fetch_layer_scale_matches_spec(name):
+    encoder = fetch.LAYERS[name]
+    spec = LAYER_SPECS[name]
+    assert encoder["scale"] == spec.scale, (
+        f"fetch.py LAYERS[{name!r}].scale = {encoder['scale']!r} but "
+        f"LayerSpec for {name!r} has scale = {spec.scale!r}"
+    )
+
+
+@pytest.mark.parametrize("name", ["sst", "chl", "kd490"])
+def test_fetch_layer_unit_matches_spec(name):
+    encoder = fetch.LAYERS[name]
+    spec = LAYER_SPECS[name]
+    assert encoder["unit"] == spec.unit, (
+        f"fetch.py LAYERS[{name!r}].unit = {encoder['unit']!r} but "
+        f"LayerSpec for {name!r} has unit = {spec.unit!r}"
+    )
+
+
+def test_fetch_layer_config_helper_rejects_specs_without_range():
+    """The _layer_config helper should fail loudly if a future LayerSpec
+    entry has range=None — that's a configuration error for any layer
+    going through fetch.py (which only encodes scalar PNGs)."""
+    # `viz` and `wave` have range=None in LAYER_SPECS by design.
+    with pytest.raises(ValueError, match="no range"):
+        fetch._layer_config("viz", {"dataset": "x"})
+    with pytest.raises(ValueError, match="no range"):
+        fetch._layer_config("wave", {"dataset": "x"})


### PR DESCRIPTION
## Summary

Tier-2 follow-up: migrate `fetch.py` to read `range`/`scale`/`unit` from the `LAYER_SPECS` contract (introduced in PR #19) instead of repeating those values inline. Stacks on top of PR #19.

## Why

`fetch.py`'s `LAYERS` dict had range/scale/unit as inline literals:

```python
"sst": {
    "range": (9.0, 25.0),
    "scale": "linear",
    "unit": "degC",
    ...
},
```

Twelve fetchers across the pipeline each carried their own copy. A drift between `fetch.py`'s `range=(9.0, 25.0)` for SST and the frontend decoder's expectation would silently render with wrong colors — invisible until a user complains. The Tier-2 PR added the contract; this PR makes one fetcher actually use it, proving the migration path.

## What changed

- `pipeline/fetch.py`:
  - Imports `LAYER_SPECS` from `pipeline.lib.layer_spec`
  - New `_layer_config(spec_name, encoder_extras)` helper merges contract values (range/scale/unit) with encoder-specific config (dataset, variable, host, stride, fallbacks, pre_xy_dims, max_back, etc.)
  - `LAYERS["sst" | "chl" | "kd490"]` now built via the helper
  - Helper raises `ValueError` at module import time if a requested spec has `range=None` or `scale=None` — fast-fail before any HTTP

- `pipeline/tests/test_fetch_layer_spec_consistency.py`:
  - Parameterized tests over `["sst", "chl", "kd490"]` pin range / scale / unit to the contract
  - Helper rejection test pins the "no range" failure mode (viz, wave intentionally have range=None)

## Behavior

Functionally identical — same 0..255 → range mapping, same scale, same unit. The only change is the source of truth.

## Migration path

This is the template for the other 11 fetchers:

| Script | Layer(s) | Status |
|--------|----------|--------|
| `fetch.py` | sst, chl, kd490 | ✅ migrated (this PR) |
| `fetch_wind.py` | wind | TODO |
| `fetch_wind_5day.py` | wind5d | TODO |
| `fetch_currents.py` | current5d | TODO |
| `fetch_swell_5day.py` | swell5d | TODO |
| `fetch_sst_5day.py` | sst5d | TODO |
| `fetch_visibility.py` | viz | TODO |
| `fetch_waves.py` | wave | TODO |
| `fetch_precip.py` | precip | TODO |
| `chl_blend.py` | chl (blend variant) | TODO |
| `fetch_climatology.py` | sst climatology | TODO |
| `fetch_bathy.py` | bathy (one-shot) | TODO |

Closing drift one fetcher at a time avoids the risk of a big-bang refactor. Each of those PRs is small and follows this same pattern.

## Test plan

- [ ] Once merged into Tier 2 (PR #19), the new `test_fetch_layer_spec_consistency.py` joins the existing `pipeline-tests` job's pytest run
- [ ] `manifest-validate` job continues to pass — same range/scale values reach the published manifest

## Dependencies / order

- **Stacks on PR #19** (Tier 2 — needs `LAYER_SPECS` to exist). Merge PR #19 first.
- Independent of PR #18 (App.jsx split) and PR #20 (dataSource.js loader split) — touches different files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
