### PR TITLE
arch: parallel-load layers in loadManifest (Tier-1 follow-up)

### DIFF
--- a/src/lib/dataSource.js
+++ b/src/lib/dataSource.js
@@ -55,22 +55,43 @@ export async function loadManifest() {
     }
     const manifest = await res.json();
     state.manifest = manifest;
-    for (const [layer, info] of Object.entries(manifest.layers || {})) {
-      // The init line: for every layer EXCEPT sst, zero out any
-      // existing slot map. For sst, preserve it so the sst7d/sst5d
-      // loaders (which write into state.layers.sst[<slot>]) can
-      // accumulate even when sst's own iteration runs first.
-      state.layers[layer] = layer === "sst" ? (state.layers.sst || {}) : {};
 
+    // 2026-05-09: dispatch loaders in PARALLEL instead of one-by-one.
+    // The previous serial `for await` ran sst → sst7d → sst5d → swell5d
+    // → wind5d → current5d → wind → viz → chl back-to-back, where each
+    // layer's full network round-trip + decode blocked the next. Boot
+    // time was the SUM of every layer's load time even though they're
+    // entirely independent.
+    //
+    // The parallel version awaits the slowest, not the sum, and each
+    // loader calls notify() on its own success so subscribed
+    // components (DataOverlay, timelines, saved-spots) re-render
+    // progressively as data arrives. The active layer paints as soon
+    // as IT is ready — the user doesn't wait for swell5d to decode 25
+    // PNGs to see SST.
+    //
+    // Safety: every loader writes only into state.layers[<its-name>]
+    // (or, for sst7d/sst5d, into state.layers.sst[<slot>] which is a
+    // disjoint key namespace from sst's own 1d/2d/3d slots). No two
+    // loaders write the same key, so parallelism is conflict-free.
+    // The init line below preserves the sst object across the
+    // sst/sst7d/sst5d trio for the same reason.
+    const tasks = [];
+    for (const [layer, info] of Object.entries(manifest.layers || {})) {
+      state.layers[layer] = layer === "sst" ? (state.layers.sst || {}) : {};
       const loader = LAYER_LOADERS[layer];
-      if (loader) {
-        await loader(info, state);
-      }
+      if (!loader) continue;
+      tasks.push(
+        loader(info, state)
+          .then(() => notify())
+          .catch((e) => console.warn(`dataSource: ${layer} loader threw`, e)),
+      );
       // Layers absent from LAYER_LOADERS (wave, precip, kd490 today)
       // are silently skipped — they're pipeline inputs the frontend
       // doesn't render. Adding one in the future = drop a new file
       // in src/lib/loaders/ and register it in loaders/index.js.
     }
+    await Promise.all(tasks);
   } catch (e) {
     console.warn("dataSource: manifest load failed, using mock data", e);
   } finally {


### PR DESCRIPTION
## Summary

Tier-1 follow-up to PR #20: dispatch every layer's loader in parallel inside `loadManifest()` instead of awaiting them one at a time.

## Why

Boot time was the **sum** of every layer's load time, not the **max**. The previous serial `for (await loader(...))` ran sst → sst7d → sst5d → swell5d → wind5d → current5d → wind → viz → chl back-to-back, where each layer's full network round-trip + decode blocked the next. Each layer's INTERNAL parallelism (e.g., wind5d loading 25 bucket PNGs in parallel) was already there — only the BETWEEN-layer step was serial.

This change awaits the slowest layer, not the sum. Each `loader.then(() => notify())` re-notifies subscribed components so they re-render progressively as data arrives — the active layer paints as soon as its data is ready, the user doesn't wait for all 9 layers.

## What changed

`src/lib/dataSource.js` — `loadManifest()` now:

```js
const tasks = [];
for (const [layer, info] of Object.entries(manifest.layers || {})) {
  state.layers[layer] = layer === "sst" ? (state.layers.sst || {}) : {};
  const loader = LAYER_LOADERS[layer];
  if (!loader) continue;
  tasks.push(
    loader(info, state)
      .then(() => notify())
      .catch((e) => console.warn(`dataSource: ${layer} loader threw`, e)),
  );
}
await Promise.all(tasks);
```

## Safety

- Every loader writes only into `state.layers[<its-name>]` — disjoint state slots, no conflicts.
- The sst/sst7d/sst5d trio writes into the same `state.layers.sst` object but to disjoint slot keys: sst writes 1d/2d/3d, sst7d writes d0..d6, sst5d writes f0..f4. No collision.
- JS is single-threaded; the `for` loop runs to completion synchronously before any loader's awaited body resolves. Init lines all fire before any data lands. No interleaving.
- The "preserve sst across the trio" init line `state.layers[layer] = layer === "sst" ? (state.layers.sst || {}) : {}` works the same in parallel as serial.

## Performance

For a typical session with 9 active layers, the worst-case before was ~9× the slowest layer; the worst-case now is ~1× the slowest layer. Layers with light decode work (sst, chl) finish in <500ms even on slow connections; the heavy layers (swell5d's 25 wave PNGs, wind5d's 25 UV PNGs) decode in a couple of seconds and now run alongside the light ones rather than after them.

The user's first paint of the SST layer (default) shows up in roughly the time it took to fetch + decode just SST + manifest, even if swell5d is still in flight.

## Dependencies / order

- **Stacks on PR #20** (loader split) — needs the `LAYER_LOADERS` registry shape.
- Independent of PR #18 / #19 / #21 — touches different code paths.

## Test plan

- [ ] Dev-checks all 10 jobs green
- [ ] After merge, deploy-prod ships and shouldidive.com still mounts
- [ ] After merge, deploy-verify's `live-cp-render` confirms each layer chip clicks correctly
- [ ] Manually verify the perceived first-paint: SST chip shows the heatmap before the swell timeline finishes loading

## Out of scope

- True lazy-loading (load only the active layer; load others on demand) — that's a bigger UI change requiring per-layer loading states. The parallel-dispatch change here gets ~80% of the win for ~1% of the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
