### PR TITLE
fix: cron failures spamming inbox — fetch.py import + bot push bypass

### DIFF
--- a/pipeline/fetch.py
+++ b/pipeline/fetch.py
@@ -38,7 +38,20 @@ from PIL import Image
 # host, stride, pre_xy_dims, fallbacks, emit_age_sidecar) on top of
 # the contract-specified fields. Changing a range or scale = edit
 # LAYER_SPECS, not this file.
-from pipeline.lib.layer_spec import LAYER_SPECS
+#
+# Import handles BOTH invocation styles:
+#   * `python pipeline/fetch.py`  → cwd repo root, but sys.path[0] = pipeline/.
+#                                    Falls through to the second arm.
+#   * `python -m pipeline.fetch`   → sys.path[0] = repo root. First arm wins.
+# refresh-data.yml uses the script-style invocation (line 72), so the
+# second arm is the path the production cron actually takes. Without this
+# fallback, the daily refresh fails at module load with
+# `ModuleNotFoundError: No module named 'pipeline'` — caught the first
+# time on 2026-05-08 21:09 UTC, after PR #21 landed.
+try:
+    from pipeline.lib.layer_spec import LAYER_SPECS
+except ModuleNotFoundError:
+    from lib.layer_spec import LAYER_SPECS
 
 BBOX = dict(lat_min=31.8, lat_max=37.6, lng_min=-124.0, lng_max=-116.8)
 ERDDAP_BASE = "https://coastwatch.pfeg.noaa.gov/erddap/griddap"

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -11,18 +11,32 @@
 # What this enforces on the `main` branch:
 #
 #   - require pull request before merging
-#   - require all five dev-checks status contexts to pass
+#   - require all listed dev-checks status contexts to pass
 #   - require branch up-to-date with base before merging
 #   - disallow force pushes
 #   - disallow deletion
 #   - allow admin override (so the user can break-glass if the gate
 #     itself ever blocks a real emergency fix)
+#   - ALLOW github-actions bot to bypass the PR requirement (so the
+#     scheduled data-refresh + ingest workflows can commit refreshed
+#     PNGs / observations.jsonl directly to main without opening a PR
+#     each cycle — see bypass_pull_request_allowances below)
 #
 # Adding a new required check:
 #   1. Add a job to .github/workflows/dev-checks.yml — copy an existing
 #      job's pattern. Job-name = check-context.
 #   2. Append the new context to REQUIRED_CHECKS below.
 #   3. Re-run this script.
+#
+# 2026-05-08 update — bypass list added:
+#   The refresh-data, refresh-wind, and ingest-ground-truth workflows
+#   were all failing on push with `GH006: Protected branch update
+#   failed for refs/heads/main. - Changes must be made through a pull
+#   request.` That's by design — the PR-required rule applies to
+#   everyone by default. This script now grants the github-actions
+#   GitHub App an explicit bypass for that single rule, so scheduled
+#   bot pushes succeed while human + agent commits still go through
+#   the normal dev-checks gate.
 
 set -euo pipefail
 
@@ -65,7 +79,12 @@ payload=$(cat <<EOF
   "required_pull_request_reviews": {
     "dismiss_stale_reviews": false,
     "require_code_owner_reviews": false,
-    "required_approving_review_count": 0
+    "required_approving_review_count": 0,
+    "bypass_pull_request_allowances": {
+      "users": [],
+      "teams": [],
+      "apps": ["github-actions"]
+    }
   },
   "restrictions": null,
   "allow_force_pushes": false,


### PR DESCRIPTION
## Summary

Two bugs that have been spamming your inbox with failure emails on every scheduled workflow run since 2026-05-08.

## Bug 1 — `fetch.py` ModuleNotFoundError (introduced by PR #21)

PR #21 added `from pipeline.lib.layer_spec import LAYER_SPECS` at module top. That works under `python -m pipeline.fetch` (sys.path[0] = repo root) but fails under `python pipeline/fetch.py` (sys.path[0] = `pipeline/`) — which is exactly what `refresh-data.yml` runs on line 72.

```
File "/home/runner/work/ShoudiDive/ShoudiDive/pipeline/fetch.py", line 41, in <module>
    from pipeline.lib.layer_spec import LAYER_SPECS
ModuleNotFoundError: No module named 'pipeline'
```

The existing `from pipeline.sst_buoy_correction import (...)` at line 419 is inside a function (lazy import) so it was never affected.

**Fix:** try/except on the import so both invocation styles resolve.

```python
try:
    from pipeline.lib.layer_spec import LAYER_SPECS
except ModuleNotFoundError:
    from lib.layer_spec import LAYER_SPECS
```

This propagates: when fetch.py crashes early, the manifest never gets re-generated, then the next live-verify run flags `Manifest is 36.8 h stale` and emails you again.

## Bug 2 — `GH006` bot push rejection by branch protection

`refresh-data.yml`, `refresh-wind.yml`, and `ingest-ground-truth.yml` all commit refreshed PNGs / observations.jsonl directly to main on their cron schedules. Branch protection now requires PR before merge — which applies to bots too:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - 5 of 5 required status checks are expected.
```

This fires every ~2h (refresh-wind, ingest) and once per 24h (refresh-data). That's ~12 failure emails per day.

**Fix:** add `bypass_pull_request_allowances.apps = ["github-actions"]` to `scripts/setup-branch-protection.sh` so the GitHub Actions GitHub App can push directly.

Human + agent commits still go through the full dev-checks gate. The bypass applies only to the `required_pull_request_reviews` rule for the github-actions app — branch protection itself, force-push prohibition, and required-status-checks all still apply.

## After merge — required action

Branch-protection settings are not version-controlled, only the script is. You must re-run the script as repo admin to apply the bypass live:

```bash
bash scripts/setup-branch-protection.sh
```

The script is idempotent and prints the resulting context list when done.

## Test plan

- [x] Dev-checks all 11 jobs green
- [ ] After merge, run the branch-protection script
- [ ] Wait for next refresh-wind cron tick (~2h) — should now succeed and push refreshed PNGs to main
- [ ] Within 24h, watch for the daily `refresh-data.yml` cron to come back green
- [ ] Verify `live-cp-manifest` goes from FAIL → SUCCESS once a fresh manifest is published

## Out of scope

- The 32 `failed` forecast hours in refresh-wind logs (a separate NOMADS upstream issue, not what's emailing you)
- The kd490 13.4 d staleness warning — that's the SQ-DINEOF product's intentional ~11d lag floor, not actually broken
- Auto-installing the branch-protection bypass — would require a PAT with admin:repo scope, your call to add or not

🤖 Generated with [Claude Code](https://claude.com/claude-code)
