### PR TITLE
fix: bot-push GH006 via PAT (personal repos can't use bypass-allowances)

### DIFF
--- a/.github/workflows/ingest-ground-truth.yml
+++ b/.github/workflows/ingest-ground-truth.yml
@@ -28,6 +28,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # See refresh-data.yml header for the BOT_PUSH_TOKEN rationale.
+          # Falls back to GITHUB_TOKEN cleanly when the secret is absent.
+          token: ${{ secrets.BOT_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -30,6 +30,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Personal repos can't bypass PR-required for github-actions[bot],
+          # so the daily commit-back step needs to authenticate as a user
+          # with admin rights. BOT_PUSH_TOKEN is an owner-PAT with `repo`
+          # scope. Falls back to GITHUB_TOKEN if the secret isn't set —
+          # everything else in this workflow keeps working, only the
+          # final `git push` fails with GH006 until the PAT is added.
+          token: ${{ secrets.BOT_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/refresh-wind.yml
+++ b/.github/workflows/refresh-wind.yml
@@ -18,6 +18,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # See refresh-data.yml header for the BOT_PUSH_TOKEN rationale.
+          # Falls back to GITHUB_TOKEN cleanly when the secret is absent.
+          token: ${{ secrets.BOT_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v5
         with:

--- a/pipeline/validation/ingest/CANDIDATES.md
+++ b/pipeline/validation/ingest/CANDIDATES.md
@@ -39,17 +39,33 @@ grep -iE "vis(ibility)?|viz|[0-9]{1,2}\s*(ft|feet|')" /tmp/probe.html | head
 
 ## SoCal dive shops (highest priority — fills viz gaps)
 
+The dev sandbox couldn't reach these domains directly (`ECONNREFUSED`
+in WebFetch — likely an upstream allowlist on small-shop hostnames,
+not real unreachability). Probe each from your terminal with:
+
+```bash
+curl -sL -A "Mozilla/5.0" https://CANDIDATE/ -o /tmp/probe.html
+echo "size: $(wc -c </tmp/probe.html) bytes"
+grep -iE "vis(ibility)?|viz|[0-9]{1,2}\s*(ft|feet|')" /tmp/probe.html | head -10
+```
+
+If size > 10 KB and grep shows visibility lines, the source is
+viable — paste the URL + a sample of the matching lines back to me
+and I'll wire a scraper for it.
+
 | Candidate | URL | Region | Notes |
 |-----------|-----|--------|-------|
 | **Anacapa Divers** | https://anacapadivers.com/ | Channel Islands (Oxnard) | Day-boat to Anacapa + Santa Cruz. Currently no Channel Islands scraper. |
-| **Truth Aquatics** | https://truthaquatics.com/ | Channel Islands (Santa Barbara) | Liveaboard fleet (Vision/Conception). Posts trip reports. |
-| **Peace Divers** | https://www.peacedivers.com/ | Channel Islands (Ventura) | Day boat. |
+| **Anacapa Dive Charters** | https://www.anacapadivecharters.com/ | Channel Islands | Alternate spelling — try both. |
+| **Truth Aquatics** | https://truthaquatics.com/trip-reports/ | Channel Islands (Santa Barbara) | Liveaboard fleet (Vision/Conception). Posts trip reports. |
+| **Peace Divers** | https://www.peacedivers.com/news/ | Channel Islands (Ventura) | Day boat. |
 | **Dive Ventura** | https://diveventura.com/ | Ventura | Local boat fleet. |
 | **Searcher Charters** | https://searcherboat.com/ | Long Beach offshore | Same family as Spectre, may share a CMS. |
 | **Dudedivers / Bottom Scratchers** | https://www.dudedivers.com/ | LB / OC | Trip reports historically. |
 | **Aquarius Divers** | https://aquariusdivers.com/conditions | SD | Already noted as link-farm to CDIP/buoy widgets. **Skip.** |
-| **22nd Street Sportfishing** | https://www.22ndstreet.com/fishreports.php | LA Harbor | Static HTML, but reports are catch-focused. **Probably skip** — no viz signal. |
-| **Davey's Locker** | https://www.daveyslocker.com/news/ | Newport Beach | Whale watching + fishing. **Probably skip** — no viz signal. |
+| **22nd Street Sportfishing** | https://www.22ndstreet.com/fishreports.php | LA Harbor | Verified 2026-05-09 — static HTML reachable, but reports are catch-focused with no viz signal. **Skip.** |
+| **Davey's Locker** | https://www.daveyslocker.com/news/ | Newport Beach | Verified 2026-05-09 — whale watching + fishing focus, no viz signal. **Skip.** |
+| **Spectre Boat** | https://www.spectreboat.com/weather | LB offshore | Verified 2026-05-09 — page links out to vizfinder.com, no own data. **Skip — pursue vizfinder partnership instead.** |
 
 ## Peer forecasters (partnership > scraping)
 

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -17,26 +17,32 @@
 #   - disallow deletion
 #   - allow admin override (so the user can break-glass if the gate
 #     itself ever blocks a real emergency fix)
-#   - ALLOW github-actions bot to bypass the PR requirement (so the
-#     scheduled data-refresh + ingest workflows can commit refreshed
-#     PNGs / observations.jsonl directly to main without opening a PR
-#     each cycle — see bypass_pull_request_allowances below)
+#
+# How scheduled bot pushes get past PR-required:
+#   The refresh-data, refresh-wind, and ingest-ground-truth workflows
+#   commit refreshed data directly to main on cron. Personal repos
+#   can't use `bypass_pull_request_allowances` (that's org-only — the
+#   GitHub API returns 422 with 'Only organization repositories can
+#   have users and team restrictions'). The workaround on a personal
+#   repo: have the workflow's `git push` step authenticate as a token
+#   with admin permissions; admins are exempt from PR-required.
+#
+#   Setup (one-time, by repo owner):
+#     1. https://github.com/settings/tokens/new — classic PAT, scope:
+#        `repo`. Note: a fine-grained token with Contents:Write +
+#        repo:admin equivalents also works.
+#     2. Repo → Settings → Secrets → Actions → New: name BOT_PUSH_TOKEN,
+#        paste the PAT.
+#     3. The cron workflows already check ${{ secrets.BOT_PUSH_TOKEN }}
+#        and fall back to GITHUB_TOKEN if the secret is missing — so
+#        nothing breaks if you skip the PAT step, the bot push just
+#        keeps failing with GH006 until the secret is added.
 #
 # Adding a new required check:
 #   1. Add a job to .github/workflows/dev-checks.yml — copy an existing
 #      job's pattern. Job-name = check-context.
 #   2. Append the new context to REQUIRED_CHECKS below.
 #   3. Re-run this script.
-#
-# 2026-05-08 update — bypass list added:
-#   The refresh-data, refresh-wind, and ingest-ground-truth workflows
-#   were all failing on push with `GH006: Protected branch update
-#   failed for refs/heads/main. - Changes must be made through a pull
-#   request.` That's by design — the PR-required rule applies to
-#   everyone by default. This script now grants the github-actions
-#   GitHub App an explicit bypass for that single rule, so scheduled
-#   bot pushes succeed while human + agent commits still go through
-#   the normal dev-checks gate.
 
 set -euo pipefail
 
@@ -79,12 +85,7 @@ payload=$(cat <<EOF
   "required_pull_request_reviews": {
     "dismiss_stale_reviews": false,
     "require_code_owner_reviews": false,
-    "required_approving_review_count": 0,
-    "bypass_pull_request_allowances": {
-      "users": [],
-      "teams": [],
-      "apps": ["github-actions"]
-    }
+    "required_approving_review_count": 0
   },
   "restrictions": null,
   "allow_force_pushes": false,


### PR DESCRIPTION
## Summary

Yesterday's PR #25 added `bypass_pull_request_allowances` to the branch-protection script. **That field is org-only — personal repos get a 422 validation error from the GitHub API.** The cron workflows are still failing on `GH006: Protected branch update failed`.

This PR fixes it the right way for a personal repo: have the cron workflows authenticate the `git push` step with a PAT that has admin permissions. Admins bypass branch protection, so the bot pushes succeed without changing protection rules.

## Discovery

```
gh api -X PUT repos/Michaelpjob/ShoudiDive/branches/main/protection ...
{
  "message": "Validation Failed",
  "errors": ["Only organization repositories can have users and team restrictions"],
  "status": "422"
}
```

## Changes

| File | Change |
|------|--------|
| `scripts/setup-branch-protection.sh` | Drops the bypass_pull_request_allowances field. Adds docs section explaining the PAT path as the personal-repo workaround. |
| `.github/workflows/refresh-data.yml` | `actions/checkout@v4` uses `${{ secrets.BOT_PUSH_TOKEN \|\| secrets.GITHUB_TOKEN }}` |
| `.github/workflows/refresh-wind.yml` | same |
| `.github/workflows/ingest-ground-truth.yml` | same |
| `pipeline/validation/ingest/CANDIDATES.md` | Replaces ECONNREFUSED notes with a copy-paste curl probe ritual (sandbox can't reach small-shop domains; user's terminal can). Adds verified-skip entries for 22nd Street, Davey's Locker, Spectre Boat. |

The `|| GITHUB_TOKEN` fallback means **nothing breaks if the secret isn't set** — only the final `git push` step continues to fail with GH006 until the PAT is added. Everything else in each cron continues to work.

## Live state (already applied)

Branch protection re-applied 2026-05-09 (without the org-only bypass field):

```
required_contexts: pipeline-tests, web-build, mobile-static, secrets-scan,
                   workflow-lint, web-lint, web-tests, web-smoke, manifest-validate
pr_required: true
allow_force: false
```

The 4 new contexts (web-lint, web-tests, web-smoke, manifest-validate) are now hard gates — were live-only before, now required for merge.

## User action to fully activate

After merging this PR:

1. **Create a PAT** at https://github.com/settings/tokens/new
   - Classic PAT, scope: `repo` (full control of private repos)
   - Or fine-grained: `Contents: Read and write`, `Workflows: Read and write` on `Michaelpjob/ShoudiDive`
2. **Add as repo secret** at Settings → Secrets and variables → Actions:
   - Name: `BOT_PUSH_TOKEN`
   - Value: the PAT you just created
3. **Wait for the next scheduled tick** — should now push cleanly:
   - refresh-wind: every 2h
   - ingest-ground-truth: every 2h
   - refresh-data: 06:00 UTC daily

The next watchdog cycle should clear findings 1, 2, 3, 5 from open Issue #16 (the upstream symptoms of bot-push failure + manifest staleness).

## Channel Islands probe — your terminal needed

The dev sandbox blocks every small-shop domain (`anacapadivers.com`, `peacedivers.com`, `truthaquatics.com`, etc. all `ECONNREFUSED`). I can't validate them from here. CANDIDATES.md now has the exact `curl + grep` recipe to probe each one in <2 minutes from your terminal. Paste the matching `vis: X-Y ft` lines back to me for whichever passes and I'll wire scrapers same-day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
