### PR TITLE
ingest: add SouthCoastDiversScraper + retire eagle4 + audit your full source list

### DIFF
--- a/pipeline/tests/test_southcoastdivers_parsers.py
+++ b/pipeline/tests/test_southcoastdivers_parsers.py
@@ -1,0 +1,193 @@
+"""Unit tests for the South Coast Divers scraper's parsing helpers.
+
+The scraper hits the network in fetch() + calls the LLM extractor;
+this test file exercises only the deterministic helpers (filename
+parsing, HTML stripping, spot resolution) against fixtures.
+
+Run:
+    python -m pytest pipeline/tests/test_southcoastdivers_parsers.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from validation.ingest.southcoastdivers import (  # noqa: E402
+    _parse_post_filenames,
+    _post_view_url,
+    _strip_html,
+    _resolve_spot,
+    _load_spot_lookup,
+)
+
+
+# Fixture: realistic shape of the index page returned by /blog. The
+# actual page is a Linux-style directory listing of timestamped files.
+INDEX_HTML = """
+<html><body>
+<h2>Index of /blog</h2>
+<a href="/php/display_blog_list.php?func=view&file=20260507130022-RichP.txt">May 7</a><br>
+<a href="/php/display_blog_list.php?func=view&file=20260508124039-RichP.txt">May 8</a><br>
+<a href="/php/display_blog_list.php?func=view&file=20260506094500-RichP.txt">May 6</a><br>
+<a href="/php/display_blog_list.php?func=view&file=20260101000000-LouisU.txt">Jan 1</a><br>
+</body></html>
+"""
+
+POST_HTML = """
+<html><head><title>South Coast Divers Blog</title></head>
+<body>
+<header>HOT DOGS!!!</header>
+<script>var nope = "ignored";</script>
+<style>body { color: red; }</style>
+<div class="post">
+Saturday 5/8/26. Got out for an early dive at Bluebird Canyon, just up
+the beach from Woods Cove. Water was cold, around 60°F. Vis was about
+8 feet — group consensus was that leaves me with the viz being around
+10 feet again across the cove.
+</div>
+<footer>Visit our Facebook group for more.</footer>
+</body></html>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Filename parsing — sort by timestamp DESC, dedup
+# ---------------------------------------------------------------------------
+
+
+def test_parse_post_filenames_returns_newest_first():
+    fns = _parse_post_filenames(INDEX_HTML)
+    # 4 unique entries
+    assert len(fns) == 4
+    # Newest first: May 8 → May 7 → May 6 → Jan 1
+    assert fns[0] == "20260508124039-RichP.txt"
+    assert fns[1] == "20260507130022-RichP.txt"
+    assert fns[2] == "20260506094500-RichP.txt"
+    assert fns[3] == "20260101000000-LouisU.txt"
+
+
+def test_parse_post_filenames_dedups_repeated_anchors():
+    html = INDEX_HTML + INDEX_HTML  # same anchors repeated twice
+    fns = _parse_post_filenames(html)
+    assert len(fns) == 4  # not 8
+
+
+def test_parse_post_filenames_handles_empty():
+    assert _parse_post_filenames("<html><body>nothing here</body></html>") == []
+
+
+def test_parse_post_filenames_tolerates_other_authors():
+    """A future contributor change shouldn't break the regex."""
+    html = '<a href="?file=20260509083000-NewAuthor.txt">x</a>'
+    assert _parse_post_filenames(html) == ["20260509083000-NewAuthor.txt"]
+
+
+# ---------------------------------------------------------------------------
+# URL builder
+# ---------------------------------------------------------------------------
+
+
+def test_post_view_url_includes_filename():
+    url = _post_view_url("20260508124039-RichP.txt")
+    assert url.endswith("file=20260508124039-RichP.txt")
+    assert "display_blog_list.php" in url
+    assert url.startswith("https://southcoastdivers.com/")
+
+
+# ---------------------------------------------------------------------------
+# HTML stripping
+# ---------------------------------------------------------------------------
+
+
+def test_strip_html_drops_script_and_style():
+    out = _strip_html(POST_HTML)
+    assert "ignored" not in out  # <script> body
+    assert "color: red" not in out  # <style> body
+    assert "Vis was about 8 feet" in out  # body content preserved
+
+
+def test_strip_html_collapses_whitespace():
+    html = "<p>foo\n\n\n   bar</p>"
+    assert _strip_html(html) == "foo bar"
+
+
+def test_strip_html_handles_no_body_tag():
+    html = "<div>hello world</div>"
+    assert _strip_html(html) == "hello world"
+
+
+# ---------------------------------------------------------------------------
+# Spot resolution against the shared lookup
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_spot_finds_woods_cove():
+    lookup = _load_spot_lookup()
+    out = _resolve_spot("Woods Cove", lookup)
+    assert out is not None
+    canon, lat, lng = out
+    assert canon == "Woods Cove"
+    assert lat == 33.530
+    assert lng == -117.780
+
+
+def test_resolve_spot_longest_match_wins():
+    """When the LLM names "Pt Loma Kelp", we should match the kelp
+    entry, not the more general "Pt Loma"."""
+    lookup = _load_spot_lookup()
+    out = _resolve_spot("Pt Loma Kelp", lookup)
+    assert out is not None
+    canon = out[0]
+    # All three Pt Loma Kelp variants share the same coords
+    assert "Kelp" in canon
+
+
+def test_resolve_spot_returns_none_for_unknown():
+    lookup = _load_spot_lookup()
+    assert _resolve_spot("Nonexistent Reef", lookup) is None
+    assert _resolve_spot("", lookup) is None
+
+
+def test_resolve_spot_case_insensitive():
+    lookup = _load_spot_lookup()
+    a = _resolve_spot("La Jolla Cove", lookup)
+    b = _resolve_spot("LA JOLLA COVE", lookup)
+    c = _resolve_spot("la jolla cove", lookup)
+    assert a == b == c
+    assert a is not None
+
+
+# ---------------------------------------------------------------------------
+# Roster wiring
+# ---------------------------------------------------------------------------
+
+
+def test_scraper_is_in_orchestrator_roster():
+    from validation.ingest import SCRAPERS  # noqa: WPS433
+    from validation.ingest.southcoastdivers import SouthCoastDiversScraper
+
+    found = any(isinstance(s, SouthCoastDiversScraper) for s in SCRAPERS)
+    assert found, (
+        "SouthCoastDiversScraper is not registered in SCRAPERS — "
+        "the cron will skip it. Add it to the roster in "
+        "pipeline/validation/ingest/__init__.py."
+    )
+
+
+def test_eagle4_scraper_no_longer_in_roster():
+    """Eagle4 was retired 2026-05-09 (eagle4pacific.com DNS-fails).
+    Make sure it doesn't accidentally come back."""
+    from validation.ingest import SCRAPERS  # noqa: WPS433
+
+    names = [getattr(s, "source_id", s.__class__.__name__) for s in SCRAPERS]
+    assert "ingest_eagle4" not in names
+    # The class name is what the orchestrator reports when source_id
+    # is missing — also gate on the type to be safe.
+    assert not any(s.__class__.__name__ == "Eagle4Scraper" for s in SCRAPERS)

--- a/pipeline/validation/ingest/CANDIDATES.md
+++ b/pipeline/validation/ingest/CANDIDATES.md
@@ -1,88 +1,154 @@
-# Candidate dive-shop scrapers — manual probe queue
+# Dive-shop ingest audit — full source list
 
-Each entry below is a dive shop / charter / forum that **was on the
-original handoff list** but couldn't be validated from the dev
-sandbox (sandbox network restrictions returned `ECONNREFUSED` or
-`404` even when the URLs work in a normal browser). Once a human
-confirms the URL is reachable + has the expected content, copy the
-matching scraper template and add it to the roster in
-`__init__.py`.
+Comprehensive audit of every URL on the user-supplied source manifest
+(`outputs/dive_visibility_sources_2026-05-09.json`, 50+ entries
+covering Monterey → Coronado Islands). Each row has been individually
+probed; the verdict column says whether we already cover it, scrape
+it now, plan to scrape it, or rejected it (with the reason).
 
-The probe ritual for each candidate is the same:
+**Update cadence:** the JSON manifest is the source of truth for
+what _exists_ on the public web. This file is the source of truth for
+what we _do about each one_. Re-audit annually (CMS changes,
+webcam-only shops adding text reports, defunct shops re-opening).
+
+---
+
+## Active scrapers — viz signal flowing today
+
+| Source | Region | Type | URL | Confidence | Notes |
+|--------|--------|------|-----|:---------:|-------|
+| **Just Get Wet** | San Diego | dive shop, daily | https://justgetwet.com/blogs/dive-reports-and-conditions | 0.85 | Labelled-field prose, regex-extractable. Highest-volume secchi source today. |
+| **DiveViz** (2 blogs) | LA-OC + SD | aggregator, daily | https://diveviz.com/blogs/{daily-dive-report,la-and-oc-dive-conditions} | 0.85 | Prose, LLM-extracted. The `san-diego-dive-conditions` blog (line 152 of source manifest) is dormant since 2019 — content moved to `daily-dive-report`. |
+| **Beach Cities Scuba** | Laguna | dive shop, daily | https://beachcitiescuba.com/pages/current-conditions | 0.85 | Single-spot-per-page (Shaw's Cove default) with labelled fields. Added 2026-05-09. |
+| **South Coast Divers** | Laguna | dive shop, daily | https://southcoastdivers.com/blog | 0.80 | Daily prose blog (Rich Parker / Louis Umphenour). LLM-extracted. Custom timestamped-filename URL pattern. Added 2026-05-09. Complements Beach Cities Scuba — covers Bluebird Canyon + Woods Cove + N/S Laguna live-cam inferences. |
+| **BdOutdoors** (4 RSS feeds) | CA-wide | forum, daily | https://www.bdoutdoors.com/forums/forum/.../index.rss | 0.85 | Spear / fishing forum. Pre-filters for viz keywords before LLM call. |
+| **Reddit r/scuba + r/spearfishing** | CA-wide | forum, irregular | https://www.reddit.com/r/{scuba,spearfishing}/.rss | 0.80 | LLM-extracted. Geo subs (r/sandiego etc) excluded — noise too high. |
+| **CDIP buoys** (6) | CA coast | buoy, live | https://cdip.ucsd.edu/data_access/justdar.cdip | 0.95 | Hs + SST. **No secchi.** Useful for SST validation only. |
+| **NDBC buoys** (6) | CA coast | buoy, live | https://www.ndbc.noaa.gov/data/realtime2/ | 0.95 | Hs + SST. **No secchi.** Same as CDIP — fills central + LA-county zones. |
+
+---
+
+## Aggregator-only (no own viz signal — REJECTED)
+
+These sites are link/widget aggregators that re-display data we
+already pull from primary sources. Scraping them would duplicate
+buoy data already in `observations.jsonl` from CDIPScraper /
+NDBCScraper.
+
+| Source | URL | Why rejected |
+|--------|-----|--------------|
+| Aquarius Dive Shop (Monterey) | https://aquariusdivers.com/conditions | "Wave Models" + "Forecasts" + "Web Cams" sections only — links out to NOAA/CDIP/NDBC. **Same buoy data we already pull.** |
+| Diver Dan's | https://www.diverdans.com/local-diving/monterey-conditions/ | Pure navigation hub — links to NDBC, CDIP, Windy, webcams. No own data. |
+| Pacific Wilderness | https://pacificwilderness.com/?page_id=676 | Aggregator: webcams + Magic Seaweed + LA County beach advisories. |
+| Heff.net | https://www.heff.net/scuba/features/cdc.shtml | Links + a phone number for SD Lifeguards. No web data. |
+| L.A. Scuba Diving | https://lascubadiving.com/workshop/divereport.html | Links to wave models + webcams hosted elsewhere. |
+| South Coast Divers /conds.shtml | http://www.southcoastdivers.com/conds.shtml | Different URL than `/blog` — this one is the aggregator page. **The /blog URL is what we scrape.** |
+| Spectre Boat /weather | https://www.spectreboat.com/weather | Links out to vizfinder.com. (Spectre is a charter, not a shop.) |
+| 22nd Street Sportfishing | https://www.22ndstreet.com/fishreports.php | Reachable, but reports are catch-focused with no viz mentions. |
+| Davey's Locker | https://www.daveyslocker.com/news/ | Whale watching + fishing focus, no viz signal. |
+| Channel Islands Dive Adventures /northern-channel-islands/ | https://channelislandsdiveadventures.com/.../northern-channel-islands/ | Static informational copy ("vis rarely below 10 ft, average 40 ft"). No dated trip reports at the linked /blog/ or /category/dive-vacation-reports/ paths (both 404). |
+| Waterhorse Charters | https://www.waterhorsecharters.com/{wreck-alley,coronado-islands}/ | Customer testimonials only. No dated trip reports with numbers. |
+| Monterey Scuba Board | https://montereyscubaboard.com/conditions/ | Educational guide page, not a forum. No dated posts. |
+| Ocean Safari Scuba /islands | https://www.oceansafariscuba.com/islands | Trip albums + events, no condition reports. |
+| LagunaPages | http://www.lagunapages.com/beach/conditions.asp | Returned HTTP 500. Likely abandoned. |
+| DiveCenter.com SoCal | https://divecenter.com/dive-conditions/southern-california-... | Aggregator — irregular updates. |
+| Open Water Data (Shaw's/Diver's Cove) | https://www.openwaterdata.com/site/laguna-beach-shaws-cove-divers-cove | Live structured data — but the **structured fields are AIR data** (air temp, wind, humidity, precipitation). Water data shows "No relevant data". Useful for the existing wind/swell pipeline if we expand inputs; not for viz. |
+
+---
+
+## Dormant / camera-down (REVISIT QUARTERLY)
+
+| Source | URL | State | Action |
+|--------|-----|-------|--------|
+| **DivePros SD** | https://www.diveprosd.com/ | Format is structured ("10–13 ft" graded "C") but the underlying Scripps Pier underwater camera is "currently down for technical issues" since mid-April 2026. Last report April 18. | Revisit monthly. When camera comes back, build a scraper modeled on Beach Cities Scuba (labelled-field prose). High-value: it's a structured La Jolla viz forecast that updates daily. |
+| Truth Aquatics (Vision/Conception) | https://truthaquatics.com/ | DNS-fails from both GitHub Actions and user's network as of 2026-05-09. The Conception fire (Sep 2019) ended the company; the website is gone. | **Defunct. Do not retry.** |
+
+---
+
+## Webcam-driven (FUTURE PROJECT — image-analysis pipeline)
+
+Multiple shops link or host underwater/surface cams. Building a
+visibility-from-image inference pipeline would unlock these
+simultaneously. Sketch:
+
+- Pull cam still every hour
+- Run a small CNN (or vision-LLM) trained on (still, secchi-from-text-report) pairs
+- Emit synthetic "obs" tagged source=webcam, conf 0.65 (lower than human reports)
+
+Sources that would feed it:
+
+- Spanglers' Scuba (Monterey live cams at multiple sites)
+- Spanglers' Whaler's Cove (Point Lobos)
+- USPS Ventura aggregated cams
+- Pacific Wilderness cam list (Cabrillo Beach, Isthmus Reef, Casino Point)
+- Beach Cities Scuba's S/N Laguna cams (referenced by South Coast Divers)
+- DivePros SD's Scripps Pier cam (when restored)
+
+This is a separate body of work — defer until the text-scraper
+roster has hit its asymptote.
+
+---
+
+## Partnership ASK (highest signal-to-engineering-effort ratio)
+
+Per the original handoff: peer forecasters are friendly small teams.
+Reaching out is a 30-min email; scraping their JS-rendered SPAs is
+days of work for inferior data.
+
+| Target | URL | What to ask for |
+|--------|-----|-----------------|
+| **VizFinder** | https://www.vizfinder.com/ | Daily forecast JSON or RSS. Goes into `peer_forecasts.jsonl` (NOT `observations.jsonl`) so score.py computes 3-way agreement (their forecast vs. ours vs. dive-shop ground truth). |
+| **SpearFactor** | https://spearfactor.com/ | Same. Spearfishing-specific, narrower geography. |
+| **DiveViz** (full-feed API) | (already partnered de-facto via blog scrape) | Ask if they'd expose a structured JSON endpoint that gives us all SoCal regions in one fetch — would cut polite-rate-limit time + LLM token cost ~5x. |
+
+Email template lives below in this file.
+
+---
+
+## Forum / community (low signal density, defer)
+
+| Source | URL | Why deferred |
+|--------|-----|--------------|
+| Monterey County Dive Reports (Facebook Group) | https://www.facebook.com/groups/montereycountydivereports/ | Highly active per the source manifest, but Facebook auth-walls + actively breaks scrapers. Not worth the maintenance burden. |
+| ScubaBoard regional forums | https://scubaboard.com/community/forums/california.50/ | Probed 2026-05-09: SoCal subforum is currently 100% Chamber Day fundraiser admin chatter. The "SoCal Dive Site Reviews" subforum is historical reviews (newest from Jul 2025). Watch for activity to come back. |
+| Monterey Scuba Board "/conditions/" | https://montereyscubaboard.com/conditions/ | Static educational page, not a forum. (Domain name misleading.) |
+| DAN Alert Diver | https://dan.org/alert-diver/article/big-sur/ | Magazine — irregular long-form articles, not a regular condition feed. |
+| OpenDiveSites.org | https://opendivesites.org/Point_Lobos | Wiki-style, infrequent updates. |
+| California Diver Magazine | https://californiadiver.com/monterey-dive-conditions/ | Magazine — irregular. |
+| California Diving News | https://cadivingnews.com/dive-spots/los-coronados-islands-lobster-shack/ | Magazine — single articles per spot, not a feed. |
+
+---
+
+## Probe ritual for new candidates
+
+For any URL not yet on this list:
 
 ```bash
-# 1. Curl the candidate URL with a real browser User-Agent.
-curl -A "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36" \
-  "https://CANDIDATE/dive-reports" | head -200
-
-# 2. If you see actual HTML (not "<div id=\"app\"></div>" or 403),
-#    save a chunk to a file and grep for visibility numbers:
-curl -A "..." "URL" -o /tmp/probe.html
-grep -iE "vis(ibility)?|viz|[0-9]{1,2}\s*(ft|feet|')" /tmp/probe.html | head
-
-# 3. If the regex finds quantitative viz lines, the source is
-#    Tier 1 / regex-extractable — clone justgetwet.py or
-#    beachcitiescuba.py as a template.
-
-# 4. If only prose ("water cleared up nicely" without a number),
-#    it's Tier 2 / LLM-only — clone diveviz.py as a template
-#    and let _llm_extract.py do the structuring.
-
-# 5. If the body is empty / <div id="root"></div>, the site is JS-
-#    rendered. Either:
-#      a) inspect the network panel for a JSON API endpoint the SPA
-#         calls (often /api/posts.json or .json on a Shopify route);
-#         scrape that JSON directly — much cleaner than rendering.
-#      b) Fall back to Puppeteer (already a devDep). See the
-#         _puppeteer_base.py stub TODO at the bottom of this file.
-```
-
-## SoCal dive shops (highest priority — fills viz gaps)
-
-The dev sandbox couldn't reach these domains directly (`ECONNREFUSED`
-in WebFetch — likely an upstream allowlist on small-shop hostnames,
-not real unreachability). Probe each from your terminal with:
-
-```bash
+# From a normal terminal (not the dev sandbox — it allowlists hosts).
 curl -sL -A "Mozilla/5.0" https://CANDIDATE/ -o /tmp/probe.html
 echo "size: $(wc -c </tmp/probe.html) bytes"
-grep -iE "vis(ibility)?|viz|[0-9]{1,2}\s*(ft|feet|')" /tmp/probe.html | head -10
+grep -iE "vis(ibility)?|viz|water clarity|[0-9]{1,2}\s*(ft|feet)" /tmp/probe.html | head -10
 ```
 
-If size > 10 KB and grep shows visibility lines, the source is
-viable — paste the URL + a sample of the matching lines back to me
-and I'll wire a scraper for it.
+Verdict tree:
 
-| Candidate | URL | Region | Notes |
-|-----------|-----|--------|-------|
-| **Anacapa Divers** | https://anacapadivers.com/ | Channel Islands (Oxnard) | Day-boat to Anacapa + Santa Cruz. Currently no Channel Islands scraper. |
-| **Anacapa Dive Charters** | https://www.anacapadivecharters.com/ | Channel Islands | Alternate spelling — try both. |
-| **Truth Aquatics** | https://truthaquatics.com/trip-reports/ | Channel Islands (Santa Barbara) | Liveaboard fleet (Vision/Conception). Posts trip reports. |
-| **Peace Divers** | https://www.peacedivers.com/news/ | Channel Islands (Ventura) | Day boat. |
-| **Dive Ventura** | https://diveventura.com/ | Ventura | Local boat fleet. |
-| **Searcher Charters** | https://searcherboat.com/ | Long Beach offshore | Same family as Spectre, may share a CMS. |
-| **Dudedivers / Bottom Scratchers** | https://www.dudedivers.com/ | LB / OC | Trip reports historically. |
-| **Aquarius Divers** | https://aquariusdivers.com/conditions | SD | Already noted as link-farm to CDIP/buoy widgets. **Skip.** |
-| **22nd Street Sportfishing** | https://www.22ndstreet.com/fishreports.php | LA Harbor | Verified 2026-05-09 — static HTML reachable, but reports are catch-focused with no viz signal. **Skip.** |
-| **Davey's Locker** | https://www.daveyslocker.com/news/ | Newport Beach | Verified 2026-05-09 — whale watching + fishing focus, no viz signal. **Skip.** |
-| **Spectre Boat** | https://www.spectreboat.com/weather | LB offshore | Verified 2026-05-09 — page links out to vizfinder.com, no own data. **Skip — pursue vizfinder partnership instead.** |
+1. **Size < 500 bytes**: 404, parked domain, or bot-blocker. Skip.
+2. **Size > 10 KB, but no viz keywords in HTML**: aggregator. Skip.
+3. **Size > 10 KB, viz keywords match a STATIC range** ("vis 10-50 ft"): it's site reference info, not a current report. Skip.
+4. **viz keywords match in a DATED CONTEXT** ("Saturday 5/8/26... viz around 10 ft"): viable. Note format:
+   - Labelled fields ("Vis: X-Y ft") → regex scraper, model on Just Get Wet / Beach Cities Scuba
+   - Prose ("clean water at 8-10 feet today") → LLM scraper, model on DiveViz / South Coast Divers
+5. **Live structured data feed (JSON/CSV)**: likely high-value. Investigate API endpoints.
 
-## Peer forecasters (partnership > scraping)
+Paste the matching lines + URL pattern back to me; I'll wire a
+scraper same-day if it's regex-extractable, next-day if LLM.
 
-Per the original handoff: "reach out before scraping — these are
-friendly small teams." If they share a JSON or RSS endpoint, write
-a `PeerForecasterScraper` that emits to `peer_forecasts.jsonl`
-(NOT `observations.jsonl`) so `score.py` computes 3-way agreement
-without conflating peer forecasts with ground-truth.
+---
 
-| Candidate | URL | Notes |
-|-----------|-----|-------|
-| **vizfinder.com** | https://vizfinder.com/ | SoCal viz forecaster. JS-rendered SPA. |
-| **spearfactor.com** | https://spearfactor.com/ | Spearfishing-focused viz. |
-| **Surfline** | https://surfline.com/ | Has a JSON API; viz reports are an enterprise feature, may need a partnership ask. |
+## Partnership outreach email template
 
-Email template suggestion:
-
+> **Subject:** ShouldIDive.com — open-source CA-coast viz forecaster — partnership ask
+>
 > Hi <name>,
 >
 > I'm building **shouldidive.com** — a free CA-coast water-clarity
@@ -96,70 +162,9 @@ Email template suggestion:
 > metric (your forecast, my forecast, dive-shop reports) so I can
 > calibrate my model and surface where forecasters disagree.
 >
-> Anything I display would credit you with a clickable link back. If
-> you have an RSS, JSON, or even an emailable daily summary, I can
-> wire it into the validation pipeline within a day. Happy to chat
-> if there's a way to make this useful for both of us.
+> Anything I display would credit you with a clickable link back.
+> If you have an RSS, JSON, or even an emailable daily summary, I
+> can wire it into the validation pipeline within a day. Happy to
+> chat if there's a way to make this useful for both of us.
 >
 > — Michael
-
-## Community sources
-
-| Candidate | URL | Notes |
-|-----------|-----|-------|
-| **scubaboard.com SoCal forum** | https://www.scubaboard.com/community/forums/socal.88/ | **Skip.** Probed 2026-05-09 — current threads are Chamber Day fundraiser admin, not condition reports. |
-| **scubaboard.com SoCal Dive Site Reviews** | https://www.scubaboard.com/community/forums/socal-dive-site-reviews.1120/ | **Skip.** Newest thread is Jul 2025; content is historical reviews, not daily reports. |
-| **Spearboard CA section** | https://www.spearboard.com/ | Probe needed — forum browsing was blocked from the sandbox. Likely RSS feed available like bdoutdoors. |
-| **r/sandiego, r/orangecounty, r/santabarbara** | reddit.com | **Skip per existing reddit.py comment** — geo-subs are 99% non-diving. r/scuba + r/spearfishing with CA-keyword filter is the right shape, already implemented. |
-
-## Stretch — not on the original list but worth considering
-
-| Candidate | Why |
-|-----------|-----|
-| **Strava public freedive activities** | Many freedivers log dives on Strava with conditions in the description. Strava has an API; the geo-bbox filter would scope to CA. |
-| **NOAA SECOORA / IOOS web cams** | Already used as a buoy proxy by the cdip.py scraper. Worth probing whether the underlying pier-cam metadata exposes a viz proxy. |
-| **dive shop email list scrape** | If a shop emails a daily report, set up a dedicated inbox and parse the From: + body. Lower ops cost than scraping but requires shop opt-in. |
-
-## Implementation TODO
-
-If/when we need to scrape JS-rendered SPAs, drop a
-`pipeline/validation/ingest/_puppeteer_base.py` that subprocess-spawns
-a small Node script using the puppeteer devDep we already have.
-Sketch:
-
-```python
-# _puppeteer_base.py
-import json, subprocess, pathlib
-
-NODE_RENDERER = pathlib.Path(__file__).resolve().parent / "_render.mjs"
-
-def render_url(url: str, wait_selector: str | None = None, timeout_s: int = 30) -> str:
-    args = ["node", str(NODE_RENDERER), url]
-    if wait_selector:
-        args += ["--wait", wait_selector]
-    r = subprocess.run(args, capture_output=True, text=True, timeout=timeout_s)
-    r.check_returncode()
-    return r.stdout
-```
-
-```javascript
-// _render.mjs
-import puppeteer from "puppeteer";
-const [,, url, ...rest] = process.argv;
-const browser = await puppeteer.launch({ headless: "new" });
-const page = await browser.newPage();
-await page.setUserAgent("ShoudiDive-Validator/1.0 (+https://shouldidive.com/about/validation)");
-await page.goto(url, { waitUntil: "networkidle2", timeout: 25000 });
-const waitIdx = rest.indexOf("--wait");
-if (waitIdx >= 0) await page.waitForSelector(rest[waitIdx + 1], { timeout: 10000 });
-process.stdout.write(await page.content());
-await browser.close();
-```
-
-Cost: ~150MB Chromium per cron run (puppeteer ships its own). The
-existing `web-smoke` + `cp-visual-paint` jobs already pay this cost,
-so adding it to `ingest-ground-truth.yml` is incremental, not new.
-
-Defer this until at least 2 of the JS-only candidates above are
-confirmed to have actual viz signal — no point paying the puppeteer
-boot cost for sources that turn out to be link farms.

--- a/pipeline/validation/ingest/__init__.py
+++ b/pipeline/validation/ingest/__init__.py
@@ -20,10 +20,13 @@ from .bdoutdoors import BdOutdoorsScraper
 from .beachcitiescuba import BeachCitiesCubaScraper
 from .cdip import CDIPScraper
 from .diveviz import DiveVizScraper
-from .eagle4 import Eagle4Scraper
 from .justgetwet import JustGetWetScraper
 from .ndbc import NDBCScraper
 from .reddit import RedditCAScraper
+from .southcoastdivers import SouthCoastDiversScraper
+# eagle4 retired 2026-05-09 — domain dead (DNS doesn't resolve from
+# GitHub Actions or the user's network). File kept on disk for
+# possible future revival.
 
 
 # Scraper roster for the hourly cron. Order doesn't matter — each
@@ -50,6 +53,13 @@ SCRAPERS = [
 
     # Tier 2 — prose, LLM-extracted (no-ops gracefully without API key)
     DiveVizScraper(),      # SD + LA + OC dive shop, two-blog feed, conf 0.85
+    SouthCoastDiversScraper(),  # Laguna group blog (Rich Parker / Louis
+                                # Umphenour). Daily prose posts at custom
+                                # PHP endpoint, dated filename timestamps.
+                                # Covers Bluebird Canyon + Woods Cove +
+                                # live-cam inferences from N/S Laguna —
+                                # complements BeachCitiesCuba (Shaw's Cove).
+                                # conf 0.80.
     BdOutdoorsScraper(),   # XenForo fishing/spear forum RSS — 4 feeds:
                            # central-CA fishing, SoCal offshore, CA sport,
                            # spearfishing. First central-CA signal in the
@@ -59,23 +69,18 @@ SCRAPERS = [
                            # Posts only (comments are 10x cost; revisit
                            # once we see the post-only signal). conf 0.80.
 
-    # Tier 1/2 — best-effort URL probe; URL in handoff didn't resolve
-    Eagle4Scraper(),       # Channel Islands dive shop, conf 0.85
+    # Eagle4Scraper retired 2026-05-09: eagle4pacific.com fails DNS
+    # resolution from both GitHub Actions runners and the user's
+    # network. Confirmed dead, not just sandbox-restricted. The
+    # scraper file is kept under source control so a future revival
+    # (if the shop renames/reopens) can re-import it; it just isn't
+    # in the active roster.
 
-    # Sources evaluated and skipped this round:
-    #   aquariusdivers.com/conditions    — link farm to CDIP/buoy widgets, no own data
-    #   beachcitiescuba.com/pages/...    — JS-rendered, BS4 sees empty body
-    #   spectreboat.com/weather          — affiliate widget linking to vizfinder.com
-    #   22ndstreet / H&M / Davey's       — JS-rendered SPAs (no RSS endpoint found)
-    #   vizfinder.com / spearfactor.com  — peer forecasters (Tier 1.5),
-    #     JS-rendered SPAs. Per the handoff: "reach out before scraping —
-    #     these are friendly small teams." Better as a partnership / API
-    #     ask than a scrape. When an RSS or JSON endpoint exists, drop in
-    #     a PeerForecasterScraper that writes to a SEPARATE
-    #     peer_forecasts.jsonl (NOT observations.jsonl) so score.py can
-    #     compute the three-way agreement metric documented in
-    #     01-architecture.md without conflating peer forecasts with
-    #     ground-truth.
+    # Sources evaluated and skipped this round (full audit in
+    # CANDIDATES.md). Most are link-aggregator pages that point at
+    # CDIP buoys (already covered by CDIPScraper) or webcams (need
+    # image-analysis pipeline, not text scraping). The handful with
+    # actual visibility numbers are wired above.
     # Re-evaluate quarterly; a working URL or a static fallback would
     # let any of these slot into the same scraper pattern.
 ]

--- a/pipeline/validation/ingest/southcoastdivers.py
+++ b/pipeline/validation/ingest/southcoastdivers.py
@@ -1,0 +1,233 @@
+"""South Coast Divers — daily Laguna group posts.
+
+South Coast Divers (southcoastdivers.com) maintains a daily-updated
+blog at /blog. The blog is a directory of timestamped .txt files
+named `YYYYMMDDHHMMSS-RichP.txt`, each viewable through a custom
+PHP endpoint:
+
+    https://southcoastdivers.com/php/display_blog_list.php?func=view&file=20260508124039-RichP.txt
+
+Posts are informal prose — Rich Parker + Louis Umphenour write up
+morning conditions for Laguna's coves (Bluebird Canyon, Woods Cove,
+South/North Laguna). Quote from the 2026-05-08 post:
+
+    "that leaves me with the viz being around 10 feet again"
+
+The format is prose without labelled fields, so extraction goes
+through ``_llm_extract.extract_from_prose`` like DiveViz / BdOutdoors.
+Without ``ANTHROPIC_API_KEY`` set this scraper emits zero obs and
+exits gracefully — same pattern as the other LLM-extracted sources.
+
+Confidence weight 0.80 — slightly below the labelled-field shops
+(Just Get Wet, Beach Cities Scuba) because (a) the text is
+unstructured, and (b) reports are typically subjective viz estimates
+("around 10 feet again") rather than instrument-derived numbers.
+
+Coverage: complements BeachCitiesCubaScraper (Shaw's Cove). South
+Coast Divers writes about Bluebird Canyon, Woods Cove, and live-cam
+inferences from N/S Laguna — same zone, different reporting style.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import time
+from datetime import datetime, timezone
+
+from . import _llm_extract
+from ._base import BaseScraper
+
+
+SOURCE_ROOT = "https://southcoastdivers.com"
+BLOG_INDEX_URL = f"{SOURCE_ROOT}/blog"
+POST_VIEW_URL = f"{SOURCE_ROOT}/php/display_blog_list.php?func=view&file="
+
+# Default focal point for posts that don't explicitly name a spot —
+# Laguna Beach centroid (between Shaw's Cove and Woods Cove). The
+# spot lookup catches Woods Cove / Bluebird Canyon when named.
+DEFAULT_SPOT = "Laguna"
+DEFAULT_LAT, DEFAULT_LNG = 33.540, -117.780
+
+# Filename pattern observed 2026-05-09: YYYYMMDDHHMMSS-<author>.txt
+# Captured from `<a href="...?file=...">` anchors on the directory
+# index. Tolerant of varying author suffixes (RichP today; could be
+# something else in the future) so a future contributor change
+# doesn't silently break the scraper.
+_POST_FILE_RE = re.compile(
+    r'file=(\d{14}-[A-Za-z0-9_]+\.txt)',
+    re.IGNORECASE,
+)
+
+# How many recent posts to walk per cron tick. Same budget as Just
+# Get Wet — anything older than 3 posts is past the 24h window
+# score.py uses anyway.
+MAX_POSTS_PER_RUN = 2
+
+# Minimum prose length to attempt LLM extraction. Below this it's
+# usually a "no dives this weekend" boilerplate where the LLM has
+# nothing to extract and we'd just spend tokens for zero obs.
+MIN_PROSE_CHARS = 60
+
+
+def _load_spot_lookup() -> dict[str, tuple[float, float, str]]:
+    """Reuse the shared spot lookup so all LLM-extracted sources
+    resolve names the same way."""
+    here = pathlib.Path(__file__).resolve().parent
+    raw = json.loads((here / "_spot_lookup.json").read_text(encoding="utf-8"))
+    out: dict[str, tuple[float, float, str]] = {}
+    for k, v in raw.items():
+        if k.startswith("_"):
+            continue
+        if isinstance(v, list) and len(v) == 2:
+            out[k.lower()] = (float(v[0]), float(v[1]), k)
+    return out
+
+
+def _resolve_spot(name: str, lookup: dict[str, tuple[float, float, str]]) -> tuple[str, float, float] | None:
+    """Longest-substring-match spot resolver. Same shape as
+    DiveViz uses; returns the canonical name + coords or None if
+    we don't have coords for the LLM-named spot."""
+    if not name:
+        return None
+    n = name.lower().strip()
+    # Try exact match first.
+    if n in lookup:
+        lat, lng, canon = lookup[n]
+        return (canon, lat, lng)
+    # Longest substring match — "pt loma kelp" matches "Pt Loma Kelp"
+    # before "Pt Loma" if both are in the text.
+    candidates = [(k, v) for k, v in lookup.items() if k in n]
+    if not candidates:
+        return None
+    candidates.sort(key=lambda x: -len(x[0]))
+    _, (lat, lng, canon) = candidates[0]
+    return (canon, lat, lng)
+
+
+def _parse_post_filenames(html: str) -> list[str]:
+    """Extract every `file=<timestamp>-author.txt` filename referenced
+    on the index page, sorted newest-first. Dedup by filename."""
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for m in _POST_FILE_RE.finditer(html):
+        fn = m.group(1)
+        if fn in seen:
+            continue
+        seen.add(fn)
+        ordered.append(fn)
+    # Sort by leading 14-digit timestamp DESC.
+    ordered.sort(key=lambda s: s[:14], reverse=True)
+    return ordered
+
+
+def _post_view_url(filename: str) -> str:
+    return f"{POST_VIEW_URL}{filename}"
+
+
+def _strip_html(html: str) -> str:
+    """Cheap tag-stripper. The display_blog_list.php endpoint wraps
+    plain prose in some HTML chrome; for LLM extraction we want
+    just the body."""
+    # Drop everything outside <body>...</body> if present.
+    body = re.search(r"<body[^>]*>(.*?)</body>", html, re.DOTALL | re.IGNORECASE)
+    text = body.group(1) if body else html
+    # Drop scripts + styles.
+    text = re.sub(r"<(script|style)[^>]*>.*?</\1>", " ", text, flags=re.DOTALL | re.IGNORECASE)
+    # Strip remaining tags.
+    text = re.sub(r"<[^>]+>", " ", text)
+    # Collapse whitespace.
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+class SouthCoastDiversScraper(BaseScraper):
+    source_id = "dive-shop-southcoastdivers"
+    source_confidence = 0.80
+    source_root_url = BLOG_INDEX_URL
+
+    # Same cadence policy as the other dive-shop blogs (Just Get
+    # Wet, DiveViz). 30s between same-host requests so we walk the
+    # index → 2 recent posts within one cron tick.
+    host_rate_limit_s = 30
+    _INTRA_PAUSE_S = 30
+
+    def __init__(self):
+        super().__init__()
+        self._spot_lookup = _load_spot_lookup()
+
+    def fetch(self) -> list[dict]:
+        # No LLM key = no extraction possible. Same graceful skip
+        # the other prose sources use.
+        if not _llm_extract.is_enabled():
+            print(f"  {self.source_id}: ANTHROPIC_API_KEY unset, skipping prose-only source")
+            return []
+
+        try:
+            r_index = self._polite_get(BLOG_INDEX_URL)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  {self.source_id}: index fetch: {exc.__class__.__name__}")
+            return []
+
+        filenames = _parse_post_filenames(r_index.text)
+        if not filenames:
+            print(f"  {self.source_id}: index has no recognized post filenames")
+            return []
+
+        out: list[dict] = []
+        for i, fn in enumerate(filenames[:MAX_POSTS_PER_RUN]):
+            if i > 0:
+                time.sleep(self._INTRA_PAUSE_S)
+            url = _post_view_url(fn)
+            try:
+                r_post = self._polite_get(url)
+            except Exception as exc:  # noqa: BLE001
+                print(f"  {self.source_id}: {fn}: {exc.__class__.__name__}")
+                continue
+            prose = _strip_html(r_post.text)
+            if not prose or len(prose) < MIN_PROSE_CHARS:
+                continue
+
+            extracted = _llm_extract.extract_from_prose(prose)
+            if not extracted:
+                continue
+
+            # Use the filename's timestamp as the observation time —
+            # more accurate than the cron-fetch time for matching
+            # against same-day predictions.
+            ts_str = fn[:14]  # YYYYMMDDHHMMSS
+            try:
+                when = datetime.strptime(ts_str, "%Y%m%d%H%M%S").replace(tzinfo=timezone.utc)
+            except ValueError:
+                when = datetime.now(timezone.utc)
+
+            for seq, e in enumerate(extracted):
+                spot_name = (e.get("spot_name") or "").strip()
+                resolved = _resolve_spot(spot_name, self._spot_lookup)
+                if resolved is None:
+                    if spot_name:
+                        print(f"  {self.source_id}: unknown spot {spot_name!r} — skipped")
+                    continue
+                canonical_name, lat, lng = resolved
+
+                obs = {
+                    "obs_id":               self.make_obs_id(canonical_name, seq=seq, when=when),
+                    "timestamp_utc":        when.isoformat(timespec="minutes").replace("+00:00", "Z"),
+                    "lat":                  float(lat),
+                    "lng":                  float(lng),
+                    "spot_name":            canonical_name,
+                    "observed_secchi_ft":   e.get("viz_ft"),
+                    "observed_sst_f":       e.get("sst_f"),
+                    "observed_swell_ft":    e.get("swell_ft"),
+                    "observed_swell_period_s": e.get("swell_period_s"),
+                    "observed_swell_dir_deg":  e.get("swell_dir_deg"),
+                    "source":               self.source_id,
+                    "source_url":           url,
+                    "source_confidence":    self.source_confidence,
+                    "extraction_method":    "llm",
+                    "raw_excerpt":          (e.get("excerpt") or "")[:240] or None,
+                    "notes":                "South Coast Divers daily group post (Laguna)",
+                }
+                out.append(obs)
+
+        return out


### PR DESCRIPTION
## Summary

You sent the actual source manifest (50+ entries across 13 regions). PR #27 audited a subset; this one covers the whole list and adds one verified-working source from it.

## What's new

- **`SouthCoastDiversScraper`** — Laguna Beach daily group blog. URL pattern is custom (`/php/display_blog_list.php?func=view&file=20260508124039-RichP.txt`). LLM-extracted prose. Confidence 0.80. **Complements** BeachCitiesCubaScraper — different reporting style for the same zone.

- **Retired `Eagle4Scraper`** from the active roster. DNS failure confirmed from both GitHub Actions runners and your network (your earlier PowerShell probe). File kept on disk for possible future revival.

- **Full `CANDIDATES.md` rewrite** — every URL from your source manifest individually probed and categorized:
  - **Active (8)** — flowing today
  - **Aggregator-only rejected (15)** — relay CDIP/NDBC/webcam data we already have
  - **Dormant (DivePros SD)** — waiting on Scripps Pier cam restoration
  - **Webcam-driven** — future image-analysis project
  - **Partnership ASK (vizfinder/spearfactor)** — email template included
  - **Forum/community** — low signal, deferred

## The audit pattern

Most "dive shop conditions" pages turned out to be **link aggregators** pointing at CDIP buoys + webcams. We already pull the buoy data from primary sources, so scraping the aggregators would duplicate observations.

Real text-scraped dive-shop daily reports plateau at 4 sources:
1. Just Get Wet (existing)
2. DiveViz (existing)
3. Beach Cities Scuba (PR #27)
4. **South Coast Divers (this PR)**

That's effectively the ceiling for what static-HTML scraping can give us. The next big unlock is **webcam → AI viz inference** — multiple shops have cams (Spanglers, Beach Cities, DivePros) but no text reports. Building a small CNN that predicts viz from cam stills, trained on the 200+ secchi-from-text observations we'll have within a month, opens up that whole channel. Sketched in CANDIDATES.md as a future project.

## Coverage trajectory

| Phase | Active secchi sources | Approx obs/day |
|-------|---|---|
| Pre-audit | 2 (Just Get Wet, DiveViz) | 4-5 |
| Post-PR #27 | +Beach Cities Scuba | +1 |
| **Post-this-PR** | **+South Coast Divers** | **+1-2** |

That's ~3 weeks to push `bight_nearshore` past the 30-obs threshold where check_regression.py activates. The Laguna additions also diversify the source mix — if Just Get Wet drops out, we still have OC zone signal.

## Test plan

- [x] 14 deterministic tests covering filename parser, HTML stripper, spot resolution
- [x] Roster-wiring test (the easy bug — file exists but isn't in SCRAPERS)
- [x] Eagle4 regression test (catches accidental re-import)
- [ ] After merge + next ingest cron tick (~2h), confirm `dive-shop-southcoastdivers` appears in `ingest_health.json`
- [ ] Within 24h, expect 1-2 obs from Bluebird Canyon / Woods Cove / Laguna Cove appended to `observations.jsonl`

## Out of scope (your action items)

1. **Email vizfinder + spearfactor** for a partnership feed — template in CANDIDATES.md
2. **Decide on the webcam image-analysis pipeline** — separate project; ~1 week of work; would unlock 5+ shops simultaneously

## Verification ✅

Ingest cron just successfully pushed to main as `github-actions[bot]`:
```
github-actions[bot]: ingest: 2026-05-09T19:07Z
```
Cron emails should stop on the next scheduled tick. The `BOT_PUSH_TOKEN` secret you added is working end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
