### PR TITLE
analytics: privacy-respecting in-app event tracking (Phase 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,3 +222,63 @@ Repo admins can bypass branch protection via the GitHub UI's
 "Override" button. This exists for emergencies (e.g. if the gate
 itself breaks). Agents should never invoke this path; if a check is
 flaky, fix the check, not the bypass.
+
+## In-app analytics
+
+Privacy-respecting usage tracking: no cookies, no third-party
+trackers, no PII. Events post to our own Cloudflare Pages Function
+at `/api/analytics/event` from the same origin.
+
+Architecture:
+
+```
+React app (App.jsx, components)
+   │
+   │  track("layer_change", { from, to })
+   ▼
+src/lib/analytics.js   buffer 25 events / 30 s
+   │
+   │  POST /api/analytics/event   (sendBeacon for tab-close reliability)
+   ▼
+functions/api/analytics/event.js   (Cloudflare Pages Function)
+   │
+   ├── Phase 1 (today): console.log → Cloudflare Pages
+   │                    Real-time Logs tab
+   └── Phase 2 (todo):  also write to ANALYTICS_KV
+                        bound namespace; /stats page reads it
+```
+
+Tracked events today:
+- `pageview` — fired once per tab on init
+- `layer_change` — sst/chl/wind/swell/current/viz chip clicks (props: from, to)
+- `sst_mode_change` — history vs forecast toggle
+- `spot_click` — saved-spot panel selections (props: from, to, layer)
+- `popup_open` — MPA / bathy-feature popups
+- `settings_change` — theme, units, opacity, mpaOn, bathyOn
+- `tip_click` — Venmo tip jar in topbar
+
+**Reading the data (Phase 1 — right now):**
+```bash
+# Cloudflare dash → Workers & Pages → shouldidive → Logs tab → live tail.
+# Or via wrangler:
+npx wrangler pages deployment tail --project-name=shouldidive | grep ANALYTICS
+```
+
+**Privacy contract:**
+- No IP address logged (Cloudflare provides it; we discard it)
+- No User-Agent logged
+- Country code from `request.cf.country` is logged (already-anonymized
+  by Cloudflare, useful aggregate signal)
+- Session ID is a random 64-bit token in `sessionStorage` — dies on
+  tab close
+- Honors browser DNT and a `localStorage["sd:analytics:off"]="1"`
+  opt-out flag; analytics never fires for users who set either.
+
+**Adding a new event type:**
+1. Pick a name from the allowlist in
+   `functions/api/analytics/event.js`'s `ALLOWED_NAMES` set, or add a
+   new entry there. Names not in the allowlist are silently dropped
+   server-side (defends against client-side bugs flooding logs).
+2. Call `track("event_name", { prop1, prop2 })` from the React tree.
+   Props are flat primitives only (string/number/bool/null).
+3. Verify the event lands by tailing the Cloudflare logs (above).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,3 +222,63 @@ Repo admins can bypass branch protection via the GitHub UI's
 "Override" button. This exists for emergencies (e.g. if the gate
 itself breaks). Agents should never invoke this path; if a check is
 flaky, fix the check, not the bypass.
+
+## In-app analytics
+
+Privacy-respecting usage tracking: no cookies, no third-party
+trackers, no PII. Events post to our own Cloudflare Pages Function
+at `/api/analytics/event` from the same origin.
+
+Architecture:
+
+```
+React app (App.jsx, components)
+   │
+   │  track("layer_change", { from, to })
+   ▼
+src/lib/analytics.js   buffer 25 events / 30 s
+   │
+   │  POST /api/analytics/event   (sendBeacon for tab-close reliability)
+   ▼
+functions/api/analytics/event.js   (Cloudflare Pages Function)
+   │
+   ├── Phase 1 (today): console.log → Cloudflare Pages
+   │                    Real-time Logs tab
+   └── Phase 2 (todo):  also write to ANALYTICS_KV
+                        bound namespace; /stats page reads it
+```
+
+Tracked events today:
+- `pageview` — fired once per tab on init
+- `layer_change` — sst/chl/wind/swell/current/viz chip clicks (props: from, to)
+- `sst_mode_change` — history vs forecast toggle
+- `spot_click` — saved-spot panel selections (props: from, to, layer)
+- `popup_open` — MPA / bathy-feature popups
+- `settings_change` — theme, units, opacity, mpaOn, bathyOn
+- `tip_click` — Venmo tip jar in topbar
+
+**Reading the data (Phase 1 — right now):**
+```bash
+# Cloudflare dash → Workers & Pages → shouldidive → Logs tab → live tail.
+# Or via wrangler:
+npx wrangler pages deployment tail --project-name=shouldidive | grep ANALYTICS
+```
+
+**Privacy contract:**
+- No IP address logged (Cloudflare provides it; we discard it)
+- No User-Agent logged
+- Country code from `request.cf.country` is logged (already-anonymized
+  by Cloudflare, useful aggregate signal)
+- Session ID is a random 64-bit token in `sessionStorage` — dies on
+  tab close
+- Honors browser DNT and a `localStorage["sd:analytics:off"]="1"`
+  opt-out flag; analytics never fires for users who set either.
+
+**Adding a new event type:**
+1. Pick a name from the allowlist in
+   `functions/api/analytics/event.js`'s `ALLOWED_NAMES` set, or add a
+   new entry there. Names not in the allowlist are silently dropped
+   server-side (defends against client-side bugs flooding logs).
+2. Call `track("event_name", { prop1, prop2 })` from the React tree.
+   Props are flat primitives only (string/number/bool/null).
+3. Verify the event lands by tailing the Cloudflare logs (above).

--- a/functions/api/analytics/event.js
+++ b/functions/api/analytics/event.js
@@ -1,0 +1,167 @@
+// Cloudflare Pages Function — analytics event ingest endpoint.
+//
+// Receives batched events from src/lib/analytics.js and:
+//   * Validates the payload shape (rejects oversize / malformed)
+//   * Adds server-side timestamp + a privacy-preserving country tag
+//   * Logs each event to console (visible in the Cloudflare Pages
+//     dashboard's Real-time Logs tab — that's the Phase 1 storage)
+//
+// Phase 2 (follow-up):
+//   * Bind a Cloudflare KV namespace as `ANALYTICS_KV` and persist
+//     events keyed by `{date}/{session_id}/{seq}` so a separate
+//     /api/analytics/summary endpoint can aggregate.
+//   * Add a /stats page that reads the aggregated JSON and renders
+//     the dashboard.
+//
+// Privacy notes:
+//   * No IP address logged. Cloudflare gives us the request IP via
+//     `request.headers.get("CF-Connecting-IP")` but we deliberately
+//     ignore it. The country header is fine — it's already
+//     anonymized by CF and useful for "where are users from?".
+//   * No User-Agent logged for the same reason.
+//   * Session ID is the random 64-bit token the client minted; it
+//     dies when the user closes the tab.
+//
+// Routing:
+//   This file lives at functions/api/analytics/event.js, which
+//   Cloudflare Pages Functions auto-mounts at /api/analytics/event.
+//   No wrangler.toml route config needed.
+
+const MAX_BODY_BYTES = 16 * 1024;       // 16 KB cap; honest clients send <1 KB
+const MAX_EVENTS_PER_BATCH = 50;        // matches client buffer size + headroom
+const ALLOWED_NAMES = new Set([
+  "pageview",
+  "layer_change",
+  "sst_mode_change",
+  "spot_click",
+  "settings_change",
+  "tooltip_open",
+  "popup_open",
+  "timeline_drag",
+  "zoom",
+  "share_click",
+  "tip_click",
+]);
+
+function jsonResponse(body, init) {
+  return new Response(JSON.stringify(body), {
+    status: (init && init.status) || 200,
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "Cache-Control": "no-store",
+      // No CORS — same-origin only by design. Don't set
+      // Access-Control-Allow-Origin; we want browsers to refuse
+      // cross-origin POSTs to this endpoint.
+    },
+  });
+}
+
+export async function onRequestPost({ request }) {
+  // Defensive size guard. sendBeacon will happily POST a 10 MB blob
+  // if the client buffer is broken; we never want to spend a full
+  // request CPU budget on a malformed payload.
+  const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
+  if (contentLength > MAX_BODY_BYTES) {
+    return jsonResponse({ ok: false, error: "payload too large" }, { status: 413 });
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonResponse({ ok: false, error: "invalid json" }, { status: 400 });
+  }
+  if (!body || typeof body !== "object") {
+    return jsonResponse({ ok: false, error: "expected object" }, { status: 400 });
+  }
+
+  const sessionId = String(body.session_id || "").slice(0, 32);
+  const viewport = String(body.viewport || "").slice(0, 16);
+  const sentAt = String(body.sent_at || "").slice(0, 32);
+  const events = Array.isArray(body.events) ? body.events : [];
+
+  if (!sessionId || events.length === 0) {
+    return jsonResponse({ ok: false, error: "missing session or events" }, { status: 400 });
+  }
+  if (events.length > MAX_EVENTS_PER_BATCH) {
+    return jsonResponse({ ok: false, error: "too many events" }, { status: 413 });
+  }
+
+  // Cloudflare's request object exposes the country code under cf
+  // (no IP, no fingerprint). Useful + anonymous.
+  const country = (request.cf && request.cf.country) || "??";
+  const receivedAt = new Date().toISOString();
+
+  // Validate + sanitize each event; drop rather than reject on
+  // per-event issues — a single malformed event from a buggy client
+  // shouldn't kill the rest of the batch.
+  const accepted = [];
+  for (const ev of events) {
+    if (!ev || typeof ev !== "object") continue;
+    const name = String(ev.name || "");
+    if (!ALLOWED_NAMES.has(name)) continue;
+    const ts = String(ev.ts || "").slice(0, 32);
+    const props = {};
+    if (ev.props && typeof ev.props === "object") {
+      for (const [k, v] of Object.entries(ev.props)) {
+        if (k.length > 32) continue;
+        const t = typeof v;
+        if (v === null || t === "boolean" || t === "number") {
+          props[k] = v;
+        } else if (t === "string") {
+          props[k] = v.slice(0, 64);
+        }
+      }
+    }
+    accepted.push({ name, ts, props });
+  }
+
+  // Phase 1 storage: console.log per event. The Cloudflare Pages
+  // dashboard's Real-time Logs tab streams these, so the user can
+  // watch live usage. They're also captured in Workers Logpush if
+  // the user enables it (~$0.05 per million records).
+  for (const ev of accepted) {
+    // Compact one-line JSON per event so log greps are easy.
+    // eslint-disable-next-line no-console
+    console.log(
+      "ANALYTICS",
+      JSON.stringify({
+        sid: sessionId,
+        cc: country,
+        vp: viewport,
+        sent_at: sentAt,
+        recv_at: receivedAt,
+        name: ev.name,
+        ts: ev.ts,
+        props: ev.props,
+      })
+    );
+  }
+
+  // Phase 2 hook: when ANALYTICS_KV is bound, also persist.
+  // (Comment out for Phase 1 — uncomment + bind the namespace
+  // when you're ready to add the dashboard.)
+  // const env = arguments[0].env;
+  // if (env && env.ANALYTICS_KV) {
+  //   const day = receivedAt.slice(0, 10);          // YYYY-MM-DD bucket
+  //   const key = `${day}/${sessionId}/${Date.now()}`;
+  //   await env.ANALYTICS_KV.put(key, JSON.stringify(accepted), {
+  //     expirationTtl: 60 * 60 * 24 * 90,           // 90-day retention
+  //   });
+  // }
+
+  return jsonResponse({ ok: true, accepted: accepted.length });
+}
+
+// Reject anything that's not a POST so the endpoint surface is tiny.
+export async function onRequest({ request }) {
+  if (request.method === "POST") return onRequestPost({ request });
+  if (request.method === "OPTIONS") {
+    // No CORS; reject preflight. Same-origin only.
+    return new Response(null, { status: 405, headers: { Allow: "POST" } });
+  }
+  return new Response("Method Not Allowed", {
+    status: 405,
+    headers: { Allow: "POST" },
+  });
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -70,6 +70,7 @@ import {
   isMapGestureChildTarget,
   shouldPinMapTap,
 } from "./lib/mapInteractionGuards.js";
+import { track } from "./lib/analytics.js";
 
 // Reactive viewport hook for the bottom-sheet mobile UI.
 //
@@ -317,7 +318,30 @@ export default function App() {
 
   function setPref(key, val) {
     setPrefs((p) => ({ ...p, [key]: val }));
+    // Track settings changes — answers "do users actually toggle theme,
+    // change opacity, switch units?". Don't include the value as a
+    // string for free-form fields; just the key + a JSON-safe value.
+    track("settings_change", { key, val });
   }
+
+  // Wrapped state setters that fire analytics events alongside the
+  // setState. Passing these down to DesktopView (and through to
+  // MobileSheet) means every layer-chip click — desktop or mobile —
+  // gets one event, regardless of where in the JSX tree the click
+  // originated. The closure captures the previous value so we can
+  // emit `from`/`to` and answer "what's the most-common transition?".
+  const trackedSetLayer = (next) => {
+    if (next !== layer) {
+      track("layer_change", { from: layer, to: next });
+    }
+    setLayer(next);
+  };
+  const trackedSetSstMode = (next) => {
+    if (next !== sstMode) {
+      track("sst_mode_change", { from: sstMode, to: next });
+    }
+    setSstMode(next);
+  };
 
   // Moon-phase icon should track the active time slider when those
   // layers are active, otherwise show "now". Computed at render time
@@ -336,11 +360,11 @@ export default function App() {
       )}
       <DesktopView
         layer={layer}
-        setLayer={setLayer}
+        setLayer={trackedSetLayer}
         composite={composite}
         setComposite={setComposite}
         sstMode={sstMode}
-        setSstMode={setSstMode}
+        setSstMode={trackedSetSstMode}
         sstSel={sstSel}
         setSstSel={setSstSel}
         sstForecastSel={sstForecastSel}
@@ -458,6 +482,7 @@ function TopBar({ onSettings, settingsOpen, dataState }) {
           rel="noopener noreferrer"
           className="tip-fish"
           title="Tip the creator on Venmo (@michaelpjob)"
+          onClick={() => track("tip_click", { source: "topbar" })}
         >
           <svg
             className="tip-fish-icon"
@@ -603,7 +628,17 @@ function DesktopView({ layer, setLayer, composite, setComposite, sstMode, setSst
   const stageRef = useRef(null);
   const [size, setSize] = useState({ w: 1200, h: 700 });
   const [hover, setHover] = useState(null);
-  const [activeSpot, setActiveSpot] = useState("lajolla");
+  const [activeSpot, setActiveSpotRaw] = useState("lajolla");
+  // Wrap setActiveSpot so every saved-spot click — desktop list or
+  // mobile sheet — fires one analytics event. Answers "which spots
+  // do users actually look at, and is it the same on mobile vs
+  // desktop?".
+  const setActiveSpot = (next) => {
+    if (next !== activeSpot) {
+      track("spot_click", { from: activeSpot, to: next, layer });
+    }
+    setActiveSpotRaw(next);
+  };
   const [infoOpen, setInfoOpen] = useState(true);
   const [controlsOpen, setControlsOpen] = useState(true);
   const [spotsOpen, setSpotsOpen] = useState(true);
@@ -1111,7 +1146,10 @@ function DesktopView({ layer, setLayer, composite, setComposite, sstMode, setSst
           width={size.w}
           height={size.h}
           active={mpaOn}
-          onSelect={setSelectedMpa}
+          onSelect={(mpa) => {
+            track("popup_open", { kind: "mpa", type: mpa?.type || "unknown" });
+            setSelectedMpa(mpa);
+          }}
         />
 
         <BathyLayer
@@ -1119,7 +1157,10 @@ function DesktopView({ layer, setLayer, composite, setComposite, sstMode, setSst
           height={size.h}
           active={bathyOn}
           zoomLevel={zoomLevel}
-          onSelect={setSelectedBathy}
+          onSelect={(feat) => {
+            track("popup_open", { kind: "bathy", class: feat?.class || "unknown" });
+            setSelectedBathy(feat);
+          }}
         />
 
         <g className="spot-pins">

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -1,0 +1,213 @@
+// Privacy-respecting in-app analytics.
+//
+// What this is:
+//   * A tiny event tracker that lets the React app emit named events
+//     ("layer_change", "spot_click", "settings_change", ...) with a
+//     small properties payload.
+//   * A buffered POST sender that batches events and ships them to
+//     /api/analytics/event (a Cloudflare Pages Function — see
+//     functions/api/analytics/event.js) every 30s and on tab close.
+//
+// What this is NOT:
+//   * No cookies. Each session generates a random 64-bit ID held in
+//     sessionStorage; it lives only until the tab closes.
+//   * No third-party trackers. All events go to our own /api endpoint
+//     served from the same origin (no CORS, no leakage).
+//   * No PII. We send: event name, named props, the layer the user
+//     was viewing, viewport size class (mobile/desktop), local UTC
+//     hour, and the random session ID. We don't send IP, user-agent,
+//     coordinates, or saved-spot identity beyond what the user's
+//     current click implies.
+//
+// What you can ask of the data:
+//   * "How many sessions per day?" — count distinct session_id
+//   * "Most-viewed layer?" — count layer_change events grouped by `to`
+//   * "Are people actually clicking the SST forecast toggle?" —
+//     count sst_mode_change events
+//   * "Is mobile-vs-desktop usage 50/50 or 90/10?" — group by viewport
+//
+// Phase 1 (this file): events are just logged by the Pages Function.
+// You read them in the Cloudflare dashboard's Real-time Logs tab.
+// Phase 2 (follow-up): events get persisted to a Cloudflare KV
+// namespace + aggregated nightly into a JSON published at /stats.
+
+const ENDPOINT = "/api/analytics/event";
+const FLUSH_INTERVAL_MS = 30_000;
+const MAX_BUFFER = 25;
+
+// 64-bit random ID; sessionStorage keeps it alive across page reloads
+// within the same tab but expires when the tab closes. Different tab =
+// different session, which is the GA convention.
+function ensureSessionId() {
+  if (typeof window === "undefined") return null;
+  try {
+    let id = window.sessionStorage.getItem("sd:sid");
+    if (id) return id;
+    const buf = new Uint8Array(8);
+    (window.crypto || {}).getRandomValues?.(buf);
+    id = Array.from(buf, (b) => b.toString(16).padStart(2, "0")).join("");
+    window.sessionStorage.setItem("sd:sid", id);
+    return id;
+  } catch {
+    // Private mode / storage disabled — we still want events to flow.
+    return "no-session";
+  }
+}
+
+function viewportClass() {
+  if (typeof window === "undefined") return "unknown";
+  const w = window.innerWidth || 0;
+  if (w < 600) return "mobile";
+  if (w < 1024) return "tablet";
+  return "desktop";
+}
+
+function pad(n) {
+  return n < 10 ? "0" + n : "" + n;
+}
+
+function nowIsoMinute() {
+  // Truncate to the minute. Cardinality of timestamps blows up the
+  // back-end aggregation cost otherwise. Minute-level is plenty for
+  // usage analytics; we don't need second-level.
+  const d = new Date();
+  return (
+    d.getUTCFullYear() +
+    "-" +
+    pad(d.getUTCMonth() + 1) +
+    "-" +
+    pad(d.getUTCDate()) +
+    "T" +
+    pad(d.getUTCHours()) +
+    ":" +
+    pad(d.getUTCMinutes()) +
+    "Z"
+  );
+}
+
+const _buffer = [];
+let _flushTimer = null;
+let _started = false;
+let _disabled = false;
+
+function send(payload) {
+  // sendBeacon is the only reliable way to ship events on tab close.
+  // It survives navigation away from the page where fetch() would
+  // be aborted. Cloudflare Pages Functions accept it as a normal POST.
+  try {
+    if (navigator.sendBeacon) {
+      const blob = new Blob([JSON.stringify(payload)], {
+        type: "application/json",
+      });
+      const ok = navigator.sendBeacon(ENDPOINT, blob);
+      if (ok) return true;
+    }
+  } catch {
+    // fall through to fetch
+  }
+  try {
+    fetch(ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      keepalive: true,
+    }).catch(() => {});
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function flush() {
+  if (_disabled) return;
+  if (_buffer.length === 0) return;
+  const events = _buffer.splice(0, _buffer.length);
+  send({
+    session_id: ensureSessionId(),
+    viewport: viewportClass(),
+    sent_at: nowIsoMinute(),
+    events,
+  });
+}
+
+/**
+ * Fire-and-forget event tracker. Buffered + batched.
+ *
+ * @param {string} name e.g. "layer_change", "spot_click", "settings_change"
+ * @param {object} [props] flat object of safe primitives only
+ */
+export function track(name, props) {
+  if (_disabled || typeof window === "undefined") return;
+  if (!name) return;
+  // Defensive: only ship JSON-safe primitives. Drop functions, DOM
+  // nodes, etc. that callers might accidentally pass.
+  const safeProps = {};
+  if (props && typeof props === "object") {
+    for (const [k, v] of Object.entries(props)) {
+      const t = typeof v;
+      if (v === null || t === "string" || t === "number" || t === "boolean") {
+        safeProps[k] = v;
+      }
+    }
+  }
+  _buffer.push({
+    name,
+    ts: nowIsoMinute(),
+    props: safeProps,
+  });
+  if (_buffer.length >= MAX_BUFFER) flush();
+}
+
+/**
+ * Disable analytics for the rest of this page session. Honors
+ * Do-Not-Track and any user-set localStorage opt-out — call this
+ * from a settings UI if you build one.
+ */
+export function disableAnalytics() {
+  _disabled = true;
+  _buffer.length = 0;
+}
+
+/**
+ * Initialize buffered flush + page-load event. Call once from main.jsx.
+ */
+export function initAnalytics() {
+  if (_started || typeof window === "undefined") return;
+  _started = true;
+
+  // Honor the browser's Do-Not-Track signal. Privacy-respecting by
+  // default; users who set DNT get no telemetry, period.
+  if (window.navigator && window.navigator.doNotTrack === "1") {
+    _disabled = true;
+    return;
+  }
+  // Honor a localStorage opt-out (so you can give users a UI later
+  // without having to re-add machinery).
+  try {
+    if (window.localStorage.getItem("sd:analytics:off") === "1") {
+      _disabled = true;
+      return;
+    }
+  } catch {
+    /* ignore */
+  }
+
+  // Initial pageview — fires once per tab. Subsequent navigations
+  // (none on a single-page app) would fire more.
+  track("pageview", {
+    path: window.location.pathname,
+    referrer: document.referrer ? new URL(document.referrer).host : "",
+    viewport: viewportClass(),
+  });
+
+  // Periodic flush so events ship even on long sessions where the
+  // user never navigates away.
+  _flushTimer = window.setInterval(flush, FLUSH_INTERVAL_MS);
+
+  // Ship buffered events on tab close / hide. visibilitychange covers
+  // mobile (where pagehide fires) AND desktop tab-close.
+  const onHide = () => flush();
+  window.addEventListener("visibilitychange", onHide);
+  window.addEventListener("pagehide", onHide);
+  window.addEventListener("beforeunload", onHide);
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,12 +2,23 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
 import "./styles/app.css";
+import { initAnalytics } from "./lib/analytics.js";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>
 );
+
+// Privacy-respecting in-app analytics. Honors Do-Not-Track + a
+// localStorage opt-out flag. No cookies, no third-party trackers,
+// no PII — events post to our own /api/analytics/event Pages
+// Function. See src/lib/analytics.js for the contract +
+// functions/api/analytics/event.js for the receiver.
+//
+// Init AFTER the React tree mounts so the pageview event isn't
+// counted before the app actually renders something visible.
+initAnalytics();
 
 // Register the service worker after the page has settled. Production only —
 // during dev the SW would intercept hot-reload assets and break Vite.


### PR DESCRIPTION
## Summary

Privacy-respecting in-app analytics. Phase 1: client-side event tracker + same-origin Cloudflare Pages Function that logs events to the dashboard's Real-time Logs tab. **Zero new infrastructure required** — works the moment it deploys.

## Architecture

```
React app  ──track(name, props)──►  src/lib/analytics.js (buffer + sendBeacon)
                                            │
                                            │  POST /api/analytics/event
                                            ▼
                          functions/api/analytics/event.js
                                            │
                                            ├── Phase 1 (today): console.log → Cloudflare Pages Logs
                                            └── Phase 2 (follow-up): also write to KV namespace
```

## Tracked events (server-side allowlist enforced)

| Event | Props | Answers the question |
|-------|-------|---|
| `pageview` | path, referrer, viewport | "How many sessions per day?" |
| `layer_change` | from, to | "Most-viewed layer? sst vs swell vs viz" |
| `sst_mode_change` | from, to | "Are people clicking the SST forecast toggle?" |
| `spot_click` | from, to, layer | "Which saved spots get clicked, on what layer?" |
| `popup_open` | kind, type/class | "Do people read MPA / bathy popups?" |
| `settings_change` | key, val | "Do users actually toggle theme / units / opacity?" |
| `tip_click` | source | "Does the WSB fish convert?" |

## Privacy contract

- **No cookies.** Random 64-bit session ID in `sessionStorage` only — dies on tab close.
- **No PII.** No IP, no User-Agent, no coordinates beyond what the user clicked.
- **No third-party trackers.** All events post to our own `/api` on the same origin.
- **Honors browser Do-Not-Track** — analytics never fires for those users.
- **Honors `localStorage["sd:analytics:off"]="1"`** — easy opt-out flag for users who set it manually (or for a future settings UI to toggle).
- **Country code logged** via `request.cf.country` — already anonymized by Cloudflare, useful aggregate signal.

## Defenses against abuse

The Pages Function:
- Caps request body at **16 KB**
- Caps events per batch at **50**
- Server-side **allowlist of event names** — anything not on the list is silently dropped (defends against client-side bugs flooding logs)
- Per-prop string truncation (64 chars) and key truncation (32 chars)
- Same-origin only — no CORS headers, browser refuses cross-origin POSTs to this endpoint
- Rejects every method except POST

## How to read events (today)

```bash
# Cloudflare dashboard → Workers & Pages → shouldidive → Logs tab → Live tail
# Or via wrangler:
npx wrangler pages deployment tail --project-name=shouldidive | grep ANALYTICS
```

Each event prints one compact-JSON line tagged `ANALYTICS`, e.g.:

```
ANALYTICS {"sid":"a1b2c3...","cc":"US","vp":"mobile","name":"layer_change","props":{"from":"sst","to":"swell"}}
```

## Phase 2 (follow-up PR — not in this one)

- Bind a Cloudflare KV namespace as `ANALYTICS_KV`
- Uncomment the KV write block in `functions/api/analytics/event.js`
- Build `/api/analytics/summary` that reads + aggregates
- Build a `/stats` page that renders the dashboard

Phase 1 alone gives you "what are users clicking right now" via live logs. Phase 2 turns that into a queryable dashboard with daily/weekly/monthly aggregates.

## Test plan

- [ ] Dev-checks all 11 jobs green
- [ ] After merge + first user visit: tail Cloudflare Pages logs, see `ANALYTICS pageview` events flow
- [ ] Click through layer chips, confirm `layer_change` events fire with correct from/to
- [ ] Toggle theme in Settings, confirm `settings_change` fires
- [ ] Click a saved spot, confirm `spot_click`
- [ ] On a DNT-enabled browser, confirm NO events fire (tail logs while clicking)

## Files changed

- `src/lib/analytics.js` (new) — 213 LOC. Buffered tracker, sendBeacon, DNT/opt-out.
- `functions/api/analytics/event.js` (new) — 167 LOC. Pages Function ingester.
- `src/main.jsx` — call `initAnalytics()` after React mount
- `src/App.jsx` — wrapped setters fire layer/sst-mode/spot/settings events; popup callbacks fire `popup_open`; tip-fish anchor fires `tip_click`
- `CLAUDE.md` / `AGENTS.md` — full architecture + privacy + how to add new event types

🤖 Generated with [Claude Code](https://claude.com/claude-code)
