### PR TITLE
fix: SST forecast slider — pipeline/loader/UI now agree on slot keys

### DIFF
--- a/pipeline/fetch_sst_5day.py
+++ b/pipeline/fetch_sst_5day.py
@@ -336,10 +336,19 @@ def main() -> int:
     manifest["layers"]["sst5d"] = {
         "summary_url":  "/data/sst5d/summary.json",
         "horizon_days": HORIZON_DAYS,
+        # ``range`` is the LayerSpec contract field that the
+        # manifest-validate dev-checks job enforces. ``range_c`` is
+        # kept as a legacy alias for any older readers that still
+        # depend on it. Drift between the contract and what we emit
+        # here was the cause of the pipeline-tests failure on
+        # PR #30 (and by extension the daily refresh-data run).
+        "range":        list(SST_RANGE_C),
         "range_c":      list(SST_RANGE_C),
+        "scale":        SST_SCALE,
         "unit":         SST_UNIT_C,
         "grid":         {"width": W, "height": H},
         "method":       "persistence_decay",
+        "beta":         True,
     }
     MANIFEST_PATH.write_text(json.dumps(manifest, indent=2))
     print(f"[sst5d] manifest entry written")

--- a/pipeline/fetch_sst_5day.py
+++ b/pipeline/fetch_sst_5day.py
@@ -271,11 +271,24 @@ def main() -> int:
             if np.any(np.isfinite(anom)) else None
         )
         days.append({
+            # ``slot`` is the in-memory key the frontend uses to reference
+            # this day in ``state.layers.sst[<slot>]``. The frontend's
+            # SstTimeline + sstSelToSlotKey + defaultSstSelection ALL
+            # require this field to exist; without it the loader's
+            # ``if (!d?.slot)`` guard skipped every day and the forecast
+            # heatmap silently never loaded (slider had nothing to render).
+            # Format ``f{lead}`` matches what fetch.py's parallel sst5d
+            # block emits, so the frontend stays consistent regardless
+            # of which forecaster wrote the most recent summary.
+            "slot":        f"f{d}",
             "day":         DAY_LABELS_REL[d],
             "offset":      d,
             "date":        (today + timedelta(days=d)).isoformat(),
             "url":         f"/data/sst5d/d{d}.png",
             "confidence":  CONFIDENCE_BY_DAY[d],
+            "mean":        st["mean"],     # frontend uses .mean for the
+                                           # timeline pill; mean_c kept
+                                           # below for backward compat.
             "mean_c":      st["mean"],
             "anom_c":      anom_mean,
             "min_c":       st["min"],
@@ -291,10 +304,20 @@ def main() -> int:
         "horizon_days": HORIZON_DAYS,
         "method":       "persistence_decay",
         "tz":           "UTC",
-        "range_c":      list(SST_RANGE_C),
+        "range":        list(SST_RANGE_C),  # frontend's loader reads
+                                            # info.range || summary.range
+        "range_c":      list(SST_RANGE_C),  # legacy field; keep for any
+                                            # downstream that already
+                                            # depends on it
         "scale":        SST_SCALE,
         "unit":         SST_UNIT_C,
         "grid":         {"width": W, "height": H},
+        # Defaults the frontend uses to pick the initial slider position
+        # before the user moves it. f0 = today.
+        "default_slot": "f0",
+        "latest_slot":  "f0",
+        "beta":         True,  # tells the SstModeToggle this is the beta
+                               # forecast tier; matches fetch.py emission
         "days":         days,
     }
     (SST5D_DIR / "summary.json").write_text(json.dumps(summary, indent=2))

--- a/public/data/manifest.json
+++ b/public/data/manifest.json
@@ -532,16 +532,22 @@
     "sst5d": {
       "summary_url": "/data/sst5d/summary.json",
       "horizon_days": 7,
+      "range": [
+        9.0,
+        25.0
+      ],
       "range_c": [
         9.0,
         25.0
       ],
+      "scale": "linear",
       "unit": "degC",
+      "beta": true,
+      "method": "persistence_decay",
       "grid": {
         "width": 144,
         "height": 117
-      },
-      "method": "persistence_decay"
+      }
     }
   }
 }

--- a/public/data/sst5d/summary.json
+++ b/public/data/sst5d/summary.json
@@ -3,6 +3,10 @@
   "horizon_days": 7,
   "method": "persistence_decay",
   "tz": "UTC",
+  "range": [
+    9.0,
+    25.0
+  ],
   "range_c": [
     9.0,
     25.0
@@ -13,13 +17,18 @@
     "width": 144,
     "height": 117
   },
+  "default_slot": "f0",
+  "latest_slot": "f0",
+  "beta": true,
   "days": [
     {
+      "slot": "f0",
       "day": "Today",
       "offset": 0,
       "date": "2026-05-09",
       "url": "/data/sst5d/d0.png",
       "confidence": "high",
+      "mean": 16.12,
       "mean_c": 16.12,
       "anom_c": 1.15,
       "min_c": 11.77,
@@ -27,11 +36,13 @@
       "coverage_frac": 0.596
     },
     {
+      "slot": "f1",
       "day": "+1",
       "offset": 1,
       "date": "2026-05-10",
       "url": "/data/sst5d/d1.png",
       "confidence": "high",
+      "mean": 16.05,
       "mean_c": 16.05,
       "anom_c": 1.08,
       "min_c": 11.62,
@@ -39,11 +50,13 @@
       "coverage_frac": 0.596
     },
     {
+      "slot": "f2",
       "day": "+2",
       "offset": 2,
       "date": "2026-05-11",
       "url": "/data/sst5d/d2.png",
       "confidence": "medium",
+      "mean": 15.99,
       "mean_c": 15.99,
       "anom_c": 1.02,
       "min_c": 11.38,
@@ -51,11 +64,13 @@
       "coverage_frac": 0.596
     },
     {
+      "slot": "f3",
       "day": "+3",
       "offset": 3,
       "date": "2026-05-12",
       "url": "/data/sst5d/d3.png",
       "confidence": "medium",
+      "mean": 15.93,
       "mean_c": 15.93,
       "anom_c": 0.96,
       "min_c": 11.17,
@@ -63,11 +78,13 @@
       "coverage_frac": 0.596
     },
     {
+      "slot": "f4",
       "day": "+4",
       "offset": 4,
       "date": "2026-05-13",
       "url": "/data/sst5d/d4.png",
       "confidence": "low",
+      "mean": 15.87,
       "mean_c": 15.87,
       "anom_c": 0.9,
       "min_c": 10.99,
@@ -75,11 +92,13 @@
       "coverage_frac": 0.596
     },
     {
+      "slot": "f5",
       "day": "+5",
       "offset": 5,
       "date": "2026-05-14",
       "url": "/data/sst5d/d5.png",
       "confidence": "low",
+      "mean": 15.82,
       "mean_c": 15.82,
       "anom_c": 0.85,
       "min_c": 10.84,
@@ -87,11 +106,13 @@
       "coverage_frac": 0.596
     },
     {
+      "slot": "f6",
       "day": "+6",
       "offset": 6,
       "date": "2026-05-15",
       "url": "/data/sst5d/d6.png",
       "confidence": "low",
+      "mean": 15.77,
       "mean_c": 15.77,
       "anom_c": 0.8,
       "min_c": 10.63,

--- a/src/components/SstTimeline.jsx
+++ b/src/components/SstTimeline.jsx
@@ -137,7 +137,10 @@ export default function SstTimeline({ sel, setSel, units, mode = "history" }) {
   const days = summary?.days || [];
   const numDays = days.length;
   const slot = sstSelToSlotKey(sel, summary);
-  const idx = Math.max(0, days.findIndex((d) => d.slot === slot));
+  // Match the same effectiveSlot resolution used by the helpers above
+  // so legacy summaries (no per-day .slot field) still position the
+  // playhead correctly when slot keys are synthesized as f<offset>.
+  const idx = Math.max(0, days.findIndex((d, i) => effectiveSlot(d, i) === slot));
 
   const drag = useTimelineDrag({
     ref,
@@ -151,7 +154,7 @@ export default function SstTimeline({ sel, setSel, units, mode = "history" }) {
     targetToFrac: (i) => (numDays > 1 ? i / (numDays - 1) : 0),
     onCommit: (nextIdx) => {
       const next = days[nextIdx];
-      if (next) setSel({ slot: next.slot });
+      if (next) setSel({ slot: effectiveSlot(next, nextIdx) });
     },
     step: (cur, delta) =>
       Math.max(0, Math.min(numDays - 1, cur + delta)),
@@ -174,7 +177,7 @@ export default function SstTimeline({ sel, setSel, units, mode = "history" }) {
     const width = 100 / numDays;
     return (
       <div
-        key={d.slot}
+        key={effectiveSlot(d, i)}
         className={`tl-day-cell ${i % 2 === 0 ? "even" : "odd"} conf-${d.confidence || "high"}`}
         style={{ left: `${left}%`, width: `${width}%` }}
       >
@@ -189,7 +192,7 @@ export default function SstTimeline({ sel, setSel, units, mode = "history" }) {
     const left = numDays > 1 ? (i / (numDays - 1)) * 100 : 0;
     return (
       <div
-        key={d.slot}
+        key={effectiveSlot(d, i)}
         className={`tl-tick ${i === 0 ? "day" : "major"}`}
         style={{ left: `${left}%` }}
       />
@@ -239,14 +242,35 @@ export default function SstTimeline({ sel, setSel, units, mode = "history" }) {
   );
 }
 
+// Tolerate summaries that omit the `slot` field on each day (legacy
+// fetch_sst_5day.py emissions before the 2026-05-09 fix). The loader
+// in src/lib/loaders/sst5d.js synthesizes `f<offset>` keys when the
+// slot is missing — the timeline must use the same synthesis so the
+// slider's `days` array references the same keys the loader wrote.
+//
+// Resolution order (must match loaders/sst5d.js):
+//   explicit d.slot  →  "f<offset>" if offset is an integer  →  "f<idx>"
+function effectiveSlot(d, idx) {
+  if (d?.slot) return d.slot;
+  if (Number.isInteger(d?.offset)) return `f${d.offset}`;
+  return `f${idx}`;
+}
+
 export function defaultSstSelection(summary) {
-  const slot = summary?.default_slot || summary?.latest_slot || summary?.days?.[summary.days.length - 1]?.slot;
-  return { slot: slot || "d0" };
+  const days = summary?.days || [];
+  const explicit = summary?.default_slot || summary?.latest_slot;
+  if (explicit) return { slot: explicit };
+  if (days.length === 0) return { slot: "d0" };
+  // Last day is the most-recent observation for history (sst7d) and
+  // furthest-out forecast for sst5d. defaultSstSelection used to
+  // pick the LAST day for both; matches the existing behaviour.
+  const last = days[days.length - 1];
+  return { slot: effectiveSlot(last, days.length - 1) };
 }
 
 export function sstSelectionHasData(summary, sel) {
   if (!summary?.days?.length || !sel?.slot) return false;
-  return summary.days.some((d) => d.slot === sel.slot);
+  return summary.days.some((d, idx) => effectiveSlot(d, idx) === sel.slot);
 }
 
 export function sstSelToSlotKey(sel, summary = null) {

--- a/src/lib/loaders/sst5d.js
+++ b/src/lib/loaders/sst5d.js
@@ -1,10 +1,23 @@
 // SST 5-day forecast loader. Same pattern as sst7d: fetch summary,
 // decode per-day PNGs in parallel, write into state.layers.sst[<slot>]
-// keyed by forecast slot (f0..f4) with history:false / forecast:true
-// to differentiate from history slots.
+// keyed by forecast slot (f0..f4/f6) with forecast:true so the
+// timeline UI can distinguish it from observed history.
 //
 // Carved out of dataSource.js loadManifest's if/else if chain on
 // 2026-05-09 (Tier-1 follow-up).
+//
+// Defensive slot synthesis (added 2026-05-09 fix):
+//   The committed summary.json that ships from fetch_sst_5day.py
+//   used to omit the `slot` field on each day. Without it the
+//   loader's `if (!d?.slot)` guard silently dropped every day,
+//   nothing got written to state.layers.sst.f0..fN, and the
+//   forecast slider had no data to render. The pipeline is fixed
+//   to emit `slot: "f<offset>"` going forward; this loader also
+//   synthesizes the slot from `offset` (or the day's index in the
+//   array) so a legacy summary still loads correctly. Same for
+//   range/scale fallbacks: the loader now treats summary-level
+//   `range_c` and a default linear `scale` as valid, matching
+//   what fetch_sst_5day.py emits and what fetch.py emits.
 
 import { decodePng } from "./decoders.js";
 
@@ -16,24 +29,33 @@ export async function loadSst5d(info, state) {
     state.layers.sst5d = { summary };
     state.layers.sst = state.layers.sst || {};
     const scale = info.scale || summary.scale || "linear";
-    const range = info.range || summary.range;
+    // Tolerate either ``range`` (preferred — matches fetch.py) or
+    // ``range_c`` (legacy from fetch_sst_5day.py before today's fix).
+    const range = info.range || summary.range || summary.range_c;
     if (!range) throw new Error("sst5d has no range");
     const tasks = [];
-    for (const d of summary.days || []) {
-      if (!d?.slot || !d?.url) continue;
+    (summary.days || []).forEach((d, idx) => {
+      if (!d?.url) return;
+      // Slot resolution waterfall: explicit slot > "f<offset>" >
+      // "f<idx>". The first arm matches fetch.py emissions; the
+      // second matches fetch_sst_5day.py emissions (offset is
+      // always present); the third is a last-resort fallback.
+      const slot =
+        d.slot ||
+        (Number.isInteger(d.offset) ? `f${d.offset}` : `f${idx}`);
       tasks.push(
         decodePng(d.url, scale, range)
           .then((decoded) => {
-            state.layers.sst[d.slot] = {
+            state.layers.sst[slot] = {
               ...decoded,
               dates: d.date ? [d.date] : [],
               forecast: true,
               stats: d,
             };
           })
-          .catch((e) => console.warn(`sst5d ${d.slot} failed`, e))
+          .catch((e) => console.warn(`sst5d ${slot} failed`, e))
       );
-    }
+    });
     await Promise.all(tasks);
   } catch (e) {
     console.warn("dataSource: sst5d summary load failed", e);


### PR DESCRIPTION
## Summary

User-reported bug: "the forecasting temp slider doesn't seem to be working". Diagnosed + fixed across three layers.

## Root cause

`pipeline/fetch_sst_5day.py` was writing `public/data/sst5d/summary.json` with each day having `day`, `offset`, `date`, `url` — but **no `slot` field**. The frontend's loader requires `d.slot` to be truthy via:

```js
for (const d of summary.days || []) {
  if (!d?.slot || !d?.url) continue;   // ← every day skipped
  ...
}
```

→ no forecast PNGs ever loaded → `state.layers.sst.f0..f6` empty → DataOverlay's `getLayerGrid("sst", "f1")` returned null → slider rendered but heatmap never updated when dragged.

Compounding it: `pipeline/fetch.py` (around line 350) writes the **correct** shape with `slot: "f0"`, `default_slot: "f0"`, etc. But `pipeline/fetch_sst_5day.py` runs later in `refresh-data.yml` and overwrites the good summary with the stripped-down format. The deployed JSON has been the broken version since 2026-05-07.

## Fix — defense in depth across three layers

| Layer | File | Change |
|-------|------|--------|
| Pipeline | `pipeline/fetch_sst_5day.py` | Emit `slot: f"f{d}"` per day; add `default_slot`, `latest_slot`, `beta`, top-level `range` (alongside legacy `range_c`); add top-level `mean` per day for the timeline pill. |
| Loader | `src/lib/loaders/sst5d.js` | Defensive slot synthesis: `d.slot` → `"f<offset>"` if offset is integer → `"f<idx>"`. Tolerates `range_c` fallback. Legacy summaries still load. |
| UI | `src/components/SstTimeline.jsx` | New private `effectiveSlot(d, idx)` helper used in `defaultSstSelection`, `sstSelectionHasData`, the slider's `findIndex`, `onCommit`, and React keys. |
| Live data | `public/data/sst5d/summary.json` | Manually patched the currently-committed file to add `slot`/`default_slot`/`latest_slot`/`range`/`beta`/per-day `mean`. Without this, the live site stays broken for ~24h waiting for the next cron. |

## Why all four

- **Pipeline fix alone:** live site stays broken for 24h. Patching the JSON closes the gap.
- **Loader/UI alone:** future pipeline scripts could regress this without anyone noticing.
- **All four:** defense-in-depth. Future emitters that drop slot are recovered by the loader. The UI tolerates either world.

## Verification

**Reproduce on main right now:** load shouldidive.com → click "Forecast" toggle in the SST panel → drag the slider. Badge updates ("16.1 °F"), but the heatmap stays frozen on f0.

**After this lands:**
1. Committed summary.json has slot fields → loader writes `state.layers.sst[f0..f6]` on first load
2. Slider drag → `setSstForecastSel({slot: "f1"})` → re-render → `getLayerGrid("sst", "f1")` returns the f1 forecast grid → heatmap updates
3. Next refresh-data cron writes a fresh summary in the new shape — no regression

## Test plan

- [ ] Dev-checks 11 jobs green (no test pins SstTimeline internals; the source-grep contracts only check the App.jsx + MobileSheet.jsx JSX which I didn't touch)
- [ ] After merge + deploy: the SST forecast slider visually updates the heatmap as the playhead moves f0 → f6
- [ ] `live-cp-render` puppeteer check stays green (it asserts the primary layer paints; SST forecast is on the same heatmap pipeline)

## Out of scope

- The dual-emitter situation (`fetch.py` and `fetch_sst_5day.py` both write `sst5d/summary.json`). Fix here is to make both produce the same shape; the question of which one is the canonical forecaster (observed-trend vs zone-tau persistence-decay) deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
