### PR TITLE
CA-beta staging workflows

### DIFF
--- a/.github/workflows/refresh-ca-beta-data.yml
+++ b/.github/workflows/refresh-ca-beta-data.yml
@@ -1,0 +1,166 @@
+name: Refresh CA-beta — data (daily)
+
+# California STAGING — daily data refresh at 06:15 UTC (15 min after
+# CA prod's 06:00 slot). Same fetchers as refresh-ca-data.yml but
+# checks out `dev` (so it picks up the NorCal expansion + PR-NC-1 viz
+# calibration + any other in-progress work that hasn't reached main
+# yet), and deploys to ca-beta.shouldidive.pages.dev instead of
+# shouldidive.com.
+#
+# Cannot reach prod: wrangler --branch=ca-beta routes to a Cloudflare
+# Pages preview branch, never main.
+
+on:
+  schedule:
+    - cron: "15 6 * * *"
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Git ref to refresh against (default: dev)"
+        required: false
+        default: "dev"
+        type: string
+
+concurrency:
+  group: refresh-ca-beta-data
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    env:
+      SHOULDIDIVE_REGION: ca
+    permissions:
+      contents: write
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch || (github.event_name == 'schedule' && 'dev' || github.ref) }}
+          token: ${{ secrets.BOT_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pipeline/requirements.txt
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install pipeline dependencies
+        run: pip install -r pipeline/requirements.txt
+
+      - name: Fetch latest ocean data (SST, chl, kd490)
+        continue-on-error: true
+        timeout-minutes: 15
+        env:
+          EARTHDATA_TOKEN: ${{ secrets.EARTHDATA_TOKEN }}
+        run: python pipeline/fetch.py
+
+      - name: Fetch 7-day precipitation
+        continue-on-error: true
+        timeout-minutes: 5
+        run: python pipeline/fetch_precip.py
+
+      - name: Fetch CA river discharge (USGS NWIS)
+        continue-on-error: true
+        timeout-minutes: 5
+        run: python pipeline/fetch_rivers.py
+
+      - name: Fetch CA tide range (NOAA CO-OPS)
+        continue-on-error: true
+        timeout-minutes: 5
+        run: python pipeline/fetch_tides.py
+
+      - name: Refresh climatology if needed
+        continue-on-error: true
+        run: python pipeline/fetch_climatology.py
+
+      - name: Fetch bathymetry (one-shot)
+        continue-on-error: true
+        timeout-minutes: 5
+        run: python pipeline/fetch_bathy.py
+
+      - name: Fetch coastline (one-shot)
+        continue-on-error: true
+        timeout-minutes: 8
+        run: python pipeline/fetch_coastline.py
+
+      - name: Fetch MPA boundaries
+        continue-on-error: true
+        timeout-minutes: 5
+        run: python pipeline/fetch_mpa.py
+
+      - name: Probe all external feeds
+        continue-on-error: true
+        timeout-minutes: 5
+        env:
+          EARTHDATA_TOKEN: ${{ secrets.EARTHDATA_TOKEN }}
+        run: python pipeline/check_feeds.py
+
+      - name: Run 5-day SST forecast
+        continue-on-error: true
+        run: python pipeline/fetch_sst_5day.py
+
+      - name: Run visibility prediction
+        continue-on-error: true
+        run: python pipeline/fetch_visibility.py
+
+      - name: Assert chl freshness sidecar
+        continue-on-error: true
+        run: python -m pipeline.tests.assert_outputs fetch_chl
+
+      - name: Assert visibility outputs
+        continue-on-error: true
+        run: python -m pipeline.tests.assert_outputs visibility
+
+      - name: Assert local manifest freshness budgets
+        continue-on-error: true
+        run: python pipeline/check_manifest_freshness.py --layers sst,sst7d,sst5d,chl,kd490,viz,wave,precip --check-sst-source
+
+      - name: Install JS dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages (ca-beta preview)
+        # Soft-fail (matching pnw-beta/tropical-beta) so a Cloudflare
+        # auth/quota issue doesn't block the commit step below.
+        continue-on-error: true
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=shouldidive --branch=ca-beta --commit-dirty=true
+
+      - name: Commit refreshed CA-beta data
+        if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          # CA writes to public/data/ (no region subdir) — same path as
+          # prod, but commits land on dev (not main), so prod's tree is
+          # untouched. Validation sidecars are CA-keyed; commit them too
+          # so dev's preview shows the same watchdog state as prod.
+          git add public/data/
+          git add pipeline/validation/data/per_zone_metrics.json \
+                  pipeline/validation/data/residuals.jsonl \
+                  pipeline/validation/data/watchdog_summary.md \
+                  pipeline/validation/data/feed_health.json \
+                  pipeline/validation/data/freshness_health.json \
+                  pipeline/validation/data/ingest_health.json 2>/dev/null || true
+          if git diff --staged --quiet; then
+            echo "No CA-beta data changes to commit."
+          else
+            git commit -m "data: refresh ca-beta $(date -u +%Y-%m-%d)"
+            for attempt in 1 2 3; do
+              if git push; then break; fi
+              echo "push failed (attempt $attempt) — rebasing"
+              git pull --rebase --autostash origin "$(git rev-parse --abbrev-ref HEAD)"
+            done
+          fi

--- a/.github/workflows/refresh-ca-beta-wind.yml
+++ b/.github/workflows/refresh-ca-beta-wind.yml
@@ -1,0 +1,109 @@
+name: Refresh CA-beta — wind (hourly)
+
+# California STAGING — HOURLY wind/swell/currents at :50 past every
+# hour (15 min after tropical's :45 slot, last open slot in the hour
+# so we don't crowd NOAA NOMADS). Checks out `dev` for the latest
+# multi-region code; deploys to ca-beta.shouldidive.pages.dev.
+
+on:
+  schedule:
+    - cron: "50 * * * *"
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Git ref to refresh against (default: dev)"
+        required: false
+        default: "dev"
+        type: string
+
+concurrency:
+  group: refresh-ca-beta-wind
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    env:
+      SHOULDIDIVE_REGION: ca
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch || (github.event_name == 'schedule' && 'dev' || github.ref) }}
+          token: ${{ secrets.BOT_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pipeline/requirements.txt
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install pipeline dependencies
+        run: pip install -r pipeline/requirements.txt
+
+      - name: Fetch wind (HRRR now / +6h / +24h)
+        continue-on-error: true
+        timeout-minutes: 5
+        run: python pipeline/fetch_wind.py
+
+      - name: Fetch 5-day hourly wind
+        continue-on-error: true
+        timeout-minutes: 15
+        run: python pipeline/fetch_wind_5day.py
+
+      - name: Fetch 5-day hourly swell
+        continue-on-error: true
+        timeout-minutes: 10
+        run: python pipeline/fetch_swell_5day.py
+
+      - name: Fetch WaveWatch III nowcast
+        continue-on-error: true
+        timeout-minutes: 5
+        run: python pipeline/fetch_waves.py
+
+      - name: Fetch surface currents
+        continue-on-error: true
+        timeout-minutes: 5
+        run: python pipeline/fetch_currents.py
+
+      - name: Assert wind/swell freshness budgets
+        continue-on-error: true
+        run: python pipeline/check_manifest_freshness.py --layers wind,wind5d,swell5d,current5d --skip-top-level
+
+      - name: Install JS dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages (ca-beta preview)
+        continue-on-error: true
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=shouldidive --branch=ca-beta --commit-dirty=true
+
+      - name: Commit refreshed CA-beta wind data
+        if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add public/data/
+          if git diff --staged --quiet; then
+            echo "No CA-beta wind data changes to commit."
+          else
+            git commit -m "wind: refresh ca-beta $(date -u +%Y-%m-%dT%H:%MZ)"
+            for attempt in 1 2 3; do
+              if git push; then break; fi
+              echo "push failed (attempt $attempt) — rebasing"
+              git pull --rebase --autostash origin "$(git rev-parse --abbrev-ref HEAD)"
+            done
+          fi


### PR DESCRIPTION
## Summary

Adds two new workflows that publish dev's bundle to a dedicated CA staging URL: **`ca-beta.shouldidive.pages.dev`**. Lets you exercise the NorCal expansion + PR-NC-1 viz calibration + any other in-progress multi-region work against real CA data WITHOUT touching `shouldidive.com`.

| Workflow | Cadence | Deploys to |
|---|---|---|
| `refresh-ca-beta-data.yml` | daily 06:15 UTC | `ca-beta.shouldidive.pages.dev` |
| `refresh-ca-beta-wind.yml` | hourly :50 | `ca-beta.shouldidive.pages.dev` |

**Workflow files only** — no app code, data, or routing changes.

## Production safety

Cannot reach `shouldidive.com`:
- Both workflows use `wrangler pages deploy --branch=ca-beta`. The production branch (`main`) is locked to `refresh-ca-data.yml` + `refresh-ca-wind.yml`.
- Both check out `dev` on the schedule path. Even a manual dispatch defaults to `dev`.
- Deploy step is `continue-on-error: true` so a Cloudflare hiccup can't break the data commit.

## Cadence offsets

Daily slots: CA prod 06:00 → CA-beta **06:15** → PNW 06:30 → tropical 07:00.
Hourly slots: CA prod :15 → PNW :30 → tropical :45 → CA-beta **:50**.

15-min spread keeps the four refreshes from competing for NOAA NOMADS rate limits.

## What CA-beta will show

Same `/data/` tree as prod (no region subdir for ca), but the BUNDLE deployed comes from `dev`, which currently carries:
- Full-coast bbox (lat 31.8 → 42.0°N, NorCal expansion)
- PR-NC-1 visibility model coefficients (`norcal_nearshore`, `norcal_islands`, `norcal_offshore`)
- Region-aware SST encoding range (CA: [9, 25]°C)
- The frontend hostname-lock that pins `ca-beta.*` to `region=ca` and hides the RegionSwitcher

## Test plan

- [ ] Merge → dispatch `refresh-ca-beta-data` against dev → verify `ca-beta.shouldidive.pages.dev` returns 200
- [ ] Confirm the deployed bundle has the NorCal viz coefficients (compare against dev preview)
- [ ] Wait for first scheduled run at 06:15 UTC → confirm cadence