### PR TITLE
Bypass cloudflare/wrangler-action@v3 (broken)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -58,14 +58,19 @@ jobs:
         run: npm run build
 
       - name: Deploy to Cloudflare Pages (dev branch)
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          # --branch=dev tags this deploy as a preview (not production).
-          # CF Pages routes dev preview deploys to dev.shouldidive.pages.dev
-          # automatically; production at shouldidive.com is unaffected.
-          command: pages deploy dist --project-name=shouldidive --branch=dev --commit-dirty=true
+        # --branch=dev tags this deploy as a preview (not production).
+        # CF Pages routes dev preview deploys to dev.shouldidive.pages.dev
+        # automatically; production at shouldidive.com is unaffected.
+        # Bypass cloudflare/wrangler-action@v3 — moving tag broke
+        # 2026-05-13 with 'Headers.set: *** invalid header value' under
+        # the newer wrangler's strict fetch. Direct invocation + token
+        # whitespace strip + pinned wrangler version.
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          export CLOUDFLARE_API_TOKEN=$(printf '%s' "$CLOUDFLARE_API_TOKEN" | tr -d '[:space:]')
+          npx wrangler@4.85.0 pages deploy dist --project-name=shouldidive --branch=dev --commit-dirty=true
 
       - name: Annotate run with preview URL
         run: |

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -65,13 +65,15 @@ jobs:
         run: npm run build
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          # --branch=main marks this deploy as production. CF Pages
-          # routes it to shouldidive.com (the production custom domain).
-          command: pages deploy dist --project-name=shouldidive --branch=main --commit-dirty=true
+        # --branch=main marks this deploy as production. CF Pages
+        # routes it to shouldidive.com (the production custom domain).
+        # Bypass cloudflare/wrangler-action@v3 (broken 2026-05-13).
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          export CLOUDFLARE_API_TOKEN=$(printf '%s' "$CLOUDFLARE_API_TOKEN" | tr -d '[:space:]')
+          npx wrangler@4.85.0 pages deploy dist --project-name=shouldidive --branch=main --commit-dirty=true
 
       - name: Annotate run summary
         run: |

--- a/.github/workflows/refresh-ca-beta-data.yml
+++ b/.github/workflows/refresh-ca-beta-data.yml
@@ -132,12 +132,16 @@ jobs:
         # Soft-fail (matching pnw-beta/tropical-beta) so a Cloudflare
         # auth/quota issue doesn't block the commit step below.
         continue-on-error: true
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=shouldidive --branch=ca-beta --commit-dirty=true
-
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          # Bypass cloudflare/wrangler-action@v3 — moving tag started
+          # rejecting tokens with whitespace 2026-05-13 (Headers.set strict
+          # validation in newer wrangler). Strip whitespace defensively
+          # and call wrangler directly with a pinned version.
+          export CLOUDFLARE_API_TOKEN=$(printf '%s' "$CLOUDFLARE_API_TOKEN" | tr -d '[:space:]')
+          npx wrangler@4.85.0 pages deploy dist --project-name=shouldidive --branch=ca-beta --commit-dirty=true
       - name: Commit refreshed CA-beta data
         if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         run: |

--- a/.github/workflows/refresh-ca-beta-wind.yml
+++ b/.github/workflows/refresh-ca-beta-wind.yml
@@ -85,12 +85,16 @@ jobs:
 
       - name: Deploy to Cloudflare Pages (ca-beta preview)
         continue-on-error: true
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=shouldidive --branch=ca-beta --commit-dirty=true
-
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          # Bypass cloudflare/wrangler-action@v3 — moving tag started
+          # rejecting tokens with whitespace 2026-05-13 (Headers.set strict
+          # validation in newer wrangler). Strip whitespace defensively
+          # and call wrangler directly with a pinned version.
+          export CLOUDFLARE_API_TOKEN=$(printf '%s' "$CLOUDFLARE_API_TOKEN" | tr -d '[:space:]')
+          npx wrangler@4.85.0 pages deploy dist --project-name=shouldidive --branch=ca-beta --commit-dirty=true
       - name: Commit refreshed CA-beta wind data
         if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         run: |

--- a/.github/workflows/refresh-ca-data.yml
+++ b/.github/workflows/refresh-ca-data.yml
@@ -185,12 +185,16 @@ jobs:
 
       - name: Deploy to Cloudflare Pages (production)
         if: github.ref == 'refs/heads/main'
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=shouldidive --branch=main --commit-dirty=true
-
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          # Bypass cloudflare/wrangler-action@v3 — moving tag started
+          # rejecting tokens with whitespace 2026-05-13 (Headers.set strict
+          # validation in newer wrangler). Strip whitespace defensively
+          # and call wrangler directly with a pinned version.
+          export CLOUDFLARE_API_TOKEN=$(printf '%s' "$CLOUDFLARE_API_TOKEN" | tr -d '[:space:]')
+          npx wrangler@4.85.0 pages deploy dist --project-name=shouldidive --branch=main --commit-dirty=true
       - name: Commit refreshed data
         if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         run: |
@@ -210,6 +214,6 @@ jobs:
             for attempt in 1 2 3; do
               if git push; then break; fi
               echo "push failed (attempt $attempt) — rebasing"
-              git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
+              git pull --rebase --autostash origin "$(git rev-parse --abbrev-ref HEAD)"
             done
           fi

--- a/.github/workflows/refresh-ca-wind.yml
+++ b/.github/workflows/refresh-ca-wind.yml
@@ -90,12 +90,16 @@ jobs:
 
       - name: Deploy to Cloudflare Pages (production)
         if: github.ref == 'refs/heads/main'
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=shouldidive --branch=main --commit-dirty=true
-
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          # Bypass cloudflare/wrangler-action@v3 — moving tag started
+          # rejecting tokens with whitespace 2026-05-13 (Headers.set strict
+          # validation in newer wrangler). Strip whitespace defensively
+          # and call wrangler directly with a pinned version.
+          export CLOUDFLARE_API_TOKEN=$(printf '%s' "$CLOUDFLARE_API_TOKEN" | tr -d '[:space:]')
+          npx wrangler@4.85.0 pages deploy dist --project-name=shouldidive --branch=main --commit-dirty=true
       - name: Commit refreshed wind data
         if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         run: |
@@ -109,6 +113,6 @@ jobs:
             for attempt in 1 2 3; do
               if git push; then break; fi
               echo "push failed (attempt $attempt) — rebasing"
-              git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
+              git pull --rebase --autostash origin "$(git rev-parse --abbrev-ref HEAD)"
             done
           fi

--- a/.github/workflows/refresh-pnw-data.yml
+++ b/.github/workflows/refresh-pnw-data.yml
@@ -119,12 +119,23 @@ jobs:
         run: npm run build
 
       - name: Deploy to Cloudflare Pages (pnw-beta preview)
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=shouldidive --branch=pnw-beta --commit-dirty=true
-
+        # Soft-fail: a Cloudflare auth or quota hiccup must NOT block
+        # the commit-refreshed-data step below. Without continue-on-error,
+        # a 10001 'Unable to authenticate' (seen during the 2026-05-12
+        # rollout when the API token's permission scope on --branch=pnw-beta
+        # was still being figured out) cascaded into the commit step and
+        # dropped the fresh data on the floor.
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          # Bypass cloudflare/wrangler-action@v3 — moving tag started
+          # rejecting tokens with whitespace 2026-05-13 (Headers.set strict
+          # validation in newer wrangler). Strip whitespace defensively
+          # and call wrangler directly with a pinned version.
+          export CLOUDFLARE_API_TOKEN=$(printf '%s' "$CLOUDFLARE_API_TOKEN" | tr -d '[:space:]')
+          npx wrangler@4.85.0 pages deploy dist --project-name=shouldidive --branch=pnw-beta --commit-dirty=true
       - name: Commit refreshed PNW data
         if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         run: |
@@ -138,6 +149,6 @@ jobs:
             for attempt in 1 2 3; do
               if git push; then break; fi
               echo "push failed (attempt $attempt) — rebasing"
-              git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
+              git pull --rebase --autostash origin "$(git rev-parse --abbrev-ref HEAD)"
             done
           fi

--- a/.github/workflows/refresh-pnw-wind.yml
+++ b/.github/workflows/refresh-pnw-wind.yml
@@ -79,12 +79,18 @@ jobs:
         run: npm run build
 
       - name: Deploy to Cloudflare Pages (pnw-beta preview)
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=shouldidive --branch=pnw-beta --commit-dirty=true
-
+        # Soft-fail (see refresh-pnw-data.yml for context).
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          # Bypass cloudflare/wrangler-action@v3 — moving tag started
+          # rejecting tokens with whitespace 2026-05-13 (Headers.set strict
+          # validation in newer wrangler). Strip whitespace defensively
+          # and call wrangler directly with a pinned version.
+          export CLOUDFLARE_API_TOKEN=$(printf '%s' "$CLOUDFLARE_API_TOKEN" | tr -d '[:space:]')
+          npx wrangler@4.85.0 pages deploy dist --project-name=shouldidive --branch=pnw-beta --commit-dirty=true
       - name: Commit refreshed PNW wind data
         if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         run: |
@@ -98,6 +104,6 @@ jobs:
             for attempt in 1 2 3; do
               if git push; then break; fi
               echo "push failed (attempt $attempt) — rebasing"
-              git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
+              git pull --rebase --autostash origin "$(git rev-parse --abbrev-ref HEAD)"
             done
           fi

--- a/.github/workflows/refresh-tropical-data.yml
+++ b/.github/workflows/refresh-tropical-data.yml
@@ -114,12 +114,18 @@ jobs:
         run: npm run build
 
       - name: Deploy to Cloudflare Pages (tropical-beta preview)
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=shouldidive --branch=tropical-beta --commit-dirty=true
-
+        # Soft-fail (see refresh-pnw-data.yml for context).
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          # Bypass cloudflare/wrangler-action@v3 — moving tag started
+          # rejecting tokens with whitespace 2026-05-13 (Headers.set strict
+          # validation in newer wrangler). Strip whitespace defensively
+          # and call wrangler directly with a pinned version.
+          export CLOUDFLARE_API_TOKEN=$(printf '%s' "$CLOUDFLARE_API_TOKEN" | tr -d '[:space:]')
+          npx wrangler@4.85.0 pages deploy dist --project-name=shouldidive --branch=tropical-beta --commit-dirty=true
       - name: Commit refreshed tropical data
         if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         run: |
@@ -133,6 +139,6 @@ jobs:
             for attempt in 1 2 3; do
               if git push; then break; fi
               echo "push failed (attempt $attempt) — rebasing"
-              git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
+              git pull --rebase --autostash origin "$(git rev-parse --abbrev-ref HEAD)"
             done
           fi

--- a/.github/workflows/refresh-tropical-wind.yml
+++ b/.github/workflows/refresh-tropical-wind.yml
@@ -81,12 +81,18 @@ jobs:
         run: npm run build
 
       - name: Deploy to Cloudflare Pages (tropical-beta preview)
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=shouldidive --branch=tropical-beta --commit-dirty=true
-
+        # Soft-fail (see refresh-pnw-data.yml for context).
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          # Bypass cloudflare/wrangler-action@v3 — moving tag started
+          # rejecting tokens with whitespace 2026-05-13 (Headers.set strict
+          # validation in newer wrangler). Strip whitespace defensively
+          # and call wrangler directly with a pinned version.
+          export CLOUDFLARE_API_TOKEN=$(printf '%s' "$CLOUDFLARE_API_TOKEN" | tr -d '[:space:]')
+          npx wrangler@4.85.0 pages deploy dist --project-name=shouldidive --branch=tropical-beta --commit-dirty=true
       - name: Commit refreshed tropical wind data
         if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         run: |
@@ -100,6 +106,6 @@ jobs:
             for attempt in 1 2 3; do
               if git push; then break; fi
               echo "push failed (attempt $attempt) — rebasing"
-              git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
+              git pull --rebase --autostash origin "$(git rev-parse --abbrev-ref HEAD)"
             done
           fi


### PR DESCRIPTION
Workflow files only. cloudflare/wrangler-action@v3 is a moving tag that updated 2026-05-13 to a wrangler build using Node's strict built-in fetch — now rejects tokens with whitespace (Headers.set: invalid header value). Direct npx wrangler@4.85.0 + token-trim bypass validated on dev. Without this on main, scheduled deploys keep failing.