### PR TITLE
ops: register beta deploy workflows + composite action on main

### DIFF
--- a/.github/actions/deploy-cloudflare/action.yml
+++ b/.github/actions/deploy-cloudflare/action.yml
@@ -1,0 +1,70 @@
+name: 'Deploy to Cloudflare Pages'
+description: |
+  Build the React PWA bundle and deploy `dist/` to a Cloudflare Pages
+  branch. Wraps the wrangler-bypass workaround we adopted 2026-05-13
+  after cloudflare/wrangler-action@v3's moving tag started rejecting
+  tokens with whitespace under newer wrangler's strict header
+  validation. Once Cloudflare ships a fix upstream, swap the body of
+  this action back to `uses: cloudflare/wrangler-action@v3` and all
+  callers get the upgrade in one diff.
+
+  Callers MUST set these via the `env:` block on the `uses:` step:
+    CLOUDFLARE_API_TOKEN
+    CLOUDFLARE_ACCOUNT_ID
+
+inputs:
+  branch:
+    description: |
+      Cloudflare Pages branch to deploy to. `main` routes to the
+      production custom domain (shouldidive.com). Any other value
+      lands at `<branch>.shouldidive.pages.dev` as a preview branch.
+    required: true
+  project-name:
+    description: 'Cloudflare Pages project name.'
+    required: false
+    default: 'shouldidive'
+  wrangler-version:
+    description: |
+      Pinned wrangler version. Pinned (not `latest`) so a wrangler
+      release with another regression like the 2026-05-13 Headers.set
+      one can't take production down via a moving-tag deploy.
+    required: false
+    default: '4.85.0'
+  node-version:
+    description: 'Node version for build + wrangler.'
+    required: false
+    default: '20'
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: npm
+
+    - name: Install JS dependencies
+      shell: bash
+      # `npm install` rather than `npm ci` to tolerate lockfile drift.
+      # All deploy callers historically used `npm install` — keeping
+      # behavior identical to avoid surprise lockfile-related failures.
+      run: npm install --no-audit --no-fund
+
+    - name: Build
+      shell: bash
+      run: npm run build
+
+    - name: Deploy to Cloudflare Pages (${{ inputs.branch }})
+      shell: bash
+      run: |
+        # SC2155: declare + export on separate lines so the
+        # substitution's exit status isn't masked by `export`.
+        # Token whitespace strip defends against accidental
+        # newline/space in the GitHub secret (the 2026-05-13
+        # Headers.set: '*** invalid header value' failure mode).
+        CLOUDFLARE_API_TOKEN=$(printf '%s' "${CLOUDFLARE_API_TOKEN:-}" | tr -d '[:space:]')
+        export CLOUDFLARE_API_TOKEN
+        npx wrangler@${{ inputs.wrangler-version }} pages deploy dist \
+          --project-name=${{ inputs.project-name }} \
+          --branch=${{ inputs.branch }} \
+          --commit-dirty=true

--- a/.github/workflows/deploy-ca-beta.yml
+++ b/.github/workflows/deploy-ca-beta.yml
@@ -1,0 +1,67 @@
+name: Deploy ca-beta (code-only)
+
+# Code-only deploy to the ca-beta Cloudflare Pages preview branch.
+# Fires automatically after `dev-checks` passes on `dev`, OR via
+# manual workflow_dispatch (e.g. from the refresh-ca-beta-*.yml
+# workflows after they commit fresh data).
+#
+# Why this exists separately from refresh-ca-beta-data.yml:
+# Before, the only thing that pushed a bundle to ca-beta was the
+# DAILY data refresh. That meant every CSS / JSX tweak you wanted
+# to eyeball on ca-beta.shouldidive.pages.dev had to wait for the
+# next 06:15 UTC cron, or for a manual dispatch that triggered a
+# ~10 min data fetch first. This workflow is the iteration loop:
+# push to dev → dev-checks green → bundle on ca-beta in ~90 s.
+#
+# Cannot reach prod: wrangler --branch=ca-beta routes to the
+# Cloudflare Pages preview branch within the same project, never
+# the production custom domain at shouldidive.com.
+
+on:
+  workflow_run:
+    workflows: ["Dev checks"]
+    types: [completed]
+    branches: [dev]
+  workflow_dispatch:
+
+# A new push that arrives mid-deploy supersedes the in-flight one —
+# we only want the latest commit live. Old run is cancelled.
+concurrency:
+  group: deploy-ca-beta
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    # Only run if the upstream Dev checks succeeded — workflow_run
+    # fires on success AND failure, so gate explicitly.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # workflow_run runs on the default branch's HEAD by default;
+          # explicitly check out the same SHA dev-checks ran against
+          # so the preview matches what was tested.
+          ref: ${{ github.event.workflow_run.head_sha || 'dev' }}
+
+      - uses: ./.github/actions/deploy-cloudflare
+        with:
+          branch: ca-beta
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Annotate run with preview URL
+        run: |
+          {
+            echo "## CA-beta preview deployed"
+            echo
+            echo "Preview URL: https://ca-beta.shouldidive.pages.dev"
+            echo "Commit:      \`${{ github.event.workflow_run.head_sha || github.sha }}\`"
+            echo
+            echo "_Production at shouldidive.com is unchanged. CA-beta carries the NorCal expansion + PR-NC-1 viz calibration._"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-pnw-beta.yml
+++ b/.github/workflows/deploy-pnw-beta.yml
@@ -1,0 +1,55 @@
+name: Deploy pnw-beta (code-only)
+
+# Code-only deploy to the pnw-beta Cloudflare Pages preview branch.
+# Fires automatically after `dev-checks` passes on `dev`, OR via
+# manual workflow_dispatch (e.g. from refresh-pnw-*.yml workflows
+# after they commit fresh data).
+#
+# See deploy-ca-beta.yml for the broader rationale on splitting
+# code-deploy from data-refresh.
+#
+# Cannot reach prod: wrangler --branch=pnw-beta routes to the
+# Cloudflare Pages preview branch within the same project, never
+# the production custom domain.
+
+on:
+  workflow_run:
+    workflows: ["Dev checks"]
+    types: [completed]
+    branches: [dev]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-pnw-beta
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || 'dev' }}
+
+      - uses: ./.github/actions/deploy-cloudflare
+        with:
+          branch: pnw-beta
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Annotate run with preview URL
+        run: |
+          {
+            echo "## PNW-beta preview deployed"
+            echo
+            echo "Preview URL: https://pnw-beta.shouldidive.pages.dev"
+            echo "Commit:      \`${{ github.event.workflow_run.head_sha || github.sha }}\`"
+            echo
+            echo "_Production at shouldidive.com is unchanged._"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-tropical-beta.yml
+++ b/.github/workflows/deploy-tropical-beta.yml
@@ -1,0 +1,56 @@
+name: Deploy tropical-beta (code-only)
+
+# Code-only deploy to the tropical-beta Cloudflare Pages preview
+# branch (Florida + Gulf + Caribbean). Fires automatically after
+# `dev-checks` passes on `dev`, OR via manual workflow_dispatch
+# (e.g. from refresh-tropical-*.yml workflows after they commit
+# fresh data).
+#
+# See deploy-ca-beta.yml for the broader rationale on splitting
+# code-deploy from data-refresh.
+#
+# Cannot reach prod: wrangler --branch=tropical-beta routes to the
+# Cloudflare Pages preview branch within the same project, never
+# the production custom domain.
+
+on:
+  workflow_run:
+    workflows: ["Dev checks"]
+    types: [completed]
+    branches: [dev]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-tropical-beta
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || 'dev' }}
+
+      - uses: ./.github/actions/deploy-cloudflare
+        with:
+          branch: tropical-beta
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Annotate run with preview URL
+        run: |
+          {
+            echo "## tropical-beta preview deployed"
+            echo
+            echo "Preview URL: https://tropical-beta.shouldidive.pages.dev"
+            echo "Commit:      \`${{ github.event.workflow_run.head_sha || github.sha }}\`"
+            echo
+            echo "_Production at shouldidive.com is unchanged._"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Why

Surfaces 4 new workflow files on main so dev's per-region refresh workflows stop 404'ing at their trigger step.

The data/deploy-split refactor on dev ends each refresh-*-data.yml with:
```yaml
- name: Trigger {region}-beta deploy
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  run: gh workflow run deploy-{region}-beta.yml --ref dev
```

GitHub's workflow_dispatch API requires the target workflow file to exist on the **default branch** (main) — `--ref dev` only controls which ref the dispatched workflow checks out, not where the file lives. Without these 4 files on main, every refresh on tropical/pnw/ca-beta fails at the trigger step with `HTTP 404: workflow not found on the default branch`. Verified empirically against run 25779409394.

## What

- **NEW**: `.github/actions/deploy-cloudflare/action.yml` — local composite action wrapping the wrangler-bypass deploy step (setup-node + install + build + pinned `wrangler@4.85.0` + token-trim).
- **NEW**: `.github/workflows/deploy-ca-beta.yml`
- **NEW**: `.github/workflows/deploy-pnw-beta.yml`
- **NEW**: `.github/workflows/deploy-tropical-beta.yml`

Each beta deploy workflow:
- Triggers on `workflow_run` after `Dev checks` succeeds on dev (= auto-deploy on every dev push) + `workflow_dispatch` (= callable from refresh workflows via `gh workflow run`).
- Checks out the same SHA that `Dev checks` ran against.
- Uses the new composite action with `branch: {region}-beta`.
- Posts the preview URL into the run summary.
- Cannot reach prod — `wrangler --branch={region}-beta` is contained to the Cloudflare Pages preview slot.

## Surface area

**4 NEW files. Zero edits to existing files on main.**

Specifically NOT in this PR (lives on dev, will land via the bigger PR #18):
- The composite-action refactor of `deploy-{dev,prod}.yml`
- The `npm install + build + wrangler` strip from the 8 `refresh-*` workflows
- The `gh workflow run` trigger step appended to those refresh workflows
- The `deploy-verify.yml` workflow-list cleanup

## After merge

1. The 4 new workflows show up under Actions on main (registered, runnable).
2. Dev's refresh-tropical-data / refresh-pnw-data / refresh-ca-beta-data trigger steps stop 404'ing — the next cron tick or `force_climo` dispatch will auto-publish the corresponding beta surface within ~90 s of the data commit.
3. Production (shouldidive.com) is unaffected — none of these workflows can reach the `main` CF Pages branch. Only deploy-prod.yml (already on main) does that.

## Test plan

- [x] dev-checks already validates these files (they live on dev today; this PR mirrors them to main)
- [ ] After merge: `gh workflow run refresh-tropical-data.yml --ref dev -f force_climo=true` → expect the trigger step to succeed and `deploy-tropical-beta` to fire
- [ ] Tropical-beta preview reflects the freshly-published OISST-based climatology (today's anomaly should drop from -4.38°C to ~+0.82°C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)