### PR TITLE
feat: SoCal upgrade — pipeline/security improvements (NorCal deferred)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,108 @@
+version: 2
+
+# Dependabot config — automated dependency PRs.
+#
+# The principle here is "lots of PRs, low review burden" rather than
+# "few PRs, careful review". Patch + minor bumps get grouped so a week
+# of `react@18.3.0 → 18.3.1` / `eslint-plugin-react@7.34.0 → 7.34.1`
+# don't each open their own PR. Major bumps DO get individual PRs
+# because they're the ones that need human eyes.
+#
+# Why this exists:
+# Two coding agents (Claude Code, Codex) make autonomous commits to
+# this repo. Without Dependabot the agents would never update
+# transitive deps on their own (they have no signal), so security CVEs
+# in nested packages would accumulate silently. Dependabot is the
+# automated "check this every week" that nobody has to remember.
+
+updates:
+  # ---- web app (React PWA at the repo root) -------------------------
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "automated"
+    groups:
+      # All dev-only deps in one PR per week — typically 5-10 patch
+      # bumps. Low review burden; just glance at the changelog summary.
+      dev-deps:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      # Production deps grouped at the patch/minor level. Majors get
+      # their own PR (Dependabot's default for "minor" group exclusion).
+      prod-deps:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+    # Ignore packages we deliberately pin (none today; placeholder
+    # for the inevitable "wrangler 4.85.0 — don't upgrade until X" case).
+    ignore: []
+
+  # ---- python pipeline ----------------------------------------------
+  - package-ecosystem: "pip"
+    directory: "/pipeline"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:30"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "pipeline"
+      - "automated"
+    groups:
+      pipeline-deps:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ---- GitHub Actions versions --------------------------------------
+  # `actions/checkout@v4` etc. — Dependabot bumps these to fix CVEs
+  # in the action runtime (e.g. the actions/setup-node Node 20 → 24
+  # migration that's currently warned on every run).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"
+      - "automated"
+    groups:
+      actions-deps:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ---- React Native mobile client -----------------------------------
+  - package-ecosystem: "npm"
+    directory: "/mobile"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:30"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "mobile"
+      - "automated"
+    groups:
+      mobile-deps:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,78 @@
+name: CodeQL
+
+# Static-analysis security scan. Catches the class of regressions
+# we already manually grep'd for in the 2026-05-13 hardening pass
+# (XSS via dangerouslySetInnerHTML, eval / new Function, template-
+# injection patterns, unsafe URL handling, hardcoded secrets, etc.)
+# automatically on every push to dev/main + every PR.
+#
+# Why this exists:
+# Two coding agents (Claude Code, Codex) make autonomous commits to
+# this repo. The hardening pass that audited the current codebase
+# was a manual exercise — a future agent adding `dangerouslySetInner
+# HTML` in a component would slip past the existing dev-checks suite
+# (web-build / web-lint / web-tests catch syntax + contract issues,
+# not security regressions). CodeQL is the automated equivalent of
+# that hardening pass, running continuously.
+#
+# Free for public repositories. Results appear under the repo's
+# Security tab → Code scanning alerts.
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly re-scan — catches CVEs added to CodeQL's query packs
+    # after the last code change. Monday 10:30 UTC = a Sunday-night
+    # commit gets re-scanned before Monday-morning work starts.
+    - cron: "30 10 * * 1"
+
+# Minimal permissions per least-privilege.
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+# Cancel in-progress scans when a new commit lands on the same ref —
+# the older scan's results are stale anyway.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # CodeQL supports javascript, python, go, java/kotlin, ruby,
+        # swift, c/c++, csharp. We have JS (web + mobile) and Python
+        # (pipeline). The CodeQL JS analyzer covers both .js and .jsx.
+        language:
+          - javascript-typescript
+          - python
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # Use the "security-extended" query pack — broader coverage
+          # than the default "security-and-quality" but still well-
+          # scoped (doesn't include code-style nags).
+          queries: security-extended
+
+      # CodeQL handles JS/TS without a build step; for Python it also
+      # works without one. Skip autobuild entirely.
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,145 @@
+# ShouldIDive — Security policy
+
+## Reporting a vulnerability
+
+If you find a security issue, please report it via
+[GitHub Security Advisories on this repo](https://github.com/Michaelpjob/ShoudiDive/security/advisories)
+rather than opening a public issue. We'll acknowledge within 72 hours.
+
+Do **not**:
+
+- Run automated scanners against `shouldidive.com` (we already see
+  enough of those from CN/IN/RU script-kiddie IP blocks; please
+  don't add to the noise).
+- Use vulnerabilities to access data beyond what's needed to
+  demonstrate them.
+- Modify data, deface pages, or degrade service.
+
+## What's in scope
+
+- The live web app at `https://shouldidive.com/` and its beta surfaces
+  (`{ca,pnw,tropical}-beta.shouldidive.pages.dev`, `dev.shouldidive.pages.dev`).
+- The single Cloudflare Pages Function at `/api/analytics/event`.
+- The GitHub Actions workflows in `.github/workflows/` (if you find a
+  way to inject into our auto-deploy chain).
+- Mobile app (`mobile/`) — currently RN/Expo, single-purpose read-only client.
+
+## What's out of scope
+
+- The published static data under `/data/` is, by design, fully
+  public. Reading it isn't a vulnerability.
+- Cloudflare and NOAA upstream infrastructure.
+- Denial of service via volumetric traffic — Cloudflare's free tier
+  handles that. Logical-flaw DoS (e.g. an endpoint that allocates
+  unbounded memory for a small request) IS in scope.
+- Self-XSS that requires the victim to paste attacker-supplied JS
+  into devtools.
+
+## Security posture summary (2026-05-13)
+
+### Surface area
+
+- One POST endpoint, `/api/analytics/event`. Same-origin only, no CORS.
+- Everything else is static (HTML, JS, CSS bundles, PNG / JSON data).
+- No user accounts. No auth. No DB writes from the web tier.
+- No third-party JS bundled — fonts come from `fonts.googleapis.com` /
+  `fonts.gstatic.com`, no analytics or ad SDKs.
+
+### Code-level hardening
+
+- Zero `dangerouslySetInnerHTML`, zero `eval()`, zero `new Function()`,
+  zero `innerHTML` writes, zero `document.write` in the React app.
+- All URL params come through `URLSearchParams` and are whitelisted
+  against known values (region switcher).
+- No `import.meta.env.*` secrets in the client bundle; only `PROD`
+  flag is read (build-time boolean).
+- `git ls-files` has zero `.env`, `.pem`, `id_rsa`, or other
+  credential files tracked.
+
+### `/api/analytics/event` defense-in-depth
+
+- 16 KB body cap.
+- 50-events-per-batch cap.
+- 64-char prop string cap.
+- Strict allowlist of event names.
+- Origin/Referer check against `TRUSTED_ORIGINS` whitelist.
+- Content-Type filter (rejects non-JSON / non-text/plain).
+- Session-ID charset restricted to `[a-zA-Z0-9_-]+`.
+- IP address and User-Agent deliberately never logged.
+- No CORS — cross-origin browsers can't reach the endpoint.
+
+### Cloudflare Pages headers (see `public/_headers`)
+
+- `Content-Security-Policy` — denies inline scripts, restricts img/font/style/connect/worker/manifest to same-origin (+ Google Fonts for style/font). `frame-ancestors 'none'` blocks clickjacking. `upgrade-insecure-requests` auto-upgrades.
+- `Strict-Transport-Security: max-age=31536000; includeSubDomains` — HSTS enforced for 1 year on the domain and all subdomains. Preload submission deferred until policy stable for >2 weeks.
+- `X-Frame-Options: DENY` — belt-and-suspenders alongside CSP frame-ancestors.
+- `X-Content-Type-Options: nosniff` — no MIME guessing.
+- `Referrer-Policy: strict-origin-when-cross-origin`.
+- `Permissions-Policy` — denies camera/mic/geolocation/payment/USB/etc.; allows `geolocation=(self)` + `fullscreen=(self)` only (we don't use them today but want headroom).
+- `Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Resource-Policy: same-site` — isolates browsing context.
+
+### Cloudflare Pages routing (see `public/_redirects`)
+
+- Scanner-known paths (`/.env*`, `/.git/*`, `/wp-*`, `/phpmyadmin*`, etc.) return **hard HTTP 404** instead of the SPA fallback's 200-with-HTML. Lowers our visibility in attacker target queues.
+
+## Recommended Cloudflare dashboard settings
+
+The code-level work in this repo is half of the story. The other half
+lives in the Cloudflare dashboard for the `shouldidive.com` zone.
+
+If you (the repo owner) haven't already, set these:
+
+### 1. Security → WAF → Managed rules
+- Enable **Cloudflare Managed Ruleset** (free).
+- Set sensitivity to **High** for the first few weeks; ratchet down if you see false positives.
+- Enable **OWASP ModSecurity Core Rule Set** in monitoring mode for a week, then enforce.
+
+### 2. Security → Bots → Bot Fight Mode
+- Enable **Bot Fight Mode** (free; auto-challenges known-bot IPs).
+- Don't enable Super Bot Fight Mode unless you're on Pro plan — it costs more and the free tier is usually enough.
+
+### 3. Security → Rate Limiting → Rate limiting rules
+Add a rule scoped to the analytics endpoint:
+- **Rule name:** `analytics-rate-limit`
+- **Match:** `http.request.uri.path eq "/api/analytics/event" and http.request.method eq "POST"`
+- **Rate:** 20 requests / 10 seconds, per IP.
+- **Action:** Block, duration 1 minute.
+
+(Free tier includes one rate-limiting rule.)
+
+### 4. SSL/TLS → Edge Certificates
+- Enforce **Always Use HTTPS**.
+- **Min TLS Version:** 1.2 (or 1.3 if your audience is modern).
+- **Automatic HTTPS Rewrites:** on.
+- **HSTS:** the `_headers` file already declares it; you don't need to also enable Cloudflare's HSTS plugin (would cause duplicate headers).
+
+### 5. Speed → Optimization → Auto Minify
+- Skip. Vite already minifies; CF's pass after that has no benefit and can break source maps if we ever enable them.
+
+### 6. Security → Settings → Browser Integrity Check
+- Enable.
+
+### 7. (Optional, paid) Cloudflare Turnstile
+- Embed Turnstile on `/api/analytics/event` if bot floods continue
+  past WAF + Bot Fight Mode + rate limiting. Free for the first 1M
+  monthly challenges.
+
+### Geographic posture
+
+The user has reported elevated bot traffic from CN/IN/RU IP ranges.
+
+- **Don't geo-block.** Many legitimate divers travel; blocking
+  countries hurts real users disproportionately.
+- The right move is the combination above: WAF + Bot Fight + rate
+  limit + hard-404s. Together those drop scanner success rate to
+  near zero without false positives.
+- If a specific ASN or IP range becomes consistently malicious,
+  add a per-ASN block under Security → WAF → Custom rules.
+
+## Maintenance / review cadence
+
+- Re-run `_redirects` against new scanner patterns whenever CF
+  Analytics shows a new path class spiking (~quarterly).
+- Re-audit the analytics endpoint when `ANALYTICS_KV` Phase 2 lands
+  (storage abuse becomes a real cost; tighten rate limit then).
+- Rotate any CF API tokens annually and on any secret-leak suspicion.

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -1,0 +1,127 @@
+// Cloudflare Pages middleware — global request gate.
+//
+// This file lives at functions/_middleware.js and runs BEFORE static
+// asset serving for every request to the site. We use it to:
+//   1. Return HARD 404 for scanner-known paths (/.env, /.git/*, etc.)
+//      that the SPA fallback would otherwise serve as 200 + index.html.
+//      CF Pages' `_redirects` file only supports 200/301/302/303/307/308
+//      — NOT 404 — so this is the only way to produce a real 404 status
+//      for these paths.
+//   2. Pass everything else through to the next handler (static asset
+//      or another Function) via `next()`.
+//
+// CPU cost:
+//   This middleware runs on every request. The path check below is a
+//   single Set lookup + a couple of startsWith calls — sub-microsecond.
+//   The hot path (real assets and the SPA fallback) costs effectively
+//   nothing.
+//
+// Why not handle this in `_redirects` with a 302 to /404?
+//   Because then scanners see HTTP 302 + Location: /404 and follow it.
+//   Once they fetch /404 (which would be the SPA index.html, status 200),
+//   they conclude the site "exists" and escalate. A crisp 404 immediately
+//   tells the scanner this URL is dead — they drop us in their priority
+//   queues.
+
+// Scanner-known path prefixes. Maintained alongside SECURITY.md.
+// Order doesn't matter; we walk the whole list. Patterns:
+//   * exact match  → request.url.pathname === pattern
+//   * "*" suffix   → request.url.pathname.startsWith(pattern without "*")
+const SCANNER_PATHS_EXACT = new Set([
+  "/.env",
+  "/.htaccess",
+  "/.htpasswd",
+  "/.DS_Store",
+  "/xmlrpc.php",
+  "/wlwmanifest.xml",
+  "/info.php",
+  "/test.php",
+  "/admin.php",
+  "/adminer.php",
+  "/server-status",
+  "/server-info",
+  "/composer.json",
+  "/composer.lock",
+  "/package-lock.json",
+  "/yarn.lock",
+  "/pnpm-lock.yaml",
+  "/Dockerfile",
+  "/.dockerignore",
+  "/docker-compose.yml",
+  "/.travis.yml",
+  "/dump.sql",
+  "/db.sql",
+  "/database.sql",
+]);
+
+const SCANNER_PREFIXES = [
+  "/.env.",        // /.env.local, /.env.production, etc.
+  "/.git",         // /.git/config, /.git/HEAD, etc.
+  "/.svn",
+  "/.hg",
+  "/.aws",
+  "/.ssh",
+  "/.vscode",
+  "/.idea",
+  "/wp-admin",     // WordPress probes (#1 bot class)
+  "/wp-login",
+  "/wp-includes",
+  "/wp-content",
+  "/wp-config",
+  "/wp-json",
+  "/phpmyadmin",
+  "/phpMyAdmin",
+  "/pma/",
+  "/admin/",
+  "/administrator/",
+  "/manager/html",
+  "/cgi-bin/",
+  "/console/",
+  "/jenkins/",
+  "/private/",
+  "/backup/",
+  "/backups/",
+];
+
+function isScannerPath(pathname) {
+  if (SCANNER_PATHS_EXACT.has(pathname)) return true;
+  for (const prefix of SCANNER_PREFIXES) {
+    if (pathname === prefix || pathname.startsWith(prefix + "/") || pathname.startsWith(prefix)) {
+      return true;
+    }
+  }
+  // Source-map probes — we don't ship source maps in prod (Vite default),
+  // but the SPA fallback was returning 200 for these. Crisp 404 instead.
+  if (pathname.startsWith("/assets/") && pathname.endsWith(".map")) {
+    return true;
+  }
+  return false;
+}
+
+// Tiny static 404 body. No headers leaked, no useful info for scanners.
+const NOT_FOUND_BODY = "Not Found";
+
+export async function onRequest(context) {
+  let pathname;
+  try {
+    pathname = new URL(context.request.url).pathname;
+  } catch {
+    // Malformed URL — let the platform handle it.
+    return context.next();
+  }
+
+  if (isScannerPath(pathname)) {
+    return new Response(NOT_FOUND_BODY, {
+      status: 404,
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Cache-Control": "public, max-age=3600",
+        // Bots cache 404s for a while → fewer subsequent probes.
+        // Inherit the global X-Content-Type-Options + Referrer-Policy
+        // from the `_headers` file (CF merges middleware + _headers).
+      },
+    });
+  }
+
+  return context.next();
+}

--- a/functions/api/analytics/event.js
+++ b/functions/api/analytics/event.js
@@ -29,6 +29,31 @@
 
 const MAX_BODY_BYTES = 16 * 1024;       // 16 KB cap; honest clients send <1 KB
 const MAX_EVENTS_PER_BATCH = 50;        // matches client buffer size + headroom
+
+// Origin allowlist. Same-origin requests from shouldidive.com don't
+// always set Origin/Referer (depends on browser + sendBeacon mode),
+// but when set they must be one of these. Listed verbatim rather than
+// regex to keep the check trivially auditable.
+const TRUSTED_ORIGINS = new Set([
+  "https://shouldidive.com",
+  "https://www.shouldidive.com",
+  "https://dev.shouldidive.pages.dev",
+  "https://ca-beta.shouldidive.pages.dev",
+  "https://pnw-beta.shouldidive.pages.dev",
+  "https://tropical-beta.shouldidive.pages.dev",
+  // shouldidive.pages.dev — root Pages preview that CF auto-generates
+  "https://shouldidive.pages.dev",
+]);
+
+function isTrustedOrigin(probe) {
+  try {
+    const u = new URL(probe);
+    return TRUSTED_ORIGINS.has(`${u.protocol}//${u.host}`);
+  } catch {
+    return false;
+  }
+}
+
 const ALLOWED_NAMES = new Set([
   "pageview",
   "layer_change",
@@ -57,6 +82,45 @@ function jsonResponse(body, init) {
 }
 
 export async function onRequestPost({ request }) {
+  // ---- defense-in-depth guard rails ---------------------------------
+  // Each of these checks is cheap (header read or constant-time string
+  // compare) and short-circuits before we spend any CPU on body parsing.
+  // The intent isn't perfect rejection — it's making this endpoint
+  // unattractive to opportunistic abuse:
+  //   * a flood of bot POSTs adds noise to Cloudflare logs (Phase 1
+  //     storage); harmless today but degrades the signal we built
+  //     analytics for
+  //   * Phase 2 (when ANALYTICS_KV is bound) every successful POST
+  //     writes a KV entry; abuse becomes a real $ cost
+  //   * Rate-limit / WAF rules at the Cloudflare dashboard are the
+  //     primary defense; the checks below are belt-and-suspenders
+  //     so the endpoint still behaves correctly if a config drifts
+
+  // Origin / Referer check. Honest browser clients always send Origin
+  // for `fetch()` POST requests and either Origin OR Referer for
+  // sendBeacon. Reject anything that's missing both (script tools,
+  // curl-from-CLI without --header). Allow same-origin and our beta
+  // surfaces only.
+  const origin = request.headers.get("origin") || "";
+  const referer = request.headers.get("referer") || "";
+  if (origin || referer) {
+    const probe = origin || referer;
+    if (!isTrustedOrigin(probe)) {
+      return jsonResponse({ ok: false, error: "untrusted origin" }, { status: 403 });
+    }
+  }
+  // (Missing-both case allowed — sendBeacon under some privacy modes
+  // strips the headers; we don't want to reject legitimate beacons.)
+
+  // Content-Type must be JSON. Bots that just blindly POST a form
+  // encoded body trip on this immediately.
+  const contentType = (request.headers.get("content-type") || "").toLowerCase();
+  if (contentType && !contentType.startsWith("application/json") && !contentType.startsWith("text/plain")) {
+    // text/plain is what sendBeacon sometimes sets when the body is
+    // a string. We accept it because the body parser doesn't care.
+    return jsonResponse({ ok: false, error: "bad content-type" }, { status: 415 });
+  }
+
   // Defensive size guard. sendBeacon will happily POST a 10 MB blob
   // if the client buffer is broken; we never want to spend a full
   // request CPU budget on a malformed payload.
@@ -85,6 +149,13 @@ export async function onRequestPost({ request }) {
   }
   if (events.length > MAX_EVENTS_PER_BATCH) {
     return jsonResponse({ ok: false, error: "too many events" }, { status: 413 });
+  }
+  // Session ID must be ASCII hex-ish (the client mints it with
+  // crypto.getRandomValues → toString(16)). This catches the
+  // "bot copy-paste of a session ID with `<` or `'` in it" cases
+  // that are otherwise harmless but signal abuse.
+  if (!/^[a-zA-Z0-9_-]+$/.test(sessionId)) {
+    return jsonResponse({ ok: false, error: "bad session id" }, { status: 400 });
   }
 
   // Cloudflare's request object exposes the country code under cf

--- a/pipeline/chl_blend.py
+++ b/pipeline/chl_blend.py
@@ -50,13 +50,29 @@ import xarray as xr
 from PIL import Image
 
 
-# ---- Common bbox + grid (matches fetch.py exactly) ------------------------
+# ---- Common bbox + grid (sourced from pipeline/regions/) -----------------
 
-BBOX = dict(lat_min=31.8, lat_max=37.6, lng_min=-124.0, lng_max=-116.8)
+# Bbox via the regions/ scaffold (PR-X-1). CA region snapshot matches
+# fetch.py bit-for-bit; SHOULDIDIVE_REGION env var switches PNW /
+# tropical when those regions are wired in PR-X-3.
+try:
+    from pipeline.regions import active_region
+except ModuleNotFoundError:
+    from regions import active_region
+
+BBOX = active_region().bbox
 
 # Output grid — kept at the legacy ERDDAP stride-1 dims for backward compat
 # with manifest.json consumers (React MapCanvas, RN MapScreen, viz_predict).
 # Higher-res grid is a separate v2 task that requires updating those readers.
+#
+# NOTE on coastal resolution: at the current 71×87 over the CA bbox
+# (11.7° × 10.2°), each cell is ~18×13 km. Coastal cells span ocean + land,
+# and DINEOF gap-fill can leak synthetic chl values past the coastline. The
+# land mask below (loaded from bathy.png) NaN's land-dominant cells before
+# encoding so the visible heatmap stops at the shoreline. A future v2 grid
+# bump (142×174 or finer) would also sharpen the nearshore signal — that's
+# a separate change requiring frontend / RN / viz_predict updates first.
 OUT_W, OUT_H = 71, 87
 
 # Each canonical cell anchored at the bbox edges; lat descends top→bottom
@@ -73,7 +89,7 @@ CHL_UNIT = "mg/m^3"
 # ---- Storage -----------------------------------------------------------
 
 ROOT = Path(__file__).resolve().parents[1]
-OUT_DIR = ROOT / "public" / "data"
+OUT_DIR = active_region().data_output_dir(ROOT)
 CACHE_DIR = ROOT / "pipeline" / ".cache"
 
 # How far back each NASA source will walk if today's data is missing. NASA
@@ -534,6 +550,76 @@ def _encode_source_png(src_arr: np.ndarray, out_path: Path) -> None:
     Image.fromarray(src_arr, mode="L").save(out_path, optimize=True)
 
 
+# ---- Land mask ---------------------------------------------------------
+#
+# Same pattern as fetch_wind.py: read bathy.png's alpha channel, downsample
+# to the chl grid (71×87) using a box-averaged land-area fraction, then
+# threshold so a cell is flagged "land" only when >70% of its area is land.
+# Encoded chl gets NaN'd over flagged cells, so the published PNG has
+# alpha=0 there and the frontend's coastline render isn't fighting a chl
+# blob that leaks 9-18 km inland.
+#
+# Why this matters specifically for chl (more than for wind):
+#   1. The chl product is a BLEND of 5 sources, 4 of which honor land
+#      correctly (NaN-over-land L3 satellite products). But priority 4-5
+#      (DINEOF NRT 4km, DINEOF SCI 2km) are GAP-FILLED products: they
+#      spatially extrapolate chl values across cloud-blocked cells, and
+#      their land mask is slightly different from our basemap coastline.
+#      Coastal cells classified as ocean in DINEOF but land in our basemap
+#      end up with valid blended chl.
+#   2. The chl grid is coarse (71×87 → ~18 km wide cells). A coastal cell
+#      that's 60% land but has any DINEOF gap-fill ocean value renders the
+#      entire cell as chl-colored.
+#   3. The visibility model reads chl_1d.png as an input. If that chl is
+#      contaminated, viz predictions degrade (the chl-anomaly signal is
+#      one of the model's biggest "less viz" levers).
+
+def _load_land_mask(out_w: int, out_h: int,
+                    land_threshold: float = 0.7) -> np.ndarray | None:
+    """Read bathy.png and downsample to (out_h, out_w) with box-averaging.
+
+    Returns a boolean array, True = land. None if bathy.png missing
+    (graceful degradation: chl encoding continues without masking).
+    """
+    bathy_path = OUT_DIR / "bathy.png"
+    if not bathy_path.exists():
+        return None
+    try:
+        img = Image.open(bathy_path).convert("L")
+    except Exception as e:
+        print(f"  [chl-land-mask] bathy.png unreadable ({e!s}) — skipping mask",
+              flush=True)
+        return None
+    arr = np.asarray(img)
+    if arr.ndim != 2:
+        return None
+    src_h, src_w = arr.shape
+    src_land = arr == 0  # bathy: pixel 0 = land/NaN, 1..255 = depth
+    if src_h < out_h or src_w < out_w:
+        # Degenerate: bathy lower-res than chl grid. NN fallback.
+        yi = np.linspace(0, src_h - 1, out_h).round().astype(int)
+        xi = np.linspace(0, src_w - 1, out_w).round().astype(int)
+        return src_land[yi[:, None], xi[None, :]]
+    is_land = np.zeros((out_h, out_w), dtype=bool)
+    for i in range(out_h):
+        y0 = i * src_h // out_h
+        y1 = max(y0 + 1, (i + 1) * src_h // out_h)
+        for j in range(out_w):
+            x0 = j * src_w // out_w
+            x1 = max(x0 + 1, (j + 1) * src_w // out_w)
+            cell = src_land[y0:y1, x0:x1]
+            land_frac = cell.mean() if cell.size else 0.0
+            is_land[i, j] = land_frac > land_threshold
+    return is_land
+
+
+def _apply_land_mask(arr: np.ndarray, mask: np.ndarray | None) -> np.ndarray:
+    """NaN out arr where mask is True. No-op if mask is None."""
+    if mask is None or mask.shape != arr.shape:
+        return arr
+    return np.where(mask, np.nan, arr)
+
+
 # ---- Public entry point ------------------------------------------------
 
 def build_blended_chl(end: date) -> dict | None:
@@ -564,11 +650,26 @@ def build_blended_chl(end: date) -> dict | None:
         print("[chl] no source returned data, skipping layer", flush=True)
         return None
 
+    # Land mask loaded once per run; reused across all 3 windows. None when
+    # bathy.png is missing (first-run on a fresh region) — encoding falls
+    # through to today's behavior in that case.
+    land_mask = _load_land_mask(OUT_W, OUT_H)
+    if land_mask is not None:
+        print(f"  loaded land mask from bathy.png "
+              f"({float(land_mask.mean()):.0%} land cells)", flush=True)
+
     # 2) Blend per cell for each window: 1d/2d/3d differ only in how many
     # within-source frames are nanmean'd before the cross-source merge.
     windows = {}
     for win, n_frames in [("1d", 1), ("2d", 2), ("3d", 3)]:
         blended, ages, sources, stats = _blend_freshest(per_source, end, n_frames)
+        # Mask land cells BEFORE coverage/encoding. ages + sources also get
+        # masked so the sidecar PNGs (chl_1d_age_days.png, chl_1d_source.png)
+        # don't show land-pixel provenance either.
+        blended = _apply_land_mask(blended, land_mask)
+        if land_mask is not None:
+            ages = np.where(land_mask, 255, ages)      # 255 = no-data sentinel
+            sources = np.where(land_mask, 0, sources)  # 0 = no-data sentinel
         valid_cells = int(np.isfinite(blended).sum())
         total = OUT_H * OUT_W
         coverage = valid_cells / total

--- a/pipeline/fetch.py
+++ b/pipeline/fetch.py
@@ -53,14 +53,28 @@ try:
 except ModuleNotFoundError:
     from lib.layer_spec import LAYER_SPECS
 
-BBOX = dict(lat_min=31.8, lat_max=37.6, lng_min=-124.0, lng_max=-116.8)
+# Bbox sourced from `pipeline/regions/` (PR-X-1 scaffold). The CA
+# region snapshot matches today's hardcoded values bit-for-bit; the
+# `SHOULDIDIVE_REGION` env var (default `ca`) switches to PNW or
+# tropical when the refresh-data CI matrix runs that region. Bumping
+# the CA bbox now happens in one place: `pipeline/regions/ca.py`.
+try:
+    from pipeline.regions import active_region
+except ModuleNotFoundError:
+    from regions import active_region
+
+BBOX = active_region().bbox
 ERDDAP_BASE = "https://coastwatch.pfeg.noaa.gov/erddap/griddap"
 REQUEST_HEADERS = {
     "User-Agent": "shouldidive-data-pipeline/1.0 (+https://shouldidive.com)",
 }
 
 ROOT = Path(__file__).resolve().parents[1]
-OUT_DIR = ROOT / "public" / "data"
+# Region-aware output dir. CA stays at `public/data/` (frontend-visible
+# path the React app expects). PNW + tropical land under
+# `public/data/pnw/` and `public/data/tropical/` respectively, so the
+# matrix CI runs (PR-X-3b) don't overwrite CA's PNGs.
+OUT_DIR = active_region().data_output_dir(ROOT)
 CACHE_DIR = ROOT / "pipeline" / ".cache"
 
 
@@ -83,8 +97,16 @@ def _layer_config(spec_name: str, encoder_extras: dict) -> dict:
         raise ValueError(
             f"fetch.py: LayerSpec for {spec_name!r} has no scale"
         )
+    # Region range override (PR-X-3a follow-up). Tropical SST is 20-32°C
+    # not 9-25; PNW is cooler than CA. The override lives on the Region
+    # dataclass so PNW / tropical encoders span the right band without
+    # touching the shared LAYER_SPECS defaults.
+    layer_range = tuple(spec.range)
+    overrides = getattr(active_region(), "layer_range_overrides", {}) or {}
+    if spec_name in overrides:
+        layer_range = tuple(overrides[spec_name])
     return {
-        "range": tuple(spec.range),
+        "range": layer_range,
         "scale": spec.scale,
         "unit": spec.unit,
         **encoder_extras,
@@ -751,10 +773,18 @@ def main() -> None:
     if manifest_path.exists():
         manifest = json.loads(manifest_path.read_text())
     else:
-        manifest = {
-            "bbox": [BBOX["lng_min"], BBOX["lat_min"], BBOX["lng_max"], BBOX["lat_max"]],
-            "layers": {},
-        }
+        manifest = {"layers": {}}
+    # ALWAYS overwrite the top-level bbox with the current BBOX dict.
+    # Otherwise a bbox change in code (e.g. the 2026-05-09 NorCal
+    # expansion: latMax 37.6 → 42.0) doesn't propagate to the manifest
+    # on the next refresh — fetch.py merges into the existing JSON
+    # which still carries the OLD bbox values, and the frontend reads
+    # those stale values when computing layer-data extents.
+    manifest["bbox"] = [
+        BBOX["lng_min"], BBOX["lat_min"],
+        BBOX["lng_max"], BBOX["lat_max"],
+    ]
+    manifest.setdefault("layers", {})
     generated_at = datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
     if args.layer == "all":
         manifest["generated_at"] = generated_at

--- a/pipeline/fetch_bathy.py
+++ b/pipeline/fetch_bathy.py
@@ -22,7 +22,9 @@ Encoding:
 from __future__ import annotations
 
 import io
+import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import numpy as np
@@ -30,10 +32,24 @@ import requests
 from PIL import Image
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-OUT_PATH = REPO_ROOT / "public" / "data" / "bathy.png"
 
-# Match the rest of the pipeline's CA bbox.
-BBOX = dict(lat_min=31.8, lat_max=37.6, lng_min=-124.0, lng_max=-116.8)
+# Bbox + output path sourced from `pipeline/regions/` (PR-X-1 scaffold).
+# Same CA/PNW/tropical switch as the rest of the fetchers.
+try:
+    from pipeline.regions import active_region
+except ModuleNotFoundError:
+    from regions import active_region
+
+BBOX = active_region().bbox
+OUT_PATH = active_region().data_output_dir(REPO_ROOT) / "bathy.png"
+# Sidecar JSON tracks which bbox + grid dimensions the cached
+# bathy.png was generated for. Without this, an idempotent skip
+# can silently leave a stale PNG over an OLD bbox in place after
+# the region's bbox is bumped (e.g. CA's NorCal expansion
+# 2026-05-09 + offshore widenings 2026-05-13 / 14). Downstream
+# consumers that use bathy.png as a land mask (fetch_wind.py,
+# fetch_wind_5day.py) then have geographic mis-registration.
+META_PATH = OUT_PATH.with_suffix(".json")
 
 # Output PNG dimensions. 4× the model's standard 140×110 to preserve
 # shelf-edge detail; consumers bilinear-resample to their own grid.
@@ -219,9 +235,51 @@ def encode_linear_png(arr, lo, hi, out_path):
     Image.fromarray(px, mode="L").save(out_path, optimize=True)
 
 
+def _current_meta() -> dict:
+    """The bbox / dims signature for the CURRENT region+config. Used to
+    decide if a cached bathy is stale."""
+    return {
+        "bbox": [BBOX["lng_min"], BBOX["lat_min"],
+                 BBOX["lng_max"], BBOX["lat_max"]],
+        "out_w": OUT_W,
+        "out_h": OUT_H,
+    }
+
+
+def _is_cache_fresh() -> bool:
+    """True iff bathy.png exists AND its sidecar JSON says it was built
+    for the current bbox+dims."""
+    if not OUT_PATH.exists():
+        return False
+    if not META_PATH.exists():
+        # Legacy cache (no sidecar) — assume stale. The PR that introduced
+        # the sidecar (2026-05-14) explicitly forces a regen on first run
+        # so old bathys built before the recent NorCal bbox bumps get
+        # replaced even though the PNG itself is "present".
+        print(f"  {OUT_PATH.relative_to(REPO_ROOT)} exists but no sidecar — "
+              f"treating as stale (regenerating)")
+        return False
+    try:
+        cached = json.loads(META_PATH.read_text())
+    except Exception as e:
+        print(f"  sidecar read failed ({e!s}) — regenerating")
+        return False
+    current = _current_meta()
+    if cached.get("bbox") != current["bbox"]:
+        print(f"  bbox changed since cache was built — regenerating")
+        print(f"    cached: {cached.get('bbox')}")
+        print(f"    current: {current['bbox']}")
+        return False
+    if cached.get("out_w") != current["out_w"] or cached.get("out_h") != current["out_h"]:
+        print(f"  output dims changed since cache was built — regenerating")
+        return False
+    return True
+
+
 def main():
-    if OUT_PATH.exists():
-        print(f"  {OUT_PATH.relative_to(REPO_ROOT)} already exists, skipping")
+    if _is_cache_fresh():
+        print(f"  {OUT_PATH.relative_to(REPO_ROOT)} already current for this "
+              f"bbox + dims, skipping")
         return 0
 
     print(f"Fetching GMRT bathymetry → {OUT_PATH.relative_to(REPO_ROOT)}")
@@ -246,6 +304,17 @@ def main():
     encode_linear_png(out, DEPTH_MIN_M, DEPTH_MAX_M, OUT_PATH)
     size_kb = OUT_PATH.stat().st_size // 1024
     print(f"  wrote {OUT_PATH.relative_to(REPO_ROOT)} ({size_kb} KB)")
+
+    # Stamp the sidecar so the next run knows the cache is fresh for
+    # this bbox+dims. If anything bumps these, _is_cache_fresh fires
+    # a regen automatically — no manual rm of bathy.png needed.
+    META_PATH.write_text(json.dumps({
+        **_current_meta(),
+        "generated_at": datetime.now(timezone.utc)
+            .isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "source": "GMRT GridServer",
+        "depth_range_m": [DEPTH_MIN_M, DEPTH_MAX_M],
+    }, indent=2))
     return 0
 
 

--- a/pipeline/fetch_climatology.py
+++ b/pipeline/fetch_climatology.py
@@ -1,15 +1,19 @@
-"""Fetch a small monthly climatology for SST + chl from ERDDAP.
+"""Fetch monthly climatology baselines for SST + chl.
 
 The visibility model wants a "what's typical for this time of year" baseline
-for both SST and chl-a so it can compute anomalies. A full multi-decade
-climatology would be ideal but is wildly heavy to host. This fetcher
-approximates it cheaply:
+for both SST and chl-a so it can compute anomalies. Sources:
 
-  * sst_climo.png       — mean of N MUR L4 daily slices from this calendar
-                          month last year (and the year before, if available).
-  * chl_climo.png       — same, for the VIIRS gap-filled chl product.
-  * chl_climo_annual.png — mean of one chl slice per quarter from prior year,
-                          giving a year-round baseline for log-anomaly use.
+  * sst_climo.png         — NOAA OISST v2.1 1991-2020 monthly long-term
+                            mean (TRUE 30-year normal). Single ERDDAP call
+                            against NEFSC COMET, ~50KB per region.
+                            Replaced the prior-year-sample hack on
+                            2026-05-13 — see git log fetch_climatology.py.
+  * chl_climo.png         — MODIS Aqua (erdMWchla1day) prior-year same-month
+                            mean. No 30-year-normal product exists for chl,
+                            so the prior-year approximation persists.
+  * chl_climo_annual.png  — Mean of one chl slice per quarter from prior
+                            year, giving a year-round baseline for
+                            log-anomaly use.
 
 The fetcher is idempotent and self-throttling: it stamps a tiny cache file
 and only re-fetches if the stamp's calendar month differs from "now" — so
@@ -34,16 +38,56 @@ import requests
 import xarray as xr
 from PIL import Image
 
-BBOX = dict(lat_min=31.8, lat_max=37.6, lng_min=-124.0, lng_max=-116.8)
-ERDDAP_BASE = "https://coastwatch.pfeg.noaa.gov/erddap/griddap"
+# Bbox via pipeline/regions/ (PR-X-1). CA / PNW / tropical switch on
+# SHOULDIDIVE_REGION; default `ca` preserves today's behavior.
+try:
+    from pipeline.regions import active_region
+except ModuleNotFoundError:
+    from regions import active_region
+
+BBOX = active_region().bbox
+
+# 2026-05-13 — `coastwatch.pfeg.noaa.gov` started returning 403 / network-
+# unreachable from GitHub Actions egress IPs. fetch.py already migrated
+# off PFEG onto `coastwatch.noaa.gov` (NCEI's primary CoastWatch ERDDAP)
+# which still works. chl + annual chl on this fetcher still use that
+# host (the W-US MODIS Aqua archive is mirrored there); SST climo now
+# uses the NEFSC COMET ERDDAP for the 1991-2020 OISST normal — see
+# OISST_CLIMO_* below.
+ERDDAP_BASE = "https://coastwatch.noaa.gov/erddap/griddap"
+
+# NOAA OISST v2.1 1991-2020 monthly climatology, hosted on NEFSC
+# COMET ERDDAP. Single precomputed 12-month grid (1/4° global), free,
+# anonymous. Replaces the prior "average 3 prior-year-May days" hack
+# that baked the 2024-2025 marine heatwave into the baseline.
+#
+# Dataset metadata (verified 2026-05-13 against .das):
+#   climo_period:  "1991/01/01 - 2020/12/31"
+#   variable:      sst (Float32 °C, "Long Term Mean Monthly Mean SST")
+#   time:          12 monthly grids, index 0=Jan, 11=Dec
+#   lat:           720 cells, -89.875 .. 89.875 (south→north, 0.25°)
+#   lng:           1440 cells, 0.125 .. 359.875 (0-360 convention!)
+OISST_CLIMO_HOST = "https://comet.nefsc.noaa.gov/erddap/griddap"
+OISST_CLIMO_DATASET = "noaa_psl_55a2_880b_1f29"
 
 ROOT = Path(__file__).resolve().parents[1]
-OUT_DIR = ROOT / "public" / "data"
+OUT_DIR = active_region().data_output_dir(ROOT)
 CACHE_DIR = ROOT / "pipeline" / ".cache"
 
 # Match the daily fetcher's encoding so the visibility orchestrator can
 # decode climo PNGs the same way it decodes today's PNGs.
-SST_RANGE = (9.0, 25.0)             # linear °C
+#
+# 2026-05-13 — region-aware override. Until today SST_RANGE was hardcoded
+# (9, 25) for CA. Tropical SST_RANGE is (20, 32), so a Caribbean climo
+# pixel of 28°C got CLIPPED to 25 during encode, saturating pixel 255,
+# and then fetch_sst_5day.py decoded that 255 with tropical's (20, 32)
+# range → 32°C. Every tropical climatology cell came out ~7°C too hot,
+# the nowcast anomaly read ~-4.4°C (artifact), and the 5-day forecast
+# decayed toward the false-ceiling climatology — painting 85–89°F across
+# the Caribbean in May. Reading the encoding range from the active region
+# closes the encode/decode mismatch.
+_sst_overrides = active_region().layer_range_overrides
+SST_RANGE = tuple(_sst_overrides.get("sst", (9.0, 25.0)))   # linear °C
 CHL_RANGE = (0.05, 20.0)            # log10 mg/m³
 
 # Sample days per month: we average these slices for the monthly climo.
@@ -187,6 +231,60 @@ def kelvin_to_c(arr):
     return arr - 273.15 if np.nanmean(arr) > 100 else arr
 
 
+def fetch_oisst_monthly_climo(month: int):
+    """Fetch the OISST 1991-2020 long-term mean for one month, subset to bbox.
+
+    Returns (sst_2d, lat_1d, lng_1d) — all numpy arrays. SST is °C.
+
+    The dataset stores longitude in 0-360°; our bbox uses -180/180°.
+    For bboxes that don't cross the dateline (CA/PNW/tropical all
+    sit west of 0° meridian) the conversion is a simple ``+ 360``.
+
+    Cache key: month-based. The 30-year mean never changes within
+    a calendar month, so we only re-fetch when the month rolls over.
+    """
+    if not (1 <= month <= 12):
+        raise ValueError(f"month must be 1..12, got {month}")
+    time_idx = month - 1  # 0=Jan, 11=Dec
+
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    nc_path = CACHE_DIR / f"climo_oisst_1991-2020_m{month:02d}.nc"
+
+    # Convert -180/180 → 0/360 for the request. Handles negative-lng
+    # bboxes; dateline-crossing bboxes would need two requests stitched,
+    # which none of our regions need today.
+    lng_min_0360 = (BBOX["lng_min"] + 360.0) % 360.0
+    lng_max_0360 = (BBOX["lng_max"] + 360.0) % 360.0
+    if lng_min_0360 > lng_max_0360:
+        raise NotImplementedError(
+            "OISST climo: dateline-crossing bbox not yet supported "
+            f"(lng_min_0360={lng_min_0360}, lng_max_0360={lng_max_0360})"
+        )
+
+    if not nc_path.exists():
+        url = (
+            f"{OISST_CLIMO_HOST}/{OISST_CLIMO_DATASET}.nc"
+            f"?sst[{time_idx}:1:{time_idx}]"
+            f"[({BBOX['lat_min']}):1:({BBOX['lat_max']})]"
+            f"[({lng_min_0360}):1:({lng_max_0360})]"
+        )
+        print(f"  GET OISST climo month={month:02d}", flush=True)
+        r = SESSION.get(url, timeout=180)
+        r.raise_for_status()
+        nc_path.write_bytes(r.content)
+
+    result = open_first_array(nc_path)
+    if result is None:
+        raise RuntimeError(f"OISST climo netCDF unreadable: {nc_path}")
+    arr, lat, lng = result
+    # `open_first_array` already orients lat as south-down (row 0 = lat_max).
+    # Convert longitude back to -180/180 for downstream consistency. Since
+    # our bbox is fully in 0-360 western hemisphere, this is a simple shift.
+    if lng[0] > 180:
+        lng = lng - 360.0
+    return arr, lat, lng
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--force", action="store_true", help="ignore the cache stamp")
@@ -196,11 +294,31 @@ def main() -> None:
     now = datetime.now(timezone.utc)
 
     meta_path = OUT_DIR / "climo_meta.json"
+    current_bbox = [BBOX["lng_min"], BBOX["lat_min"],
+                    BBOX["lng_max"], BBOX["lat_max"]]
     if not args.force and meta_path.exists():
-        meta = json.loads(meta_path.read_text())
-        if meta.get("month") == now.month and meta.get("year_built") == now.year:
-            print(f"climo already current for {now.year}-{now.month:02d}, nothing to do")
+        try:
+            meta = json.loads(meta_path.read_text())
+        except Exception:
+            meta = {}
+        month_ok = meta.get("month") == now.month
+        year_ok = meta.get("year_built") == now.year
+        # 2026-05-14: also gate on bbox. Without this, a region's
+        # cached climatology stays in place even after the bbox is
+        # bumped (e.g. NorCal expansion), causing the same geographic
+        # misregistration we just fixed in fetch_bathy.py — the
+        # climo PNG covers a smaller area than the current bbox,
+        # downstream consumers (fetch_visibility, fetch_sst_5day)
+        # apply it as if it covered the full new bbox.
+        bbox_ok = meta.get("bbox") == current_bbox
+        if month_ok and year_ok and bbox_ok:
+            print(f"climo already current for {now.year}-{now.month:02d} "
+                  f"at bbox {current_bbox}, nothing to do")
             return
+        if not bbox_ok:
+            print(f"  bbox changed since last climo run — regenerating")
+            print(f"    cached: {meta.get('bbox')}")
+            print(f"    current: {current_bbox}")
 
     # Build the monthly sample set: pull SAMPLE_DAYS from prior year, same month.
     sample_year = now.year - 1
@@ -210,17 +328,23 @@ def main() -> None:
         if d <= last_day_of_month:
             monthly_samples.append(date(sample_year, now.month, d))
 
-    print(f"SST climo for {now.year}-{now.month:02d}: averaging {monthly_samples}")
+    # SST climatology: NOAA OISST v2.1, 1991-2020 30-year normal.
+    # Pre-2026-05-13 this section averaged 3 prior-year same-month
+    # MUR L4 daily slices. That made "climatology" track last year's
+    # anomaly — exactly wrong for an anomaly baseline, and during the
+    # 2024-2025 marine heatwave it spiked the tropical baseline to
+    # 31.9°C in May (vs ~27°C real normal). OISST gives the proper
+    # 30-year normal in a single ERDDAP call.
+    sst_climo_method = "oisst_1991-2020_monthly"
+    print(f"SST climo for month {now.month:02d}: OISST 1991-2020 normal")
     try:
-        sst_mean, sst_lat, sst_lng = mean_stack(
-            monthly_samples,
-            "jplMURSST41", "analysed_sst", stride=2, pre_xy="",
-        )
-        sst_mean = kelvin_to_c(sst_mean)
-        print(f"  SST climo: {np.nanmin(sst_mean):.2f}–{np.nanmax(sst_mean):.2f} °C")
+        sst_mean, sst_lat, sst_lng = fetch_oisst_monthly_climo(now.month)
+        print(f"  SST climo: {np.nanmin(sst_mean):.2f}–{np.nanmax(sst_mean):.2f} °C "
+              f"(shape {sst_mean.shape})")
         encode_linear(sst_mean, *SST_RANGE, OUT_DIR / "sst_climo.png")
     except Exception as e:
-        print(f"  SST climo failed — {e!s}")
+        print(f"  SST climo (OISST) failed — {e!s}")
+        sst_climo_method = "oisst_1991-2020_monthly_FAILED_existing_png_preserved"
 
     # Note: VIIRS NRT (the daily-fetcher dataset) only retains a few weeks of
     # history, so prior-year dates 404 there. For climatology we switch to
@@ -258,10 +382,24 @@ def main() -> None:
     meta_path.write_text(json.dumps({
         "year_built": now.year,
         "month": now.month,
+        # bbox: forces a regen when the region's bbox changes
+        # mid-month. Downstream consumers (fetch_visibility,
+        # fetch_sst_5day) assume climo covers the same bbox they
+        # render over, so a bbox mismatch silently produces
+        # geographic misregistration.
+        "bbox": current_bbox,
         "generated_at": now.isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "sst_climo_method": sst_climo_method,
+        "sst_climo_source": "NOAA OISST v2.1 monthly LTM, 1991-2020 baseline",
+        "sst_climo_dataset_id": OISST_CLIMO_DATASET,
+        "chl_monthly_samples": [d.isoformat() for d in monthly_samples],
+        "chl_annual_samples": [d.isoformat() for d in annual_samples],
+        # Legacy keys retained for any tooling that still reads them.
         "monthly_samples": [d.isoformat() for d in monthly_samples],
         "annual_samples": [d.isoformat() for d in annual_samples],
-        "note": "Approximate monthly climo: prior-year same-month mean. Refreshed when calendar month changes.",
+        "note": "SST climo: NOAA OISST 1991-2020 30-year normal (monthly). "
+                "chl climo: prior-year same-month MODIS Aqua mean. "
+                "Refreshed when calendar month OR bbox changes.",
     }, indent=2))
     print("wrote climo_meta.json")
 

--- a/pipeline/fetch_coastline.py
+++ b/pipeline/fetch_coastline.py
@@ -29,21 +29,62 @@ from shapely.geometry import (
 )
 from shapely.ops import polygonize, unary_union
 
-BBOX = dict(lat_min=31.8, lat_max=37.6, lng_min=-124.0, lng_max=-116.8)
+# Bbox via pipeline/regions/ (PR-X-1). CA / PNW / tropical switch on
+# SHOULDIDIVE_REGION; default `ca` preserves today's behavior.
+try:
+    from pipeline.regions import active_region
+except ModuleNotFoundError:
+    from regions import active_region
+
+BBOX = active_region().bbox
 
 # Pad the Overpass query a little so coastline ways straddling the corners
 # come back complete. We re-clip to the exact bbox at write time.
 PAD_DEG = 0.20
 
-# Drop polygons smaller than this. Below that they're sub-pixel rocks that
-# consume vertices without rendering at any zoom we support. Seeded features
-# (named islands like the Coronados) are always kept regardless of size.
-MIN_FEATURE_AREA_DEG2 = 1e-6
+# Drop polygons smaller than this. Below that they're sub-pixel rocks
+# that consume vertices without rendering at any zoom we support.
+# Seeded features (named islands like the Coronados) are always kept
+# regardless of size.
+#
+# Tropical needs a MUCH higher floor — OSM's coastline data for the
+# Bahamas / Antilles includes ~13,000 small islets, every one of which
+# becomes its own SVG <path>. The browser hit-tests every path on each
+# mouse move; 13k paths = visible cursor lag. Bumping the floor to
+# 1e-3 deg² (~12 sq km at tropical latitudes, roughly the size of an
+# island visible to the naked eye on the map at our zoom level) drops
+# the feature count to a few hundred without losing anything the user
+# can actually see.
+def _min_feature_area():
+    try:
+        from pipeline.regions import active_region
+    except ModuleNotFoundError:
+        from regions import active_region
+    if active_region().name == "tropical":
+        return 1e-3
+    return 1e-6
 
-# Douglas-Peucker tolerance, in degrees. ~10 m at 34°N — still well below
-# the pixel size at any zoom level our SVG supports, but slashes vertex
-# counts on the mainland enough to keep the file under ~400 KB.
-SIMPLIFY_TOLERANCE_DEG = 1e-4
+
+MIN_FEATURE_AREA_DEG2 = _min_feature_area()
+
+# Douglas-Peucker tolerance, in degrees. ~10 m at 34°N — still well
+# below the pixel size at any zoom level our SVG supports, but slashes
+# vertex counts on the mainland enough to keep the file under ~400 KB.
+# Tropical uses a 50x looser tolerance because (a) it covers 38° of
+# longitude vs CA's 7° (so each pixel covers far more ground anyway),
+# and (b) the per-island polygon count is so high that even small
+# per-poly vertex savings compound dramatically.
+def _simplify_tolerance():
+    try:
+        from pipeline.regions import active_region
+    except ModuleNotFoundError:
+        from regions import active_region
+    if active_region().name == "tropical":
+        return 5e-3
+    return 1e-4
+
+
+SIMPLIFY_TOLERANCE_DEG = _simplify_tolerance()
 
 # Known land seed points used to label polygonize() outputs as land vs sea.
 # Each (name, lng, lat) lies inside a real CA / Coronados land mass.
@@ -67,13 +108,34 @@ LAND_SEEDS = [
     ("baja-mainland",       -116.95, 32.10),
 ]
 
-# Used to exclude the polygonize() face that represents the open Pacific.
-# Each seed sits comfortably offshore; any polygon containing one of them
-# is sea regardless of its size.
+# Used to exclude the polygonize() face that represents the open ocean.
+# Each seed must sit comfortably offshore for SOME region the pipeline
+# runs against. The keep_land_polygons() pass rejects any polygon
+# containing any ocean seed.
+#
+# 2026-05-11 — added PNW + tropical seeds. The previous CA-only list
+# would have classified the open Pacific west of OR/WA, the Caribbean,
+# and the Gulf of Mexico as "land", because no seed landed inside the
+# bbox of those regions. Result: PNW + tropical land.geojson contained
+# the entire ocean as a huge "land" feature, which made the frontend
+# paint cream-colored land on top of the real SST data overlay. Bug
+# caught in dev QA on the multi-region rollout.
 OCEAN_SEEDS = [
+    # CA region
     (-123.50, 36.00),  # central offshore
     (-123.20, 33.50),  # SoCal offshore
     (-122.50, 32.00),  # Mexican offshore
+    # PNW region — well west of the OR/WA coast, inside the (-127..-122,
+    # 42..49) bbox.
+    (-126.00, 45.00),  # OR offshore
+    (-126.00, 47.00),  # WA outer coast offshore
+    # Tropical region — Gulf of Mexico + Caribbean.
+    (-90.00,  25.00),  # central Gulf
+    (-82.00,  26.00),  # FL east, Atlantic side
+    (-78.00,  22.00),  # Bahamas channel
+    (-75.00,  18.00),  # Caribbean Sea, north of Hispaniola
+    (-70.00,  15.00),  # mid-Caribbean
+    (-65.00,  12.00),  # eastern Caribbean
 ]
 
 OVERPASS_ENDPOINTS = [
@@ -83,7 +145,7 @@ OVERPASS_ENDPOINTS = [
 ]
 
 ROOT = Path(__file__).resolve().parents[1]
-OUT = ROOT / "public" / "data" / "land.geojson"
+OUT = active_region().data_output_dir(ROOT) / "land.geojson"
 
 
 def overpass_query(buffered_bbox: dict) -> dict:

--- a/pipeline/fetch_currents.py
+++ b/pipeline/fetch_currents.py
@@ -27,7 +27,14 @@ from PIL import Image, ImageDraw
 from scipy.spatial import cKDTree
 
 
-BBOX = dict(lat_min=31.8, lat_max=37.6, lng_min=-124.0, lng_max=-116.8)
+# Bbox via pipeline/regions/ (PR-X-1). CA / PNW / tropical switch on
+# SHOULDIDIVE_REGION; default `ca` preserves today's behavior.
+try:
+    from pipeline.regions import active_region
+except ModuleNotFoundError:
+    from regions import active_region
+
+BBOX = active_region().bbox
 GRID_W, GRID_H = 280, 220
 UV_RANGE = (-1.5, 1.5)  # m/s, roughly 0..3 kt in either component.
 HORIZON_DAYS = 5
@@ -36,7 +43,7 @@ PT = ZoneInfo("America/Los_Angeles")
 HFR_USWC_6KM = "https://dods.ndbc.noaa.gov/thredds/dodsC/hfradar_uswc_6km"
 
 ROOT = Path(__file__).resolve().parents[1]
-DATA_DIR = ROOT / "public" / "data"
+DATA_DIR = active_region().data_output_dir(ROOT)
 OUT_DIR = DATA_DIR / "currents"
 BUCKETS_DIR = OUT_DIR / "buckets"
 LAND_PATH = DATA_DIR / "land.geojson"

--- a/pipeline/fetch_mpa.py
+++ b/pipeline/fetch_mpa.py
@@ -15,7 +15,14 @@ from pathlib import Path
 
 import requests
 
-BBOX = dict(lat_min=31.8, lat_max=37.6, lng_min=-124.0, lng_max=-116.8)
+# Bbox via pipeline/regions/ (PR-X-1). CA / PNW / tropical switch on
+# SHOULDIDIVE_REGION; default `ca` preserves today's behavior.
+try:
+    from pipeline.regions import active_region
+except ModuleNotFoundError:
+    from regions import active_region
+
+BBOX = active_region().bbox
 
 # CDFW Open Data Portal — California Marine Protected Areas (ds582).
 # Direct GeoJSON download in WGS84.
@@ -25,7 +32,7 @@ URL = (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
-OUT_PATH = ROOT / "public" / "data" / "mpa-boundaries.geojson"
+OUT_PATH = active_region().data_output_dir(ROOT) / "mpa-boundaries.geojson"
 
 
 def slugify(name: str) -> str:

--- a/pipeline/fetch_precip.py
+++ b/pipeline/fetch_precip.py
@@ -21,7 +21,14 @@ import numpy as np
 import xarray as xr
 from PIL import Image
 
-BBOX = dict(lat_min=31.8, lat_max=37.6, lng_min=-124.0, lng_max=-116.8)
+# Bbox via pipeline/regions/ (PR-X-1). CA / PNW / tropical switch on
+# SHOULDIDIVE_REGION; default `ca` preserves today's behavior.
+try:
+    from pipeline.regions import active_region
+except ModuleNotFoundError:
+    from regions import active_region
+
+BBOX = active_region().bbox
 GRID_W, GRID_H = 140, 110
 
 PRECIP_RANGE_MM = (0.0, 200.0)
@@ -31,7 +38,7 @@ CPC_LON_MIN = (BBOX["lng_min"] + 360.0) % 360.0
 CPC_LON_MAX = (BBOX["lng_max"] + 360.0) % 360.0
 
 ROOT = Path(__file__).resolve().parents[1]
-OUT_DIR = ROOT / "public" / "data"
+OUT_DIR = active_region().data_output_dir(ROOT)
 
 
 def latest_url() -> str:

--- a/pipeline/fetch_rivers.py
+++ b/pipeline/fetch_rivers.py
@@ -25,7 +25,15 @@ from pathlib import Path
 import requests
 
 ROOT = Path(__file__).resolve().parents[1]
-OUT_DIR = ROOT / "public" / "data"
+
+# Region-aware output dir. CA stays at public/data/; PNW + tropical
+# land under public/data/<region>/. See pipeline/regions/ (PR-X-1).
+try:
+    from pipeline.regions import active_region
+except ModuleNotFoundError:
+    from regions import active_region
+
+OUT_DIR = active_region().data_output_dir(ROOT)
 
 # USGS site IDs picked for "closest reliable gauge to the river mouth".
 # (lat/lng here mirrors RIVER_MOUTHS in fetch_visibility.py for clarity.)

--- a/pipeline/fetch_sst_5day.py
+++ b/pipeline/fetch_sst_5day.py
@@ -37,9 +37,18 @@ from pathlib import Path
 import numpy as np
 from PIL import Image
 
+# Region config sourced from pipeline/regions/ (PR-X-1). CA / PNW /
+# tropical switch on SHOULDIDIVE_REGION; default `ca` preserves
+# today's behavior. Imported here (above PUBLIC_DATA) because
+# active_region() is also used at module load to set PUBLIC_DATA.
+try:
+    from pipeline.regions import active_region
+except ModuleNotFoundError:
+    from regions import active_region
+
 
 ROOT = Path(__file__).resolve().parents[1]
-PUBLIC_DATA = ROOT / "public" / "data"
+PUBLIC_DATA = active_region().data_output_dir(ROOT)
 SST5D_DIR   = PUBLIC_DATA / "sst5d"
 MANIFEST_PATH = PUBLIC_DATA / "manifest.json"
 
@@ -53,7 +62,7 @@ from sst_predict.config import (   # noqa: E402
     SIGMA_SST_BY_LEAD,
     LAT_LABELS,
     DIST_LABELS,
-    SST_RANGE_C,
+    SST_RANGE_C as _SST_RANGE_DEFAULT,
     SST_SCALE,
     SST_UNIT_C,
 )
@@ -63,8 +72,16 @@ HORIZON_DAYS = 7    # match fetch_wind_5day
 DAY_LABELS_REL = ["Today", "+1", "+2", "+3", "+4", "+5", "+6"]
 CONFIDENCE_BY_DAY = ["high", "high", "medium", "medium", "low", "low", "low"]
 
-# Bbox + grid (matches fetch.py exactly).
-BBOX = dict(lat_min=31.8, lat_max=37.6, lng_min=-124.0, lng_max=-116.8)
+# Bbox + grid — active_region() imported at top of file (above
+# PUBLIC_DATA assignment).
+BBOX = active_region().bbox
+
+# Region-aware SST encoding range. CA uses the legacy (9, 25); tropical
+# overrides to (20, 32) so 25-32°C water doesn't clip to 255 and read
+# back as a flat saturated max. PNW uses (5, 20). See
+# pipeline/regions/{ca,pnw,tropical}.py.layer_range_overrides.
+_overrides = getattr(active_region(), "layer_range_overrides", {}) or {}
+SST_RANGE_C = tuple(_overrides.get("sst5d", _overrides.get("sst", _SST_RANGE_DEFAULT)))
 GRID_H = 291
 GRID_W = 361
 

--- a/pipeline/fetch_swell_5day.py
+++ b/pipeline/fetch_swell_5day.py
@@ -33,7 +33,14 @@ from PIL import Image
 from scipy.ndimage import distance_transform_edt
 from scipy.spatial import cKDTree
 
-BBOX = dict(lat_min=31.8, lat_max=37.6, lng_min=-124.0, lng_max=-116.8)
+# Bbox via pipeline/regions/ (PR-X-1). CA / PNW / tropical switch on
+# SHOULDIDIVE_REGION; default `ca` preserves today's behavior.
+try:
+    from pipeline.regions import active_region
+except ModuleNotFoundError:
+    from regions import active_region
+
+BBOX = active_region().bbox
 
 NOMADS_GFS = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod"
 
@@ -61,7 +68,7 @@ DAY_LABELS_REL = ["Today", "+1", "+2", "+3", "+4"]
 CONFIDENCE_BY_DAY = ["high", "high", "high", "medium", "medium"]
 
 ROOT = Path(__file__).resolve().parents[1]
-OUT_DIR = ROOT / "public" / "data" / "swell"
+OUT_DIR = active_region().data_output_dir(ROOT) / "swell"
 HOURLY_DIR  = OUT_DIR / "hourly"
 BUCKETS_DIR = OUT_DIR / "buckets"
 CACHE_DIR   = ROOT / "pipeline" / ".cache"
@@ -80,12 +87,32 @@ def _head_ok(url: str) -> bool:
         return False
 
 
+# ---- Region-aware gfswave subset selection ---------------------------------
+#
+# NOAA publishes gfswave in geographically-narrow subsets so consumers
+# don't have to download the global grid. CA + PNW use `wcoast.0p16`
+# (US West Coast box). Tropical (Gulf + Caribbean + East FL) needs
+# `atlocn.0p16` (Atlantic + Gulf). Without this branch, fetch_swell_5day
+# silently produced empty bucket arrays for tropical — the user-visible
+# symptom was a grey swell layer with no data.
+def _gfswave_subset() -> str:
+    try:
+        from pipeline.regions import active_region
+    except ModuleNotFoundError:
+        from regions import active_region
+    name = active_region().name
+    if name == "tropical":
+        return "atlocn.0p16"
+    # CA + PNW (and any future West Coast region) use wcoast.
+    return "wcoast.0p16"
+
+
 # ---- Run discovery ----------------------------------------------------------
 
 def _idx_url(run_date: date, run_hour: int, fhour: int) -> str:
     return (
         f"{NOMADS_GFS}/gfs.{run_date.strftime('%Y%m%d')}/{run_hour:02d}/wave/gridded/"
-        f"gfswave.t{run_hour:02d}z.wcoast.0p16.f{fhour:03d}.grib2.idx"
+        f"gfswave.t{run_hour:02d}z.{_gfswave_subset()}.f{fhour:03d}.grib2.idx"
     )
 
 
@@ -106,14 +133,15 @@ def find_latest_gfswave_run_with_horizon(hours: int = 120) -> tuple[date, int]:
 
 def fetch_wave_slice(run_date: date, run_hour: int, fhour: int) -> Path:
     """Pull HTSGW + PERPW + DIRPW (surface level) for a single forecast hour."""
-    slug = f"gfswave_{run_date.strftime('%Y%m%d')}_t{run_hour:02d}z_f{fhour:03d}"
+    subset = _gfswave_subset()
+    slug = f"gfswave_{subset.replace('.', '_')}_{run_date.strftime('%Y%m%d')}_t{run_hour:02d}z_f{fhour:03d}"
     grib_path = CACHE_DIR / f"{slug}.grib2"
     if grib_path.exists():
         return grib_path
 
     base = (
         f"{NOMADS_GFS}/gfs.{run_date.strftime('%Y%m%d')}/{run_hour:02d}/wave/gridded/"
-        f"gfswave.t{run_hour:02d}z.wcoast.0p16.f{fhour:03d}.grib2"
+        f"gfswave.t{run_hour:02d}z.{subset}.f{fhour:03d}.grib2"
     )
     idx = SESSION.get(base + ".idx", timeout=60).text
     lines = idx.strip().split("\n")
@@ -460,7 +488,7 @@ def main() -> None:
     print(f"wrote {OUT_DIR / 'summary.json'}")
 
     # 6) Patch top-level manifest so the frontend can discover the layer.
-    manifest_path = ROOT / "public" / "data" / "manifest.json"
+    manifest_path = active_region().data_output_dir(ROOT) / "manifest.json"
     if manifest_path.exists():
         manifest = json.loads(manifest_path.read_text())
     else:

--- a/pipeline/fetch_tides.py
+++ b/pipeline/fetch_tides.py
@@ -1,4 +1,4 @@
-"""Fetch today's tide range for major CA tide stations from NOAA CO-OPS.
+"""Fetch today's tide range for the active region's NOAA CO-OPS stations.
 
 The visibility model's `tide_index` feature uses the daily tide range (max
 minus min over a 24h window) as a proxy for tidal mixing energy. Range is
@@ -9,10 +9,12 @@ We pull the next-24-hour hi/lo predictions for each station, take max-min,
 and emit a per-station JSON for the orchestrator to spread spatially via
 nearest-station sampling.
 
-Stations are evenly distributed along the CA coast inside our bbox; the
-visibility orchestrator picks the closest one per cell.
+2026-05-13: the per-region station list moved out of this file into
+`pipeline/regions/{ca,pnw,tropical}.py` (the `tide_stations` field on
+the Region dataclass). Add a new region's stations there; this file
+stays generic.
 
-Output: public/data/tides.json
+Output: public/data/[<region>/]tides.json
 
 Run: python pipeline/fetch_tides.py
 """
@@ -25,16 +27,17 @@ from pathlib import Path
 import requests
 
 ROOT = Path(__file__).resolve().parents[1]
-OUT_DIR = ROOT / "public" / "data"
 
-STATIONS = [
-    {"name": "monterey",      "id": "9413450", "lat": 36.605, "lng": -121.888},
-    {"name": "port-san-luis", "id": "9412110", "lat": 35.169, "lng": -120.755},
-    {"name": "santa-barbara", "id": "9411340", "lat": 34.404, "lng": -119.693},
-    {"name": "los-angeles",   "id": "9410660", "lat": 33.720, "lng": -118.272},
-    {"name": "la-jolla",      "id": "9410230", "lat": 32.866, "lng": -117.257},
-    {"name": "san-diego",     "id": "9410170", "lat": 32.713, "lng": -117.173},
-]
+# Region-aware output dir. CA stays at public/data/; PNW + tropical
+# land under public/data/<region>/. See pipeline/regions/ (PR-X-1).
+try:
+    from pipeline.regions import active_region
+except ModuleNotFoundError:
+    from regions import active_region
+
+REGION = active_region()
+OUT_DIR = REGION.data_output_dir(ROOT)
+STATIONS = REGION.tide_stations
 
 API = "https://api.tidesandcurrents.noaa.gov/api/prod/datagetter"
 
@@ -84,6 +87,12 @@ def fetch_tide_range_m(station_id: str) -> float | None:
 def main() -> None:
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     now = datetime.now(timezone.utc)
+    if not STATIONS:
+        # Region declares no tide stations (e.g., a brand-new region
+        # skeleton). Skip silently — the visibility model will fall
+        # back to its default tide_index when tides.json is missing.
+        print(f"[tides] region={REGION.name} has no tide_stations — skip")
+        return
     out_stations = []
     for st in STATIONS:
         rng = fetch_tide_range_m(st["id"])

--- a/pipeline/fetch_visibility.py
+++ b/pipeline/fetch_visibility.py
@@ -36,8 +36,23 @@ from scipy.spatial import cKDTree
 
 from viz_predict import predict as viz_predict
 
-# Match the existing app's bbox.
-BBOX = dict(lat_min=31.8, lat_max=37.6, lng_min=-124.0, lng_max=-116.8)
+# Bbox via pipeline/regions/ (PR-X-1). CA / PNW / tropical switch on
+# SHOULDIDIVE_REGION; default `ca` preserves today's behavior.
+try:
+    from pipeline.regions import active_region
+except ModuleNotFoundError:
+    from regions import active_region
+
+BBOX = active_region().bbox
+
+# Region-aware SST encoding range — must match the encoder used by
+# fetch.py / fetch_climatology.py. Hardcoding (9, 25) was a tropical
+# bug: the SST + climo PNGs are encoded with the region's range
+# (tropical = [20, 32]), so decoding with (9, 25) here read every
+# Caribbean cell as ~7°C colder than it actually was, polluting the
+# visibility model's anomaly features. (CA = (9, 25) unchanged.)
+_sst_overrides = active_region().layer_range_overrides
+SST_RANGE = tuple(_sst_overrides.get("sst", (9.0, 25.0)))
 
 # Output grid (regular lat/lng over bbox). Same shape as wind for visual consistency.
 GRID_W, GRID_H = 140, 110
@@ -57,7 +72,7 @@ QUALITY_CODES = {
 }
 
 ROOT = Path(__file__).resolve().parents[1]
-OUT_DIR = ROOT / "public" / "data"
+OUT_DIR = active_region().data_output_dir(ROOT)
 PIPELINE_DIR = ROOT / "pipeline"
 
 
@@ -475,7 +490,7 @@ def main():
         sys.exit(1)
 
     # Decode source PNGs
-    sst_src = decode_linear_png(sst_path, 9.0, 25.0)             # degC
+    sst_src = decode_linear_png(sst_path, *SST_RANGE)             # degC, region-aware
     chl_src = decode_log10_png(chl_path, 0.05, 20.0)              # mg/m³ (log10-encoded)
     u_src, v_src = decode_uv_png(wind_uv_path, -30.0, 30.0)
 
@@ -506,7 +521,7 @@ def main():
     chl_annual_path = OUT_DIR / "chl_climo_annual.png"
 
     if sst_climo_path.exists():
-        sst_climo_src = decode_linear_png(sst_climo_path, 9.0, 25.0)
+        sst_climo_src = decode_linear_png(sst_climo_path, *SST_RANGE)
         sst_climo_grid = bilinear_sample(sst_climo_src, sst_climo_src.shape[1], sst_climo_src.shape[0], lng_grid, lat_grid)
         print(f"  using SST climo: {np.nanmean(sst_climo_grid):.2f} °C mean "
               f"({np.isnan(sst_climo_grid).mean() * 100:.0f}% NaN cells)")
@@ -855,6 +870,20 @@ def main():
         "unit": "ft",
         "grid": {"width": GRID_W, "height": GRID_H},
         "source": "viz_predict (PREDICTED)",
+        # Marked beta 2026-05-14. The viz model:
+        #   * has no NorCal ground-truth observations to calibrate against
+        #     (all active dive-report scrapers are SoCal; see
+        #      pipeline/validation/ingest/CANDIDATES.md "Active scrapers")
+        #   * is fed by chl_1d.png which carries DINEOF gap-fill
+        #     synthetic values at the coast — the model's chl-anomaly
+        #     feature reads those as if they were real measurements
+        #   * uses zone coefficients (viz_predict/config.py) calibrated on
+        #     SoCal observations; norcal_* coefficients are physically
+        #     plausible defaults but haven't been validated
+        # Until at least NorCal scrapers are landed (a few weeks of
+        # actual dive reports), users should treat viz as advisory.
+        "beta": True,
+        "beta_reason": "NorCal predictions unvalidated; chl input affected by gap-fill",
         "generated_at": generated_at,
         "windows": {
             "now": {

--- a/pipeline/fetch_waves.py
+++ b/pipeline/fetch_waves.py
@@ -33,7 +33,14 @@ import xarray as xr
 from PIL import Image
 from scipy.spatial import cKDTree
 
-BBOX = dict(lat_min=31.8, lat_max=37.6, lng_min=-124.0, lng_max=-116.8)
+# Bbox via pipeline/regions/ (PR-X-1). CA / PNW / tropical switch on
+# SHOULDIDIVE_REGION; default `ca` preserves today's behavior.
+try:
+    from pipeline.regions import active_region
+except ModuleNotFoundError:
+    from regions import active_region
+
+BBOX = active_region().bbox
 NOMADS_GFS = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod"
 
 # Output grid (matches the wind / viz grid for consistency).
@@ -45,7 +52,7 @@ PERIOD_RANGE_S = (0.0, 25.0)
 # Direction stays 0..360 mapped to 0..255 byte (linear).
 
 ROOT = Path(__file__).resolve().parents[1]
-OUT_DIR = ROOT / "public" / "data"
+OUT_DIR = active_region().data_output_dir(ROOT)
 CACHE_DIR = ROOT / "pipeline" / ".cache"
 
 SESSION = requests.Session()
@@ -56,15 +63,31 @@ def _get(url, **kwargs):
     return SESSION.get(url, timeout=180, **kwargs)
 
 
+# Region-aware gfswave subset — mirrors fetch_swell_5day.py. CA + PNW
+# use the wcoast (US West Coast) subset; tropical uses atlocn (Atlantic
+# + Gulf + Caribbean). Without this, the tropical refresh tries to hit
+# the wcoast endpoint which doesn't cover the Atlantic and 404s on
+# every run.
+def _gfswave_subset() -> str:
+    try:
+        from pipeline.regions import active_region
+    except ModuleNotFoundError:
+        from regions import active_region
+    if active_region().name == "tropical":
+        return "atlocn.0p16"
+    return "wcoast.0p16"
+
+
 def _idx_url(run_date: date, run_hour: int) -> str:
     return (
         f"{NOMADS_GFS}/gfs.{run_date.strftime('%Y%m%d')}/{run_hour:02d}/wave/gridded/"
-        f"gfswave.t{run_hour:02d}z.wcoast.0p16.f000.grib2.idx"
+        f"gfswave.t{run_hour:02d}z.{_gfswave_subset()}.f000.grib2.idx"
     )
 
 
 def find_latest_gfswave_run() -> tuple[date, int]:
-    """Latest GFS cycle (00/06/12/18z) whose gfswave wcoast f000 is published."""
+    """Latest GFS cycle (00/06/12/18z) whose gfswave {subset} f000 is published."""
+    subset = _gfswave_subset()
     now = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
     cycle = (now.hour // 6) * 6
     candidate = now.replace(hour=cycle)
@@ -72,9 +95,9 @@ def find_latest_gfswave_run() -> tuple[date, int]:
         url = _idx_url(candidate.date(), candidate.hour)
         if SESSION.head(url, timeout=30, allow_redirects=True).status_code == 200:
             return candidate.date(), candidate.hour
-        print(f"  miss: gfswave {candidate.strftime('%Y-%m-%d %H')}z f000 not yet published")
+        print(f"  miss: gfswave {subset} {candidate.strftime('%Y-%m-%d %H')}z f000 not yet published")
         candidate -= timedelta(hours=6)
-    raise RuntimeError("No gfswave wcoast f000 found in last 24 hours")
+    raise RuntimeError(f"No gfswave {subset} f000 found in last 24 hours")
 
 
 def find_history_runs(latest_date: date, latest_hour: int, n_days: int = 4) -> list[tuple[date, int]]:
@@ -107,15 +130,16 @@ def find_history_runs(latest_date: date, latest_hour: int, n_days: int = 4) -> l
 
 def fetch_wave_slice(run_date: date, run_hour: int) -> Path:
     """Byte-range fetch HTSGW + PERPW + DIRPW at surface for f000."""
+    subset = _gfswave_subset()
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    slug = f"gfswave_{run_date.strftime('%Y%m%d')}_t{run_hour:02d}z_f000"
+    slug = f"gfswave_{subset.replace('.', '_')}_{run_date.strftime('%Y%m%d')}_t{run_hour:02d}z_f000"
     grib_path = CACHE_DIR / f"{slug}.grib2"
     if grib_path.exists():
         return grib_path
 
     base = (
         f"{NOMADS_GFS}/gfs.{run_date.strftime('%Y%m%d')}/{run_hour:02d}/wave/gridded/"
-        f"gfswave.t{run_hour:02d}z.wcoast.0p16.f000.grib2"
+        f"gfswave.t{run_hour:02d}z.{subset}.f000.grib2"
     )
     print(f"  GET {base}.idx", flush=True)
     idx = _get(base + ".idx").text

--- a/pipeline/fetch_wind.py
+++ b/pipeline/fetch_wind.py
@@ -31,20 +31,50 @@ import xarray as xr
 from PIL import Image
 from scipy.spatial import cKDTree
 
-# Match the existing app's bbox.
-BBOX = dict(lat_min=31.8, lat_max=37.6, lng_min=-124.0, lng_max=-116.8)
+# Bbox via pipeline/regions/ (PR-X-1). CA / PNW / tropical switch on
+# SHOULDIDIVE_REGION; default `ca` preserves today's behavior.
+try:
+    from pipeline.regions import active_region
+except ModuleNotFoundError:
+    from regions import active_region
+
+BBOX = active_region().bbox
 
 NOMADS_HRRR = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/hrrr/prod"
 NOMADS_GFS = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod"
 
 # Per-slot config: (source, fcst_hour). HRRR for short-range; GFS for +72h
 # since HRRR maxes out at f48.
-SLOTS = {
-    "now":  {"source": "hrrr", "fhour": 0},
-    "p6h":  {"source": "hrrr", "fhour": 6},
-    "p24h": {"source": "hrrr", "fhour": 24},
-    "p72h": {"source": "gfs",  "fhour": 72},
-}
+#
+# 2026-05-12 — region-aware fallback. HRRR's CONUS domain ends at
+# ~21°N, so the Caribbean half of the tropical bbox (10-22°N) is
+# outside it. Tropical refreshes that requested HRRR got a CONUS-only
+# wind PNG with the Caribbean cells NaN — visible to the user as
+# "wind only over US waters." For tropical, use GFS (global 0.25°)
+# for every slot instead. Lower resolution than HRRR but covers the
+# full bbox uniformly. CA + PNW keep HRRR for short-range.
+def _slots_for_active_region():
+    try:
+        from pipeline.regions import active_region
+    except ModuleNotFoundError:
+        from regions import active_region
+    if active_region().name == "tropical":
+        return {
+            "now":  {"source": "gfs", "fhour": 0},
+            "p6h":  {"source": "gfs", "fhour": 6},
+            "p24h": {"source": "gfs", "fhour": 24},
+            "p72h": {"source": "gfs", "fhour": 72},
+        }
+    # CA + PNW are inside HRRR's CONUS domain — keep the high-res mix.
+    return {
+        "now":  {"source": "hrrr", "fhour": 0},
+        "p6h":  {"source": "hrrr", "fhour": 6},
+        "p24h": {"source": "hrrr", "fhour": 24},
+        "p72h": {"source": "gfs",  "fhour": 72},
+    }
+
+
+SLOTS = _slots_for_active_region()
 
 # History slots: prior daily GFS f000 analyses, used by the visibility model
 # to compute upwelling anomalies (5-day along-shore wind mean). HRRR isn't
@@ -65,7 +95,7 @@ SPEED_RANGE = (0.0, 50.0)   # knots
 UV_RANGE = (-30.0, 30.0)    # m/s
 
 ROOT = Path(__file__).resolve().parents[1]
-OUT_DIR = ROOT / "public" / "data"
+OUT_DIR = active_region().data_output_dir(ROOT)
 CACHE_DIR = ROOT / "pipeline" / ".cache"
 
 # NOMADS HTTP/2 implementation is broken; force HTTP/1.1.
@@ -259,6 +289,112 @@ def regrid_to_bbox(lat2d, lng2d, u, v, source: str):
     return u_grid, v_grid
 
 
+# ---- Land mask --------------------------------------------------------------
+#
+# HRRR / GFS publish 10 m wind over LAND too — with terrain-friction-reduced
+# magnitudes and orographic distortion. If we encode those land values into
+# wind_uv_*.png, they're indistinguishable from over-water wind in the PNG
+# (alpha=255 either way), so:
+#   1. The frontend's WindParticles bilinear sampler near the coast pulls a
+#      mix of land + ocean cells → particle velocity vectors get smeared
+#      landward.
+#   2. The geojson land mask in WindParticles eventually respawns those
+#      particles, but only AFTER they've drifted a few frames inland —
+#      visible as jittery / wrong-direction streamlines at the shoreline.
+#
+# Fix (2026-05-14): consume the bathy.png alpha channel as a land mask and
+# NaN-out u/v over land cells before encoding. bathy.py guarantees `0 = land`
+# (line 18 of fetch_bathy.py). With u/v NaN over land, encode_uv_png writes
+# alpha=0 there, the frontend bilinear sampler returns NaN, and the
+# "!Number.isFinite(u)" respawn fires on the very first step instead of
+# hunting through the coarser geojson mask.
+#
+# Graceful degradation: if bathy.png is missing (first-run on a region
+# before fetch_bathy.py has fired) the mask returns None and wind encoding
+# falls back to today's behavior. Hourly wind continues to work; the land
+# crispness improves once bathy lands.
+
+def load_land_mask(out_dir: Path, grid_w: int, grid_h: int,
+                   land_threshold: float = 0.7) -> np.ndarray | None:
+    """Read bathy.png and downsample to a wind-grid-resolution land mask.
+
+    Returns a boolean numpy array where True = land, False = ocean.
+    None if bathy.png is missing.
+
+    `land_threshold` controls how aggressively coastal cells get flagged:
+      0.5 = a cell is "land" if more than half its area is land
+      0.7 = a cell is "land" only if >70% of its area is land (default)
+      0.9 = a cell is "land" only if >90% of its area is land (most lenient)
+
+    2026-05-14 — first attempt at this used nearest-neighbor sampling
+    (a single bathy pixel near each wind cell's center decided land vs
+    ocean). With 140-wide × 11.7° CA bbox each wind cell spans ~7 km;
+    every coastal cell straddles the actual coastline. NN would land
+    on whichever side of the coast happened to be at the cell center,
+    randomly flagging mostly-ocean coastal cells as land. The visible
+    effect was a uniform ~10 km gap of "no wind data" tracing the
+    entire coast — user saw wind appearing "pushed out to the left."
+
+    Box-averaging the fraction of land per cell + thresholding gives
+    physically meaningful behavior: cells that are MAJORITY ocean
+    (which is what coastal nearshore cells almost always are) keep
+    valid wind data. Wind streamlines now extend right up to the
+    shoreline before respawning.
+    """
+    bathy_path = out_dir / "bathy.png"
+    if not bathy_path.exists():
+        return None
+    try:
+        img = Image.open(bathy_path).convert("L")
+    except Exception as e:
+        print(f"  [land-mask] open failed for {bathy_path}: {e!s} — skipping mask",
+              flush=True)
+        return None
+    arr = np.asarray(img)
+    if arr.ndim != 2:
+        return None
+    src_h, src_w = arr.shape
+    # bathy.png encoding: pixel 0 = land (NaN), 1..255 = depth.
+    src_land_bool = arr == 0
+    # Compute land-area fraction for each (grid_h, grid_w) cell by
+    # box-averaging the source bathy land mask. Each wind cell maps to
+    # a (src_h/grid_h) x (src_w/grid_w) tile of bathy pixels; the
+    # cell's land fraction is the mean of the boolean mask over that
+    # tile. Falls back to NN behavior if the bathy is somehow lower
+    # res than the wind grid (shouldn't happen — bathy is 1 km, wind
+    # grid is 7-10 km).
+    is_land = np.zeros((grid_h, grid_w), dtype=bool)
+    if src_h < grid_h or src_w < grid_w:
+        # Degenerate case: bathy lower-res than wind grid. Just NN.
+        yi = np.linspace(0, src_h - 1, grid_h).round().astype(int)
+        xi = np.linspace(0, src_w - 1, grid_w).round().astype(int)
+        return src_land_bool[yi[:, None], xi[None, :]]
+    for i in range(grid_h):
+        y0 = i * src_h // grid_h
+        y1 = max(y0 + 1, (i + 1) * src_h // grid_h)
+        for j in range(grid_w):
+            x0 = j * src_w // grid_w
+            x1 = max(x0 + 1, (j + 1) * src_w // grid_w)
+            cell = src_land_bool[y0:y1, x0:x1]
+            land_frac = cell.mean() if cell.size else 0.0
+            is_land[i, j] = land_frac > land_threshold
+    return is_land
+
+
+def apply_land_mask(u: np.ndarray, v: np.ndarray,
+                    land_mask: np.ndarray | None) -> tuple[np.ndarray, np.ndarray]:
+    """Return (u, v) with land cells NaN'd out. No-op if mask is None."""
+    if land_mask is None:
+        return u, v
+    if land_mask.shape != u.shape:
+        print(f"  [land-mask] shape mismatch (mask {land_mask.shape} vs "
+              f"u {u.shape}) — skipping mask", flush=True)
+        return u, v
+    u = np.where(land_mask, np.nan, u)
+    v = np.where(land_mask, np.nan, v)
+    return u, v
+
+
 # ---- Encoders ---------------------------------------------------------------
 
 def encode_speed_png(u: np.ndarray, v: np.ndarray, out_path: Path) -> None:
@@ -311,6 +447,17 @@ def main() -> None:
         "windows": {},
     }
 
+    # Load once per run; reused for every slot. None if bathy.png missing.
+    land_mask = load_land_mask(OUT_DIR, GRID_W, GRID_H)
+    if land_mask is not None:
+        land_frac = float(land_mask.mean())
+        print(f"Loaded land mask from bathy.png ({land_frac:.0%} land cells)",
+              flush=True)
+    else:
+        print("No bathy.png yet — wind UV will include over-land HRRR/GFS "
+              "values; streamlines may jitter at the coast until bathy lands",
+              flush=True)
+
     for slot, cfg in SLOTS.items():
         source = cfg["source"]
         fhour = cfg["fhour"]
@@ -327,6 +474,14 @@ def main() -> None:
             # Per the correctness principle: skip the slot rather than fake it.
             print(f"  {slot}: failed — {e!s}", flush=True)
             continue
+
+        # Mask over-land cells BEFORE encoding so the published PNG has
+        # alpha=0 over land. WindParticles' "!Number.isFinite(u)" respawn
+        # then fires on the very first frame a particle samples a land
+        # neighbour, instead of relying on the coarser geojson mask which
+        # only catches it a few frames later. Net effect: streamlines stop
+        # crisply at the coast.
+        u, v = apply_land_mask(u, v, land_mask)
 
         speed_path = OUT_DIR / f"wind_speed_{slot}.png"
         uv_path = OUT_DIR / f"wind_uv_{slot}.png"
@@ -383,6 +538,12 @@ def main() -> None:
         except Exception as e:
             print(f"  {slot}: failed — {e!s}")
             continue
+
+        # Same land mask as the forward-looking slots above. The viz
+        # model only uses these history frames to compute upwelling
+        # anomalies (along-shore wind average), which is fine with
+        # NaN over land — its sampler is over-water-only too.
+        u, v = apply_land_mask(u, v, land_mask)
 
         encode_uv_png(u, v, cached_path)
         valid_at = datetime(run_date.year, run_date.month, run_date.day, run_hour, tzinfo=timezone.utc)

--- a/pipeline/fetch_wind_5day.py
+++ b/pipeline/fetch_wind_5day.py
@@ -44,8 +44,14 @@ import xarray as xr
 from PIL import Image
 from scipy.spatial import cKDTree
 
-# Match the existing app's bbox.
-BBOX = dict(lat_min=31.8, lat_max=37.6, lng_min=-124.0, lng_max=-116.8)
+# Bbox via pipeline/regions/ (PR-X-1). CA / PNW / tropical switch on
+# SHOULDIDIVE_REGION; default `ca` preserves today's behavior.
+try:
+    from pipeline.regions import active_region
+except ModuleNotFoundError:
+    from regions import active_region
+
+BBOX = active_region().bbox
 
 NOMADS_HRRR = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/hrrr/prod"
 NOMADS_GFS  = "https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod"
@@ -72,7 +78,7 @@ CONFIDENCE_BY_DAY = ["high", "high", "medium", "medium", "low", "low", "low"]
 HORIZON_DAYS = len(DAY_LABELS_REL)  # 7
 
 ROOT = Path(__file__).resolve().parents[1]
-OUT_DIR = ROOT / "public" / "data" / "wind"
+OUT_DIR = active_region().data_output_dir(ROOT) / "wind"
 HOURLY_DIR  = OUT_DIR / "hourly"
 BUCKETS_DIR = OUT_DIR / "buckets"
 CACHE_DIR   = ROOT / "pipeline" / ".cache"
@@ -242,6 +248,65 @@ def regrid_to_bbox(lat2d, lng2d, u, v, source: str):
     return u_grid, v_grid
 
 
+# ---- Land mask --------------------------------------------------------------
+#
+# Same rationale as fetch_wind.py — HRRR/GFS publish wind over land too, and
+# without masking them out the frontend's WindParticles streamlines smear
+# landward at the coast. bathy.png alpha=0 marks land; we apply that mask
+# to u/v before encoding.
+
+def load_land_mask(out_root: Path, grid_w: int, grid_h: int,
+                   land_threshold: float = 0.7) -> np.ndarray | None:
+    """Read bathy.png (region's data dir) and downsample to wind grid.
+
+    Returns True=land boolean array, or None if bathy.png isn't there.
+    Uses box-averaged land area fraction with threshold (default 0.7)
+    so coastal cells with majority ocean keep valid wind data. See
+    fetch_wind.py docstring for the long version — same algorithm
+    intentionally duplicated here so each fetcher can run independently
+    without an inter-fetcher import.
+    """
+    region_data_dir = active_region().data_output_dir(out_root)
+    bathy_path = region_data_dir / "bathy.png"
+    if not bathy_path.exists():
+        return None
+    try:
+        img = Image.open(bathy_path).convert("L")
+    except Exception as e:
+        print(f"  [land-mask] open failed for {bathy_path}: {e!s} — skipping",
+              flush=True)
+        return None
+    arr = np.asarray(img)
+    if arr.ndim != 2:
+        return None
+    src_h, src_w = arr.shape
+    src_land_bool = arr == 0
+    if src_h < grid_h or src_w < grid_w:
+        yi = np.linspace(0, src_h - 1, grid_h).round().astype(int)
+        xi = np.linspace(0, src_w - 1, grid_w).round().astype(int)
+        return src_land_bool[yi[:, None], xi[None, :]]
+    is_land = np.zeros((grid_h, grid_w), dtype=bool)
+    for i in range(grid_h):
+        y0 = i * src_h // grid_h
+        y1 = max(y0 + 1, (i + 1) * src_h // grid_h)
+        for j in range(grid_w):
+            x0 = j * src_w // grid_w
+            x1 = max(x0 + 1, (j + 1) * src_w // grid_w)
+            cell = src_land_bool[y0:y1, x0:x1]
+            land_frac = cell.mean() if cell.size else 0.0
+            is_land[i, j] = land_frac > land_threshold
+    return is_land
+
+
+def apply_land_mask(u: np.ndarray, v: np.ndarray,
+                    land_mask: np.ndarray | None) -> tuple[np.ndarray, np.ndarray]:
+    if land_mask is None or land_mask.shape != u.shape:
+        return u, v
+    u = np.where(land_mask, np.nan, u)
+    v = np.where(land_mask, np.nan, v)
+    return u, v
+
+
 # ---- Encoding ---------------------------------------------------------------
 
 def encode_uv_png(u: np.ndarray, v: np.ndarray, out_path: Path) -> None:
@@ -309,6 +374,19 @@ def main() -> None:
     # 3) Fetch + decode every hourly step, indexed by Pacific (day, hour).
     hourly: dict[tuple[int, int], dict] = {}
 
+    # Load the land mask once per run. None if bathy.png isn't present
+    # (first-run on a fresh region). Applied inside store() so every
+    # downstream consumer — per-hour PNG, bucket mean, bucket speed
+    # statistics — sees masked u/v consistently.
+    land_mask = load_land_mask(ROOT, GRID_W, GRID_H)
+    if land_mask is not None:
+        print(f"Loaded land mask from bathy.png "
+              f"({float(land_mask.mean()):.0%} land cells)", flush=True)
+    else:
+        print("No bathy.png yet — wind 5d UV will include over-land HRRR/GFS "
+              "values; streamlines may jitter at the coast until bathy lands",
+              flush=True)
+
     def store(valid_at_utc, u_grid, v_grid, source):
         valid_pt = valid_at_utc.astimezone(PT)
         day_offset = (valid_pt.date() - anchor_pt_date).days
@@ -318,6 +396,9 @@ def main() -> None:
         # Prefer HRRR if both sources cover the same hour.
         if key in hourly and hourly[key]["source"] == "hrrr" and source == "gfs":
             return
+        # Mask land BEFORE storing. Bucket aggregation downstream
+        # nanmean's across the time axis, so land cells stay NaN.
+        u_grid, v_grid = apply_land_mask(u_grid, v_grid, land_mask)
         hourly[key] = {"u": u_grid, "v": v_grid, "source": source, "valid_at": valid_at_utc}
 
     # GFS goes to f168 (7 days) at 1-hour spacing through f120, then 3-hour
@@ -329,9 +410,21 @@ def main() -> None:
     HRRR_END = 49  # exclusive
     GFS_END = GFS_HORIZON_HRS + 1  # exclusive
 
+    # Region-aware: skip HRRR entirely for tropical because HRRR's
+    # CONUS domain ends at ~21°N, leaving the Caribbean half of the
+    # tropical bbox without data. GFS (0.25° global) covers the whole
+    # tropical bbox uniformly. CA + PNW are inside CONUS so they keep
+    # the high-res HRRR mix for f00..f48.
+    region_name = active_region().name
+    use_hrrr = region_name != "tropical"
+    if not use_hrrr:
+        print(f"region={region_name}: skipping HRRR (outside CONUS), using GFS f000..f168")
+
     fetched = 0
     failed  = 0
-    for fhour in range(0, HRRR_END):
+    hrrr_range = range(0, HRRR_END) if use_hrrr else range(0)
+    gfs_start = HRRR_END if use_hrrr else 0
+    for fhour in hrrr_range:
         try:
             grib = fetch_hrrr_slice(hrrr_d, hrrr_h, fhour)
             lat2d, lng2d, u_native, v_native = open_uv(grib)
@@ -341,7 +434,7 @@ def main() -> None:
         except Exception as e:
             print(f"  HRRR f{fhour:02d}: {e!s}")
             failed += 1
-    for fhour in range(HRRR_END, GFS_END):
+    for fhour in range(gfs_start, GFS_END):
         try:
             grib = fetch_gfs_slice(gfs_d, gfs_h, fhour)
             lat2d, lng2d, u_native, v_native = open_uv(grib)
@@ -490,7 +583,7 @@ def main() -> None:
     #    layer payload intact (still consumed by the current 4-slot UI) and
     #    add a new `wind5d` block alongside it. Once the new UI lands the
     #    legacy one can be dropped.
-    manifest_path = ROOT / "public" / "data" / "manifest.json"
+    manifest_path = active_region().data_output_dir(ROOT) / "manifest.json"
     if manifest_path.exists():
         manifest = json.loads(manifest_path.read_text())
     else:

--- a/pipeline/lib/layer_spec.py
+++ b/pipeline/lib/layer_spec.py
@@ -236,6 +236,31 @@ LAYER_SPECS: dict[str, LayerSpec] = {
         extra_required_keys=("uv_range", "speed_range", "summary_url"),
         extra_optional_keys=("beta", "method", "vector_convention"),
     ),
+    "rtofs5d": LayerSpec(
+        # NOAA RTOFS Global ocean-model 7-day forecast. Parallel track
+        # to sst5d (persistence-decay) carrying SST + surface currents
+        # in one manifest entry — the loader (src/lib/loaders/rtofs5d.js)
+        # decodes the per-lead SST PNGs from `sst_d{1,3,5,7}.png` and the
+        # per-lead U/V RGBA PNGs from `uv_d{1,3,5,7}.png` referenced
+        # inside the summary file. Range is region-aware via
+        # active_region().layer_range_overrides["sst5d"]; the manifest
+        # entry mirrors whatever range the SST PNGs were encoded with.
+        # Beta flag matches sst5d's convention.
+        name="rtofs5d",
+        category="temperature",
+        range=(9.0, 25.0),
+        scale="linear",
+        unit="degC",
+        payload="summary_only",
+        extra_required_keys=("summary_url", "uv_range", "uv_unit"),
+        extra_optional_keys=(
+            "beta",
+            "model",
+            "init_cycle",
+            "horizon_days",
+            "leads_day_offsets",
+        ),
+    ),
     "viz": LayerSpec(
         name="viz",
         category="visibility",
@@ -244,7 +269,12 @@ LAYER_SPECS: dict[str, LayerSpec] = {
         unit="ft",
         payload="scalar_png",
         extra_required_keys=("range_ft",),
-        extra_optional_keys=("p10_url", "p90_url", "quality_url"),
+        extra_optional_keys=(
+            "p10_url", "p90_url", "quality_url",
+            # 2026-05-14: viz marked beta until NorCal ground truth lands;
+            # beta_reason is a free-text disclaimer surfaced in the UI.
+            "beta", "beta_reason",
+        ),
     ),
     "wave": LayerSpec(
         # Published as a wave_png with height_range_m + period_range_s,

--- a/pipeline/regions/__init__.py
+++ b/pipeline/regions/__init__.py
@@ -1,0 +1,102 @@
+"""Region-aware pipeline config (PR-X-1 scaffold, additive-only).
+
+This package is the foundation for `docs/expansion-regions.md`. v1 ships
+a single `ca` region that snapshots the CURRENT hardcoded behavior;
+`pnw` and `tropical` are skeleton placeholders with the proposed bbox
++ zone bounds from the scoping doc, intentionally left thin so a later
+PR (PR-X-2 / PR-X-3) can fill them in alongside the actual fetcher
+wire-up.
+
+## Why scaffold-only
+
+Today, bbox and zone bounds are duplicated across:
+  * `pipeline/fetch.py`, `chl_blend.py`, `fetch_bathy.py`, …
+  * `pipeline/viz_predict/config.py`
+  * `src/lib/mapData.js`
+
+Rewiring all of those in one PR is a multi-hundred-LOC change with
+real regression risk. PR-X-1 is *additive*: this package exists,
+exports a stable interface, and is unused by the running pipeline.
+PR-X-2 / PR-X-3 will migrate consumers one fetch script at a time
+behind a `--region` CLI flag, with the `ca` region preserving today's
+behavior bit-for-bit.
+
+## Interface
+
+    from regions import get_region, list_regions, active_region
+
+    r = get_region("ca")
+    r.bbox          # dict(lat_min, lat_max, lng_min, lng_max)
+    r.bbox_array    # [lng_min, lat_min, lng_max, lat_max] — manifest order
+    r.lat_zone_bounds  # OrderedDict[str, (low, high)]
+    r.dist_labels      # ["nearshore", "islands", "offshore"]
+    r.viz_model_variant  # "chl_based" | "subtractive_tropical"
+    r.data_dir_slug      # "ca" | "pnw" | "tropical"
+
+`active_region()` resolves from the env var ``SHOULDIDIVE_REGION``
+with a default of ``ca`` — matches today's behavior for callers that
+import the package but don't pass an explicit name.
+
+## What is NOT here (deliberately)
+
+* DriverCoefficients dictionaries — still in `viz_predict/config.py`.
+  Migrate in PR-X-2 once the wiring layer is settled.
+* Spot pins — still in `src/lib/savedSpots` + `validation/ingest/
+  _spot_lookup.json`. Migrate in PR-X-3.
+* Per-region source URLs (HYCOM, SSCOFS, …) — those land with the
+  per-region fetcher PRs (PR-PNW-2, PR-TROP-2).
+"""
+from __future__ import annotations
+
+import os
+
+from ._region import Region
+from .ca import REGION as _CA
+from .pnw import REGION as _PNW
+from .tropical import REGION as _TROPICAL
+
+
+_REGISTRY: dict[str, Region] = {
+    _CA.name:       _CA,
+    _PNW.name:      _PNW,
+    _TROPICAL.name: _TROPICAL,
+}
+
+DEFAULT_REGION = "ca"
+
+
+def get_region(name: str) -> Region:
+    """Look up a region by canonical name. Raises ``KeyError`` on miss
+    — callers should fail loud rather than silently fall back to CA.
+    """
+    if name not in _REGISTRY:
+        valid = ", ".join(sorted(_REGISTRY.keys()))
+        raise KeyError(
+            f"Unknown region {name!r}; valid regions: {valid}. "
+            f"Add a new entry under pipeline/regions/ if this is intentional.",
+        )
+    return _REGISTRY[name]
+
+
+def list_regions() -> list[str]:
+    """Stable-sorted region names. Useful for CI matrix generation."""
+    return sorted(_REGISTRY.keys())
+
+
+def active_region() -> Region:
+    """Resolve the region from ``$SHOULDIDIVE_REGION`` (default ``ca``).
+
+    Callers in fetch.py / viz_predict will use this when they don't
+    take an explicit `--region` CLI flag, preserving today's behavior
+    when the env var is unset.
+    """
+    return get_region(os.environ.get("SHOULDIDIVE_REGION", DEFAULT_REGION))
+
+
+__all__ = [
+    "Region",
+    "get_region",
+    "list_regions",
+    "active_region",
+    "DEFAULT_REGION",
+]

--- a/pipeline/regions/_region.py
+++ b/pipeline/regions/_region.py
@@ -1,0 +1,104 @@
+"""``Region`` dataclass — the shape every region must produce.
+
+Lives in its own module so test fixtures and per-region files can
+import it without circular-import gymnastics through the package
+``__init__``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+
+VizModelVariant = Literal["chl_based", "subtractive_tropical"]
+
+
+@dataclass(frozen=True)
+class Region:
+    """Per-region configuration consumed by the pipeline + frontend.
+
+    Required:
+        name              Short canonical slug (``ca``, ``pnw``,
+                          ``tropical``). Doubles as the data-dir
+                          subfolder under ``public/data/``.
+        display_name      Human-readable name for the region switcher
+                          chip in the frontend.
+        bbox              Geographic bbox in dict form. Pipeline
+                          fetchers consume this directly.
+        lat_zone_bounds   Insertion-ordered dict ``{name: (low, high)}``.
+                          ``classify_zone`` walks this generically; a
+                          new band only needs an entry here.
+        dist_labels       Distance-band labels (``["nearshore",
+                          "islands", "offshore"]`` in CA). The
+                          DriverCoefficients dict keys these labels
+                          against lat-zone names; renaming requires a
+                          coordinated viz_predict/config.py update.
+        viz_model_variant ``chl_based`` (CA/PNW outer) or
+                          ``subtractive_tropical`` (FL/Caribbean).
+                          Controls which formula viz_predict picks.
+        data_dir_slug     Folder under ``public/data/`` where this
+                          region's PNGs land. Allows CA/PNW/tropical
+                          to coexist without overwrite.
+
+    Optional / forward-looking:
+        subregion_bboxes  For regions that need multiple fetch passes
+                          to stay under data volume / runtime caps
+                          (``tropical`` splits into ``gulf_se`` +
+                          ``caribbean``). Empty for single-bbox regions.
+        notes             Free-text. Useful for "this is a placeholder,
+                          fill before PR-X-N" markers in the skeletons.
+    """
+
+    name: str
+    display_name: str
+    bbox: dict
+    lat_zone_bounds: dict
+    dist_labels: list
+    viz_model_variant: VizModelVariant
+    data_dir_slug: str
+    subregion_bboxes: dict = field(default_factory=dict)
+    # Per-layer range overrides used by the PNG encoder. LAYER_SPECS in
+    # pipeline/lib/layer_spec.py carries CA-calibrated defaults; non-CA
+    # regions override here so the 8-bit PNG encoding spans the right
+    # temperature / chl / etc. window for that water. Without this,
+    # tropical SST (25-32°C) clips at 25°C and shows uniform red.
+    layer_range_overrides: dict = field(default_factory=dict)
+    # NOAA CO-OPS tide stations used by fetch_tides.py. Each entry:
+    # ``{"name": "san-juan", "id": "9755371", "lat": 18.46, "lng": -66.12}``.
+    # The visibility orchestrator nearest-neighbors each output cell to
+    # one of these. Empty list → fetch_tides.py becomes a no-op for
+    # this region (visibility falls back to its default tide_index).
+    tide_stations: list = field(default_factory=list)
+    notes: str = ""
+
+    @property
+    def bbox_array(self) -> list[float]:
+        """Manifest-order bbox: ``[lng_min, lat_min, lng_max, lat_max]``.
+
+        Frontend ``manifest.json`` reads this shape; using a method
+        avoids stashing two representations in the dataclass body.
+        """
+        b = self.bbox
+        return [b["lng_min"], b["lat_min"], b["lng_max"], b["lat_max"]]
+
+    def data_output_dir(self, repo_root) -> "Path":  # type: ignore[name-defined]
+        """Where this region's data PNGs / JSON outputs live under ``public/data/``.
+
+        Convention:
+          * CA stays at ``public/data/`` for backward compatibility
+            (every existing PNG path the frontend expects).
+          * Every other region nests under ``public/data/<slug>/``.
+
+        The directory is created on access so callers can write to
+        it immediately without their own mkdir bookkeeping.
+        """
+        from pathlib import Path
+
+        root = Path(repo_root)
+        base = root / "public" / "data"
+        if self.name == "ca":
+            base.mkdir(parents=True, exist_ok=True)
+            return base
+        out = base / self.data_dir_slug
+        out.mkdir(parents=True, exist_ok=True)
+        return out

--- a/pipeline/regions/ca.py
+++ b/pipeline/regions/ca.py
@@ -1,0 +1,74 @@
+"""California region config — SoCal staged launch (NorCal deferred).
+
+This is the SoCal-pinned variant of the CA region config. The full NorCal
+expansion (latMax = 42.0 + lng_min = -128.5 + norcal_* viz coefficients)
+lives on `dev` and ships in a separate, later release once we have:
+
+  1. Dive-shop scrapers covering Eureka / Fort Bragg / Mendocino / Bodega
+     Bay so the visibility model has ground-truth observations to
+     calibrate `norcal_*` coefficients against.
+  2. At least a few weeks of those observations flowing through the
+     watchdog without unresolved bias findings.
+
+Until then, this file ships the CA bbox we've been running in prod —
+SoCal + Central CA only — and the `viz_predict/config.py` `norcal_*`
+zones (already on this branch as code) are dead code that won't fire
+because the bbox doesn't reach NorCal latitudes.
+
+What this branch (socal-upgrade) DOES carry to prod for SoCal users:
+  * NOAA OISST v2.1 1991-2020 30-year SST climatology (replaces 1-year
+    sample baseline that baked the 2024-2025 marine heatwave in)
+  * Region-aware encoding ranges so an encode/decode mismatch can't
+    silently saturate
+  * Land mask on chl + wind so streamlines / heatmap stop at the coast
+  * Bathy + climatology sidecar JSONs that force regeneration on any
+    future bbox bump
+  * Visibility layer marked `beta` (acknowledges the model is unvalidated
+    against NorCal even within SoCal lat band the calibration is sparse)
+  * 42-test data integrity suite
+  * Cloudflare security hardening (CSP, HSTS, scanner-path 404s) +
+    CodeQL + Dependabot
+"""
+from __future__ import annotations
+
+from ._region import Region
+
+
+REGION = Region(
+    name="ca",
+    display_name="California",
+    # 2026-05-15 — SoCal launch pin. The NorCal expansion (latMax 37.6
+    # → 42.0, lngMin -124.0 → -128.5) lives on `dev` and ships in its
+    # own later release once NorCal ground-truth scrapers are landed.
+    # See this file's module docstring for the unblock criteria.
+    bbox=dict(lat_min=31.8, lat_max=37.6, lng_min=-124.0, lng_max=-116.8),
+    lat_zone_bounds={
+        # Insertion order matters — `classify_zone` walks the dict
+        # from the highest lower-bound down. Keep this order
+        # north-to-south so the walk picks the matching band on the
+        # first hit. The `norcal` band is kept in the dict (matches
+        # viz_predict/config.py) but won't be reached given the bbox
+        # latMax = 37.6 — it's harmless dead code until NorCal launch.
+        "norcal":     (36.00, 90.0),
+        "central":    (34.45, 36.00),
+        "transition": (33.70, 34.45),
+        "bight":      (-90.0, 33.70),
+    },
+    dist_labels=["nearshore", "islands", "offshore"],
+    viz_model_variant="chl_based",
+    data_dir_slug="ca",
+    # NOAA CO-OPS stations — even coverage from Monterey to San Diego.
+    tide_stations=[
+        {"name": "monterey",      "id": "9413450", "lat": 36.605, "lng": -121.888},
+        {"name": "port-san-luis", "id": "9412110", "lat": 35.169, "lng": -120.755},
+        {"name": "santa-barbara", "id": "9411340", "lat": 34.404, "lng": -119.693},
+        {"name": "los-angeles",   "id": "9410660", "lat": 33.720, "lng": -118.272},
+        {"name": "la-jolla",      "id": "9410230", "lat": 32.866, "lng": -117.257},
+        {"name": "san-diego",     "id": "9410170", "lat": 32.713, "lng": -117.173},
+    ],
+    notes=(
+        "Source of truth for behavior today — bbox + lat zones must match "
+        "fetch.py / viz_predict/config.py / src/lib/mapData.js. NorCal "
+        "expansion deferred — see module docstring for unblock criteria."
+    ),
+)

--- a/pipeline/regions/pnw.py
+++ b/pipeline/regions/pnw.py
@@ -1,0 +1,81 @@
+"""Pacific Northwest region config — SKELETON, not yet calibrated.
+
+Proposed values from ``docs/expansion-regions.md`` § 2. The bbox and
+lat-zone bounds are placeholders sufficient for the package to import
+and for CI to validate the multi-region scaffold; coefficients,
+spot pins, and per-pixel masks (the Salish Sea polygon) come in the
+PR-PNW-N series.
+
+## What's intentionally missing
+
+* ``wa_inland`` zone — defined by a Salish Sea polygon, not a lat
+  band. ``classify_zone`` needs a polygon-aware path before this
+  zone can be honored. PR-PNW-1 will add the polygon + a per-pixel
+  inland mask; until then we treat the entire bbox as outer-coast
+  zones and accept the inland classification will be wrong.
+* DriverCoefficients — chl-based model fits the OR/WA outer coast
+  but not the Salish Sea. PR-PNW-3 introduces a ``pnw_inland``
+  variant (Option A in the scoping doc).
+* SSCOFS / HFRNet fetchers — PR-PNW-2.
+* Olympic Coast NMS + WA DNR Aquatic Reserves + OR Marine Reserves
+  polygons — PR-PNW-4.
+
+DO NOT consume this region from the running pipeline yet. The
+``test_regions.py`` smoke test only verifies it imports cleanly and
+the bbox is geographically plausible.
+"""
+from __future__ import annotations
+
+from ._region import Region
+
+
+REGION = Region(
+    name="pnw",
+    display_name="Pacific Northwest",
+    # Lat 42-49 covers Oregon coast through the Canadian border;
+    # lng -127 to -122 includes the Salish Sea complex.
+    bbox=dict(lat_min=42.0, lat_max=49.0, lng_min=-127.0, lng_max=-122.0),
+    lat_zone_bounds={
+        # ``wa_inland`` is intentionally omitted — it's a polygon
+        # zone, not a lat band. See module docstring.
+        "wa_outer":  (46.30, 49.00),
+        "or_north":  (44.00, 46.30),
+        "or_south":  (42.00, 44.00),
+    },
+    # Same labels as CA for now — PR-PNW-3 may re-label `islands`
+    # to `san_juans` if that ends up more readable in the
+    # DriverCoefficients dict.
+    dist_labels=["nearshore", "islands", "offshore"],
+    viz_model_variant="chl_based",
+    data_dir_slug="pnw",
+    layer_range_overrides={
+        # PNW water is colder. CA range (9-25°C) wastes ~half the
+        # encoding band on temperatures we'll never see in the
+        # Olympic Coast / Salish Sea / OR outer coast. 5-20°C covers
+        # the realistic surface-temp window for this region.
+        "sst":   (5.0, 20.0),
+        "sst7d": (5.0, 20.0),
+        "sst5d": (5.0, 20.0),
+    },
+    # NOAA CO-OPS stations covering OR outer coast → WA outer coast →
+    # Strait of Juan de Fuca → Salish Sea. Big tides here (Puget Sound
+    # can hit 4-5 m spring ranges) so tide_index will have real signal
+    # once PR-PNW-3 lands the inland viz variant.
+    tide_stations=[
+        {"name": "port-orford",      "id": "9431647", "lat": 42.738, "lng": -124.498},
+        {"name": "south-beach-or",   "id": "9435380", "lat": 44.625, "lng": -124.043},
+        {"name": "astoria",          "id": "9439040", "lat": 46.207, "lng": -123.768},
+        {"name": "la-push",          "id": "9442396", "lat": 47.913, "lng": -124.637},
+        {"name": "neah-bay",         "id": "9443090", "lat": 48.367, "lng": -124.601},
+        {"name": "port-angeles",     "id": "9444090", "lat": 48.125, "lng": -123.441},
+        {"name": "port-townsend",    "id": "9444900", "lat": 48.113, "lng": -122.760},
+        {"name": "seattle",          "id": "9447130", "lat": 47.603, "lng": -122.339},
+        {"name": "friday-harbor",    "id": "9449880", "lat": 48.546, "lng": -123.013},
+    ],
+    notes=(
+        "SKELETON — bbox + lat bands only. Salish Sea polygon, "
+        "SSCOFS fetcher, and PNW-tuned coefficients land in "
+        "PR-PNW-1..4. Do not enable in production routing until "
+        "those PRs ship."
+    ),
+)

--- a/pipeline/regions/tropical.py
+++ b/pipeline/regions/tropical.py
@@ -1,0 +1,107 @@
+"""Florida + Gulf + Caribbean region config — SKELETON.
+
+Proposed values from ``docs/expansion-regions.md`` § 3. Two sub-bbox
+splits (``gulf_se`` + ``caribbean``) because a single bbox would
+push past the runtime + data-volume caps for one matrix job. The
+frontend still presents this as one "Tropical" region; the pipeline
+fans out at refresh time.
+
+## What's intentionally missing
+
+* DriverCoefficients — the existing ``chl_based`` viz model is the
+  wrong shape for tropical water (oligotrophic, low chl, vis is
+  driven by Sahara dust + hurricane stirring + plumes, not by
+  chlorophyll concentration). The doc proposes a new
+  ``subtractive_tropical`` variant; the formula lives in
+  ``viz_predict/`` after PR-TROP-5 lands. This file marks the
+  variant slot so the wiring is ready when the math arrives.
+* HYCOM + Global RTOFS currents fetcher — PR-TROP-2.
+* NASA GEOS-FP Saharan dust fetcher — PR-TROP-3.
+* NOAA NHC hurricane track overlay — PR-TROP-4.
+* International MPA polygons (WDPA + NMS) — PR-TROP-6.
+* Spot pins (Looe Key, Stuart Cove, Bonaire, etc.) — PR-TROP-7.
+
+DO NOT consume this region yet. The ``viz_model_variant`` value is a
+forward-declaration that the test suite verifies as a valid Literal,
+not a contract that the formula is implemented.
+"""
+from __future__ import annotations
+
+from ._region import Region
+
+
+# Outer hull of the two sub-region bboxes — the frontend's region
+# switcher only knows the overall bounds; the per-subregion fetch
+# jobs handle the actual data fetching.
+_HULL_BBOX = dict(lat_min=10.0, lat_max=31.0, lng_min=-98.0, lng_max=-60.0)
+
+
+REGION = Region(
+    name="tropical",
+    display_name="Florida + Caribbean",
+    bbox=_HULL_BBOX,
+    subregion_bboxes={
+        # TX coast + FL Gulf + FL Keys + Flower Garden Banks +
+        # western Cuba + Yucatan
+        "gulf_se":   dict(lat_min=18.0, lat_max=31.0, lng_min=-98.0, lng_max=-80.0),
+        # Greater + Lesser Antilles + Bahamas + ABCs + Trinidad
+        "caribbean": dict(lat_min=10.0, lat_max=24.0, lng_min=-85.0, lng_max=-60.0),
+    },
+    lat_zone_bounds={
+        # Several zones are longitude-gated (`gulf_fl` vs `fl_east`
+        # overlap in latitude). The current ``classify_zone`` walks
+        # lat-only; PR-TROP-1 will add a longitude-aware path before
+        # honoring these. For now the placeholder values here let the
+        # package import + scaffold tests pass.
+        "fl_east":       (25.5, 31.0),
+        "fl_keys":       (24.0, 25.5),
+        "carib_greater": (18.0, 24.0),
+        "carib_lesser":  (10.0, 18.0),
+    },
+    # ``reefs`` + ``banks`` + ``walls`` capture more useful structure
+    # in tropical water than the CA ``nearshore`` / ``islands`` /
+    # ``offshore`` split — but renaming the dist labels requires a
+    # coordinated viz_predict/config.py update. Stick with the CA
+    # labels for the scaffold; PR-TROP-5 will revisit when the
+    # subtractive viz model lands.
+    dist_labels=["nearshore", "islands", "offshore"],
+    viz_model_variant="subtractive_tropical",
+    data_dir_slug="tropical",
+    layer_range_overrides={
+        # Tropical SST runs 20-32°C year-round (Caribbean rarely below
+        # 25, summer up to 32). The CA default (9-25°C) clipped
+        # everything above 25 to a flat saturated red on the frontend.
+        # 20-32 lets the colormap actually spread across the realistic
+        # surface-temp window.
+        "sst":   (20.0, 32.0),
+        "sst7d": (20.0, 32.0),
+        "sst5d": (20.0, 32.0),
+    },
+    # NOAA CO-OPS stations across FL, FL Keys, PR, USVI. Caribbean
+    # tides are small (~0.3 m range typical, semi-diurnal) so the
+    # tide_index signal will be weaker than CA/PNW, but still
+    # captures spring-vs-neap variation. Station IDs verified against
+    # https://tidesandcurrents.noaa.gov/stations.html as of 2026-05-13.
+    tide_stations=[
+        # Florida Gulf + Keys
+        {"name": "naples-fl",        "id": "8725110", "lat": 26.131, "lng": -81.808},
+        {"name": "fort-myers-fl",    "id": "8725520", "lat": 26.647, "lng": -81.871},
+        {"name": "vaca-key-fl",      "id": "8723970", "lat": 24.711, "lng": -81.107},
+        {"name": "key-west-fl",      "id": "8724580", "lat": 24.555, "lng": -81.808},
+        # Florida east coast
+        {"name": "virginia-key-fl",  "id": "8723214", "lat": 25.732, "lng": -80.162},
+        {"name": "lake-worth-fl",    "id": "8722670", "lat": 26.612, "lng": -80.038},
+        # Puerto Rico + USVI
+        {"name": "magueyes-island",  "id": "9759110", "lat": 17.970, "lng": -67.046},
+        {"name": "san-juan-pr",      "id": "9755371", "lat": 18.460, "lng": -66.118},
+        {"name": "lime-tree-bay",    "id": "9751381", "lat": 17.692, "lng": -64.754},
+        {"name": "christiansted",    "id": "9751364", "lat": 17.748, "lng": -64.705},
+        {"name": "lameshur-bay",     "id": "9751401", "lat": 18.318, "lng": -64.724},
+    ],
+    notes=(
+        "SKELETON — bbox hull + sub-region bboxes + viz variant marker. "
+        "The chl-based model is the WRONG SHAPE for this water; do not "
+        "enable in production until PR-TROP-5 implements the new "
+        "subtractive_tropical formula in viz_predict/."
+    ),
+)

--- a/pipeline/tests/test_data_integrity.py
+++ b/pipeline/tests/test_data_integrity.py
@@ -1,0 +1,461 @@
+"""Data integrity test suite — catches silent fetcher failures.
+
+User's mental model — these tests answer four questions:
+
+  1. CORRECT     — did each layer pull from the source we expect, and
+                   does its shape match the LayerSpec contract?
+  2. FRESH       — is the data within its per-layer recency budget?
+  3. PLAUSIBLE   — are the values physically reasonable, with the
+                   right NaN fraction (i.e. not all-NaN, not all-zero,
+                   no impossible magnitudes)?
+  4. CONSISTENT  — do the manifest bbox + bathy sidecar + climo sidecar
+                   all agree? (Stale static caches caused the
+                   wind-streamlines-shifted-west bug 2026-05-14.)
+
+The tests run in the `pipeline-tests` CI job on every PR. Region
+coverage: each test parametrizes over CA + PNW + tropical and skips
+regions whose data isn't present.
+
+These complement the existing tests:
+  test_layer_spec.py                — manifest schema vs LayerSpec
+  test_fetch_layer_spec_consistency — fetcher vs LayerSpec
+  test_freshness.py                 — freshness math
+  test_regions.py                   — region config validity
+  test_sst_phases.py / sources      — SST math + source priority
+
+What this file adds beyond those: decoding the actual published PNGs
+and validating value distributions + NaN fractions + bbox alignment
+across sidecars. The existing tests can't catch "fetcher silently
+emitted a saturated/empty PNG" because they only inspect the manifest
+metadata, not the pixel data.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DATA_ROOT = REPO_ROOT / "public" / "data"
+
+REGIONS = ("ca", "pnw", "tropical")
+
+
+def _region_dir(region: str) -> Path | None:
+    """Path to a region's data dir. None if not present.
+
+    CA lives at public/data/ (no slug subdir); PNW + tropical nest
+    under public/data/<region>/ — matches the pipeline's data_output_dir
+    convention.
+    """
+    d = DATA_ROOT if region == "ca" else DATA_ROOT / region
+    return d if d.exists() and (d / "manifest.json").exists() else None
+
+
+def _manifest(region: str) -> dict | None:
+    d = _region_dir(region)
+    if not d:
+        return None
+    try:
+        return json.loads((d / "manifest.json").read_text())
+    except Exception:
+        return None
+
+
+def _decode_grayscale_png(path: Path) -> np.ndarray:
+    """Decode an 8-bit grayscale PNG, mapping pixel 0 → NaN.
+
+    Matches the encoder convention in fetch.py / fetch_wind.py /
+    fetch_bathy.py / fetch_climatology.py: pixel 0 is the no-data
+    sentinel, 1..255 maps linearly across the layer's range.
+    """
+    img = Image.open(path).convert("L")
+    arr = np.asarray(img, dtype=np.float32).copy()
+    arr[arr == 0] = np.nan
+    return arr
+
+
+def _decode_rgba_uv_png(path: Path) -> tuple[np.ndarray, np.ndarray]:
+    """Decode wind/current UV RGBA PNG. Returns (rgba_array, valid_mask)
+    where valid is True when alpha > 0."""
+    img = Image.open(path).convert("RGBA")
+    arr = np.asarray(img, dtype=np.float32)
+    return arr, arr[..., 3] > 0
+
+
+def _decode_rgba_wave_png(path: Path) -> tuple[np.ndarray, np.ndarray]:
+    """Decode wave RGBA PNG (R=Hs, G=Tp, B=dir, A=valid)."""
+    return _decode_rgba_uv_png(path)
+
+
+def _decode_scaled_value(raw_arr: np.ndarray, range_lo: float, range_hi: float) -> np.ndarray:
+    """Apply the linear-range decoding: pixel 1..255 → range_lo..range_hi."""
+    out = np.full_like(raw_arr, np.nan, dtype=np.float32)
+    valid = np.isfinite(raw_arr)
+    out[valid] = range_lo + (raw_arr[valid] - 1) / 254.0 * (range_hi - range_lo)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Category 1: CORRECT — sources + shape match the contract
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("region", REGIONS)
+def test_manifest_exists_and_has_required_layers(region):
+    """Every region's manifest must declare the core data layers."""
+    m = _manifest(region)
+    if m is None:
+        pytest.skip(f"no committed data for region={region}")
+
+    required = {"sst", "chl", "wind"}
+    have = set(m.get("layers", {}).keys())
+    missing = required - have
+    assert not missing, f"{region} manifest missing required layers: {missing}"
+
+
+@pytest.mark.parametrize("region", REGIONS)
+def test_manifest_bbox_in_lockstep_with_region_config(region):
+    """The manifest's bbox must match active_region().bbox at the time of
+    the last refresh. A drift here means a fetcher ran with a stale
+    code checkout — fixing this is what bathy sidecar + climo sidecar
+    do for static caches."""
+    m = _manifest(region)
+    if m is None:
+        pytest.skip(f"no data for {region}")
+    try:
+        from pipeline.regions import get_region
+    except ModuleNotFoundError:
+        from regions import get_region
+    region_obj = get_region(region)
+    expected_bbox = region_obj.bbox_array  # [lng_min, lat_min, lng_max, lat_max]
+    actual_bbox = m["bbox"]
+    assert actual_bbox == expected_bbox, (
+        f"{region}: manifest bbox {actual_bbox} doesn't match "
+        f"active_region().bbox_array {expected_bbox}. "
+        f"Run refresh-{region}-data.yml to regenerate."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Category 2: CONSISTENT — static caches' sidecars match the live bbox
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("region", REGIONS)
+def test_bathy_sidecar_matches_manifest_bbox(region):
+    """Bathy.png is one-shot cached; if the region's bbox is bumped, the
+    sidecar JSON forces fetch_bathy.py to regenerate. This test catches
+    the case where someone bumps the bbox but the cache + sidecar
+    haven't been refreshed yet — the symptom would be wind streamlines
+    misregistered against the coastline (the bug we hit 2026-05-14).
+
+    Transitional behavior: regions whose bathy.png predates the sidecar
+    pattern (introduced 2026-05-14) get a SKIP with a TODO marker rather
+    than a hard fail. The skip will go away once each region runs through
+    refresh-*-data and the sidecar gets written. A test failure here
+    after that is a real regression.
+    """
+    d = _region_dir(region)
+    if d is None:
+        pytest.skip(f"no data for {region}")
+    sidecar = d / "bathy.json"
+    bathy_png = d / "bathy.png"
+    if not bathy_png.exists():
+        pytest.skip(f"{region}: no bathy.png yet (first-run on new region)")
+    if not sidecar.exists():
+        pytest.skip(
+            f"{region}: bathy.png present but bathy.json sidecar missing "
+            f"(transitional — bathy predates the 2026-05-14 sidecar pattern). "
+            f"Triggering refresh-{region}-data will regenerate."
+        )
+    meta = json.loads(sidecar.read_text())
+    m = _manifest(region)
+    assert meta.get("bbox") == m["bbox"], (
+        f"{region}: bathy sidecar bbox {meta.get('bbox')} doesn't match "
+        f"manifest {m['bbox']}. Force a fetch_bathy.py rerun (the sidecar "
+        f"check will catch this and regenerate)."
+    )
+
+
+@pytest.mark.parametrize("region", REGIONS)
+def test_climo_sidecar_matches_manifest_bbox(region):
+    """climo_meta.json must carry a bbox that matches the manifest.
+    Without this, fetch_visibility + fetch_sst_5day silently apply a
+    climatology from an OLD bbox over a NEW bbox — same geographic
+    misregistration class as the bathy bug."""
+    d = _region_dir(region)
+    if d is None:
+        pytest.skip(f"no data for {region}")
+    meta_path = d / "climo_meta.json"
+    if not meta_path.exists():
+        pytest.skip(f"{region}: no climo_meta yet")
+    meta = json.loads(meta_path.read_text())
+    if "bbox" not in meta:
+        pytest.skip(
+            f"{region}: climo_meta.json has no bbox field (transitional — "
+            f"predates the 2026-05-14 sidecar pattern). Triggering "
+            f"refresh-{region}-data with force_climo=true will add it."
+        )
+    m = _manifest(region)
+    assert meta["bbox"] == m["bbox"], (
+        f"{region}: climo bbox {meta['bbox']} doesn't match manifest "
+        f"{m['bbox']}. Re-run with `force_climo=true` workflow input."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Category 3: PLAUSIBLE — value distributions + NaN fractions
+# ---------------------------------------------------------------------------
+
+# Per-region SST physical bounds. The PNG decodes into the layer's
+# encoding range (e.g. CA [9, 25]°C), but the ACTUAL values inside that
+# range must also be plausible. Tropical water never goes below 18°C even
+# though the encoding range starts at 20 — these bounds catch encoding +
+# semantic drift simultaneously.
+SST_PHYSICAL_BOUNDS_C = {
+    "ca":       (5.0, 30.0),    # NorCal upwelling can hit 7-8°C; SoCal Bight 23-25°C peak
+    "pnw":      (5.0, 22.0),    # Salish Sea cold; OR outer coast 12-18°C summer
+    "tropical": (18.0, 34.0),   # Caribbean rarely below 22°C; Gulf summer to 32°C
+}
+
+# Acceptable NaN-fraction floors per (artifact, region). Below this means
+# the fetcher returned an empty/saturated PNG; above is fine.
+#
+# Region-tuned because cloud cover varies massively:
+#   * CA      — moderate marine layer; chl coverage 30-60% typical
+#   * PNW     — heavy cloud cover at high lats; chl can dip to 2-5%
+#                in May (and that's REAL — VIIRS/MODIS can't see through
+#                clouds). Wind from HRRR/GFS is always full-coverage.
+#   * tropical — clearer skies but cumulus pop-up; chl 10-30% typical
+#
+# A floor that doesn't account for this fails the wrong things — the
+# point of the test is "fetcher hung", not "the sky is cloudy".
+LAYER_VALID_FRAC_FLOOR = {
+    # (artifact, region) -> minimum valid-cell fraction
+    ("sst_1d.png",         "ca"):       0.20,
+    ("sst_1d.png",         "pnw"):      0.20,
+    ("sst_1d.png",         "tropical"): 0.30,   # mostly ocean bbox
+
+    ("chl_1d.png",         "ca"):       0.10,
+    ("chl_1d.png",         "pnw"):      0.01,   # cloud-heavy, 2-5% is normal
+    ("chl_1d.png",         "tropical"): 0.05,
+
+    ("wind_uv_now.png",    "ca"):       0.20,
+    ("wind_uv_now.png",    "pnw"):      0.20,
+    ("wind_uv_now.png",    "tropical"): 0.30,
+
+    ("wind_speed_now.png", "ca"):       0.20,
+    ("wind_speed_now.png", "pnw"):      0.20,
+    ("wind_speed_now.png", "tropical"): 0.30,
+
+    ("wave_now.png",       "ca"):       0.20,
+    ("wave_now.png",       "pnw"):      0.20,
+    ("wave_now.png",       "tropical"): 0.30,
+}
+
+
+@pytest.mark.parametrize("region,bounds", list(SST_PHYSICAL_BOUNDS_C.items()))
+def test_sst_values_physically_plausible(region, bounds):
+    """SST decoded values must fall inside the per-region physical
+    envelope. Catches:
+      * Kelvin-vs-Celsius mistakes (273+ values)
+      * Range/encoding drift (e.g. encoder writes (9,25) but decoder
+        reads (20,32))
+      * Saturated PNGs (all values = range_max because of clipping)
+    """
+    d = _region_dir(region)
+    if d is None:
+        pytest.skip(f"no data for {region}")
+    sst_path = d / "sst_1d.png"
+    if not sst_path.exists():
+        pytest.skip(f"{region}: no sst_1d.png")
+    m = _manifest(region)
+    encoding_range = m["layers"]["sst"]["range"]
+
+    raw = _decode_grayscale_png(sst_path)
+    decoded = _decode_scaled_value(raw, encoding_range[0], encoding_range[1])
+    valid = decoded[np.isfinite(decoded)]
+    if valid.size == 0:
+        pytest.fail(f"{region}: sst_1d.png has no valid cells (all NaN)")
+
+    mn, mx, mean = float(valid.min()), float(valid.max()), float(valid.mean())
+    lo, hi = bounds
+    assert lo <= mn, f"{region} SST min {mn:.1f}°C below {lo}°C floor"
+    assert mx <= hi, f"{region} SST max {mx:.1f}°C above {hi}°C ceiling"
+    assert lo <= mean <= hi, f"{region} SST mean {mean:.1f}°C outside [{lo},{hi}]°C"
+    # Saturation guard: if every valid cell is within 0.1°C of the
+    # encoding ceiling, the fetcher hit a uniform clip — symptom of
+    # the encode/decode mismatch bug we hit 2026-05-13.
+    near_ceiling = (encoding_range[1] - valid).max() < 0.1 and valid.std() < 0.1
+    assert not near_ceiling, (
+        f"{region} SST appears saturated at encoding ceiling "
+        f"{encoding_range[1]}°C — check encode/decode range alignment"
+    )
+
+
+@pytest.mark.parametrize("artifact,region",
+                         sorted(LAYER_VALID_FRAC_FLOOR.keys()))
+def test_no_nan_floods(artifact, region):
+    """A PNG is 'flooded' if fewer than the per-region floor of cells
+    have valid data. Floors are tuned to the realistic cloud cover and
+    land/water split per region (see LAYER_VALID_FRAC_FLOOR docstring).
+    """
+    d = _region_dir(region)
+    if d is None:
+        pytest.skip(f"no data for {region}")
+    path = d / artifact
+    if not path.exists():
+        pytest.skip(f"{region}: no {artifact}")
+
+    if "uv" in artifact or "wave" in artifact:
+        _, valid_mask = _decode_rgba_uv_png(path)
+        valid_frac = float(valid_mask.mean())
+    else:
+        arr = _decode_grayscale_png(path)
+        valid_frac = float(np.isfinite(arr).mean())
+
+    floor = LAYER_VALID_FRAC_FLOOR[(artifact, region)]
+    assert valid_frac > floor, (
+        f"{region}/{artifact}: only {valid_frac*100:.1f}% valid cells "
+        f"(floor {floor*100:.0f}%). Fetcher likely hung — check NOMADS / "
+        f"ERDDAP / NASA endpoints."
+    )
+
+
+@pytest.mark.parametrize("region", REGIONS)
+def test_wind_speed_in_plausible_range(region):
+    """Wind speed should be 0-80 kt in normal conditions. Outside this
+    range = encoding drift or hurricane (which we'd notice). The check
+    is on the max; the min is always 0 in practice."""
+    d = _region_dir(region)
+    if d is None:
+        pytest.skip(f"no data for {region}")
+    path = d / "wind_speed_now.png"
+    if not path.exists():
+        pytest.skip(f"{region}: no wind_speed_now")
+
+    m = _manifest(region)
+    speed_range = m["layers"]["wind"]["speed_range"]
+    raw = _decode_grayscale_png(path)
+    decoded = _decode_scaled_value(raw, speed_range[0], speed_range[1])
+    valid = decoded[np.isfinite(decoded)]
+    if valid.size == 0:
+        pytest.fail(f"{region}: wind_speed_now all NaN")
+
+    max_kt = float(valid.max())
+    assert 0.5 < max_kt < 80.0, (
+        f"{region} wind speed max {max_kt:.1f} kt outside [0.5, 80] — "
+        f"likely encoding drift or extreme weather (check NOMADS upstream)"
+    )
+
+
+@pytest.mark.parametrize("region", REGIONS)
+def test_bathy_depth_in_plausible_range(region):
+    """Bathy depth: 0 = shoreline, 6000 = deep abyss. Encoded as 1..255
+    linear. Pixel 0 = NaN (land)."""
+    d = _region_dir(region)
+    if d is None:
+        pytest.skip(f"no data for {region}")
+    path = d / "bathy.png"
+    if not path.exists():
+        pytest.skip(f"{region}: no bathy.png")
+
+    raw = _decode_grayscale_png(path)
+    decoded = _decode_scaled_value(raw, 0.0, 6000.0)
+    valid = decoded[np.isfinite(decoded)]
+    assert valid.size > 0, f"{region}: bathy all NaN"
+    assert float(valid.min()) >= 0.0, f"{region}: negative depth"
+    assert float(valid.max()) <= 6000.0, f"{region}: depth > 6000m"
+    # Sanity: median depth should be > 100m for any CA-class region (most
+    # of the bbox is ocean shelf + abyssal). Tropical can be shallower
+    # (continental shelf is wider). PNW similar to CA.
+    median = float(np.median(valid))
+    assert median > 50.0, (
+        f"{region}: median bathy depth {median:.0f}m suspiciously shallow "
+        f"— check GMRT fetch + resample"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Category 4: FRESH — forecast continuity + anomaly sanity
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("region", REGIONS)
+def test_sst5d_forecast_continuity(region):
+    """SST 5-day forecast: days monotonically increase, no missing slots,
+    each day's anomaly is bounded (|anom_c| < 5°C). A larger anomaly
+    means the climatology baseline is wrong — exactly the 2026-05-13
+    bug where tropical was anchored to a heatwave-warmed baseline."""
+    d = _region_dir(region)
+    if d is None:
+        pytest.skip(f"no data for {region}")
+    summary = d / "sst5d" / "summary.json"
+    if not summary.exists():
+        pytest.skip(f"{region}: no sst5d/summary.json")
+
+    s = json.loads(summary.read_text())
+    days = s.get("days", [])
+    assert len(days) >= 5, f"{region}: sst5d has only {len(days)} days (expect >= 5)"
+
+    offsets = [day.get("offset") for day in days]
+    assert offsets == sorted(offsets), f"{region}: sst5d days out of order"
+
+    for day in days:
+        anom = day.get("anom_c")
+        if anom is None:
+            continue
+        assert abs(anom) < 5.0, (
+            f"{region}: sst5d {day.get('day')} anomaly {anom:.2f}°C "
+            f"exceeds 5°C envelope — climatology likely stale or wrong-bbox"
+        )
+
+    # Today's mean must be inside the encoding range; obvious but catches
+    # the case where the model decayed to a value the PNG can't represent.
+    encoding_range = s.get("range_c") or s.get("range")
+    if encoding_range:
+        for day in days:
+            mean = day.get("mean_c") or day.get("mean")
+            if mean is None:
+                continue
+            assert encoding_range[0] <= mean <= encoding_range[1], (
+                f"{region}: sst5d {day.get('day')} mean {mean}°C outside "
+                f"encoding range {encoding_range}"
+            )
+
+
+@pytest.mark.parametrize("region", REGIONS)
+def test_top_level_manifest_freshness(region):
+    """The manifest's generated_at must be within TOP_LEVEL_MAX_HOURS
+    of now. Reuses the budget from check_manifest_freshness.py so the
+    threshold is centralised.
+
+    Note: this test runs in dev-checks, which fires on PR pushes. The
+    committed data in public/data/ can be up to ~24h stale on a normal
+    development cycle (cron runs daily). 48h is the realistic ceiling
+    before something's genuinely broken.
+    """
+    m = _manifest(region)
+    if m is None:
+        pytest.skip(f"no data for {region}")
+    raw = m.get("generated_at")
+    if not raw:
+        pytest.fail(f"{region}: manifest has no generated_at")
+    try:
+        when = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        pytest.fail(f"{region}: manifest generated_at unparseable: {raw}")
+    age_hours = (datetime.now(timezone.utc) - when).total_seconds() / 3600
+    # 72h ceiling for dev-checks tolerance (cron runs daily, sometimes
+    # the data hasn't refreshed since 2-3 days ago on a quiet weekend).
+    assert age_hours < 72, (
+        f"{region}: manifest is {age_hours:.0f}h old (> 72h ceiling). "
+        f"refresh-{region}-data.yml cron may be broken."
+    )

--- a/public/_headers
+++ b/public/_headers
@@ -1,32 +1,63 @@
-# Cloudflare Pages — per-pattern Cache-Control headers.
+# Cloudflare Pages — per-pattern security + caching headers.
 #
-# THE problem this file fixes:
-#   "I have to open the site in private mode to get the latest update."
+# Two concerns layered into this file:
 #
-# Without explicit Cache-Control, Cloudflare's edge caches HTML for
-# its default 4-hour TTL AND the user's browser caches it indefinitely.
-# Returning users see the old HTML, which references the OLD asset
-# hash, until their browser TTL expires (sometimes weeks). Combined
-# with our service worker's previous cache-first shell strategy, that
-# gave returning users last-week's app for one full visit cycle on
-# every deploy.
+# 1. CACHING (the original purpose):
+#    The fix for "I have to open the site in private mode to get the
+#    latest update." Without explicit Cache-Control, Cloudflare's edge
+#    caches HTML for its default 4-hour TTL AND the user's browser
+#    caches it indefinitely. Returning users see old HTML referencing
+#    old asset hashes for a week+. Layered strategy:
+#      - HTML / SW / manifest:    no-cache (re-validate, small payload)
+#      - Hashed JS/CSS bundles:   1-year immutable (Vite content-hashes)
+#      - /data/manifest.json:     1-min max-age + must-revalidate
+#      - /data/*.png + /data/*.json: 5-min max-age + must-revalidate
 #
-# Layered cache strategy:
-#   - HTML / SW / manifest:    no-cache  (always re-validate, content
-#                                          is small + identifying)
-#   - Hashed JS/CSS bundles:   immutable + 1-year max-age
-#                              (Vite includes a content hash in the
-#                              filename — when the content changes,
-#                              the URL changes; safe to cache forever)
-#   - /data/manifest.json:     short max-age + must-revalidate
-#                              (changes every cron cycle)
-#   - /data/*.png and similar: 5-minute max-age
-#                              (changes daily; 5 min is the longest
-#                              window where stale data matters less
-#                              than the per-fetch cost)
+# 2. SECURITY (added 2026-05-13 hardening pass):
+#    Cloudflare's default response has only `referrer-policy` +
+#    `x-content-type-options: nosniff`. Browsers can't enforce CSP,
+#    clickjacking protection, HSTS, or origin isolation without us
+#    declaring them. The "/*" block at the bottom of this file
+#    declares the minimum strong policy across every served response;
+#    per-path blocks above /*  layer on cache-control + tighten where
+#    appropriate.
 #
-# The /* match-all at the bottom is a safety net; explicit patterns
-# above it take precedence (Cloudflare _headers uses first-match).
+#    CSP rationale:
+#      script-src 'self'                       — no inline <script>; Vite
+#                                                emits hashed external JS
+#      style-src 'self' 'unsafe-inline'        — React inline `style={}` is
+#         https://fonts.googleapis.com           a style ATTRIBUTE (allowed
+#                                                by default), but the Google
+#                                                Fonts CSS comes in via a
+#                                                <link rel="stylesheet"> tag
+#                                                so we allow that host.
+#                                                'unsafe-inline' on style-src
+#                                                permits the same on attrs
+#                                                across all browsers.
+#      font-src 'self' https://fonts.gstatic.com — Google Fonts woff2 files
+#      img-src 'self' data: blob:              — PNGs from /data/; data: for
+#                                                inline SVGs we generate;
+#                                                blob: for canvas tile rendering
+#      connect-src 'self'                      — sendBeacon + fetch hit /api/* + /data/*
+#      worker-src 'self'                       — service worker scope
+#      manifest-src 'self'                     — manifest.webmanifest
+#      frame-ancestors 'none'                  — clickjacking protection
+#      base-uri 'self'                         — block <base> tag injection
+#      form-action 'self'                      — we have no forms, but lock it
+#      object-src 'none'                       — no <object>/<embed>
+#      upgrade-insecure-requests               — auto-upgrade http→https
+#
+#    HSTS: max-age=31536000; includeSubDomains. NO preload flag yet —
+#    preload requires submission to hstspreload.org and a 1-year
+#    commitment; we add it after verifying the policy works for a
+#    couple weeks without breakage.
+#
+#    Permissions-Policy: deny everything we don't use, so a future
+#    third-party script (analytics, ads, embed widget) can't quietly
+#    activate sensors / cameras / payment APIs.
+#
+#    The /* match-all at the bottom is a safety net; explicit patterns
+#    above it take precedence (Cloudflare _headers uses first-match).
 
 # ---- HTML + service worker + PWA manifest ---------------------------
 /
@@ -87,12 +118,28 @@
 /data/*/*.json
   Cache-Control: public, max-age=300, must-revalidate
 
-# Catch-all `/*` rule REMOVED 2026-05-08:
+# Catch-all `/*` rule REMOVED 2026-05-08 for Cache-Control reasons:
 # Cloudflare Pages MERGES every matching `_headers` rule into a
 # single response, so a fallback /* combined with the more specific
-# rules above produced ugly duplicate Cache-Control directives:
-#   `Cache-Control: public, max-age=60, must-revalidate, public, max-age=0, must-revalidate`
-# Browsers handle that fine (RFC 9111 takes the first max-age) but
-# the response headers were unreadable. Letting CF use its built-in
-# default (4 h browser TTL) for any URL not matched above is fine —
-# the explicit rules above cover every path that actually matters.
+# rules above produced ugly duplicate Cache-Control directives.
+#
+# /* RESTORED 2026-05-13 *for security headers only*:
+# Cache-Control deliberately omitted here so per-path rules above
+# are the only contributors to that header. The security headers
+# below have no per-path overrides anywhere in this file, so the
+# merge produces clean single-value headers for CSP/HSTS/etc.
+#
+# Sanity-check after editing this block: `curl -sS -I https://shouldidive.com/`
+# should return ONE Content-Security-Policy line and ONE
+# Strict-Transport-Security line.
+
+/*
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self'; worker-src 'self'; manifest-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: accelerometer=(), camera=(), display-capture=(), fullscreen=(self), geolocation=(self), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), usb=(), web-share=(self), xr-spatial-tracking=()
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Resource-Policy: same-site
+  X-Permitted-Cross-Domain-Policies: none

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,17 @@
+# Cloudflare Pages `_redirects` — currently a stub.
+#
+# The hard-404 logic for scanner-known paths (/.env, /.git/*, etc.)
+# used to live here but CF Pages `_redirects` only supports status
+# codes 200/301/302/303/307/308 — NOT 404. Cloudflare silently
+# ignored those rules.
+#
+# That logic now lives in `functions/_middleware.js` which DOES support
+# arbitrary status codes. See the middleware file for the full path
+# allowlist + rationale.
+#
+# This file is kept (empty of rules) for:
+#   1. Future legitimate redirects (e.g., trailing-slash canonicalisation,
+#      domain migrations, deprecated routes).
+#   2. So nothing else in the deploy assumes the file is missing.
+
+# (no rules yet — middleware handles all 404 logic)

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,25 @@
+# ShouldIDive — crawler policy.
+#
+# Allow well-behaved crawlers to index the public pages so divers
+# searching Google for "California water visibility" / "PNW dive
+# conditions" / "Caribbean SST" can find us. Disallow the data API
+# and analytics endpoint — those are read by the React client, not
+# humans, and have no SEO value (just bandwidth churn from crawlers
+# hammering 5-min-max-age PNGs).
+#
+# Bad bots (the ones spiking from CN / IN / RU IP ranges and probing
+# `/.env`, `/wp-admin`, etc.) ignore robots.txt entirely. They're
+# handled by `_redirects` returning hard 404s and by Cloudflare WAF.
+# robots.txt only governs the well-behaved crawlers (Google, Bing,
+# DuckDuckGo, etc.) — and those we want.
+
+User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /data/
+Disallow: /sw.js
+Disallow: /manifest.webmanifest
+
+# Sitemap pointer — keeps the index fresh + signals "this is the
+# canonical entry point" to consolidate trailing-slash variants.
+Sitemap: https://shouldidive.com/sitemap.xml

--- a/public/security.txt
+++ b/public/security.txt
@@ -1,0 +1,10 @@
+# RFC 9116 security.txt — reachable at both
+#   https://shouldidive.com/.well-known/security.txt   (per spec)
+#   https://shouldidive.com/security.txt               (legacy fallback)
+# The _redirects file maps the .well-known path to this file.
+
+Contact: https://github.com/Michaelpjob/ShoudiDive/security/advisories
+Expires: 2027-05-13T00:00:00Z
+Preferred-Languages: en
+Canonical: https://shouldidive.com/.well-known/security.txt
+Policy: https://github.com/Michaelpjob/ShoudiDive/blob/main/SECURITY.md

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ShouldIDive sitemap. The site is a single-page React app; there's
+  only one URL to list, but having a sitemap (a) consolidates
+  canonical-URL signals to search engines and (b) lets us stop the
+  trailing-slash / www / non-www permutations from getting separately
+  indexed.
+
+  When per-region surfaces become customer-facing (ca-beta → ca.shouldidive.com,
+  etc.), add them as sibling <url> entries.
+-->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://shouldidive.com/</loc>
+    <changefreq>hourly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { SeaBasemap, LandBasemap, OceanMaskDefs, PLACE_LABELS } from "./components/Basemap.jsx";
+import RegionSwitcher from "./components/RegionSwitcher.jsx";
+import { activeRegion } from "./lib/region.js";
 import DataOverlay from "./components/DataOverlay.jsx";
 import WindParticles from "./components/WindParticles.jsx";
 import MpaLayer, { styleForType } from "./components/MpaLayer.jsx";
@@ -18,6 +20,7 @@ import {
   chlColor,
   getFitted,
   SAVED_SPOTS,
+  BBOX,
 } from "./lib/mapData.js";
 import {
   loadManifest,
@@ -263,7 +266,24 @@ function loadPrefs() {
   }
 }
 
+// Region-aware browser tab title. index.html ships a static
+// "ShouldIDive — CA Coast Conditions" fallback; this overrides it
+// once the React app boots so PNW + tropical visitors don't see
+// "CA Coast" in their tab.
+function useRegionAwareTitle() {
+  useEffect(() => {
+    const r = activeRegion();
+    const subtitle =
+      r === "pnw"      ? "Pacific NW Conditions" :
+      r === "tropical" ? "FL + Caribbean Conditions" :
+      "California Coast Conditions";
+    document.title = `ShouldIDive — ${subtitle}`;
+  }, []);
+}
+
+
 export default function App() {
+  useRegionAwareTitle();
   const [prefs, setPrefs] = useState(loadPrefs);
   const [layer, setLayer] = useState("sst");
   const [composite, setComposite] = useState(2);
@@ -460,10 +480,16 @@ function TopBar({ onSettings, settingsOpen, dataState }) {
           <div className="brand-name">ShouldIDive</div>
         </div>
         <span className="brand-tag">
-          Sea Temp · Water Clarity · Wind · Current · CA Coast 31.8°–37.6°N
+          {(() => {
+            const r = activeRegion();
+            if (r === "pnw") return "Pacific Northwest (beta) · OR + WA + Salish Sea";
+            if (r === "tropical") return "FL + Caribbean (beta) · Gulf + Keys + Bahamas + Antilles";
+            return "Sea Temp · Water Clarity · Wind · Current · California Coast";
+          })()}
         </span>
       </div>
       <div className="topbar-meta">
+        <RegionSwitcher />
         <span>
           <span className="dot"></span>
           <strong>{status}</strong> · Last update{" "}
@@ -1106,15 +1132,22 @@ function DesktopView({ layer, setLayer, composite, setComposite, sstMode, setSst
           const f = getFitted(size.w, size.h);
           return (
             <g clipPath="url(#ocean-clip)" mask="url(#ocean-mask)">
-              {/* No-data hatch — only inside the bbox area; outside is just sea. */}
-              <rect
-                x={f.marginX}
-                y={f.marginY}
-                width={f.innerW}
-                height={f.innerH}
-                fill="url(#noDataHatch)"
-                pointerEvents="none"
-              />
+              {/* No-data hatch — only inside the bbox area; outside is just sea.
+                  Suppressed for non-CA regions today because PNW + tropical
+                  have legitimately-sparse coverage (HFRNet has no Caribbean,
+                  rivers/tides are CA-station-only, etc.) and the hatch
+                  dominated the visible map. CA still gets it as a coverage
+                  indicator until the beta regions reach feature parity. */}
+              {activeRegion() === "ca" && (
+                <rect
+                  x={f.marginX}
+                  y={f.marginY}
+                  width={f.innerW}
+                  height={f.innerH}
+                  fill="url(#noDataHatch)"
+                  pointerEvents="none"
+                />
+              )}
 
               {/* Data overlay (positions itself inside the fitted box).
                   renderLayer is `layer` for normal modes and "sst-trend"
@@ -1352,10 +1385,11 @@ function DesktopView({ layer, setLayer, composite, setComposite, sstMode, setSst
             <button
               className={layer === "viz" ? "active" : ""}
               onClick={() => setLayer("viz")}
-              title="Predicted dive visibility — model output in feet, not a direct measurement"
+              title="Predicted dive visibility (BETA — model unvalidated for NorCal; use as advisory only). Output is feet, not a direct measurement."
             >
               <span className="lt-label">Vis</span>
               <span className="lt-sub">ft</span>
+              <span className="lt-beta">Beta</span>
             </button>
           </div>
           {layer === "sst" && hasSstTimeline ? (
@@ -1450,25 +1484,50 @@ function DesktopView({ layer, setLayer, composite, setComposite, sstMode, setSst
             {layer === "sst" ? (
               <div className="info-section">
                 <h4 className="info-h">Sea Surface Temperature</h4>
-                <p className="info-p">
-                  <span className="swatch" style={{ background: "rgb(40,130,210)" }}></span>
-                  <strong>Blue</strong> means cold — typical Central Coast (54–57°F) and
-                  upwelling near Pt. Conception.
-                </p>
-                <p className="info-p">
-                  <span className="swatch" style={{ background: "rgb(120,220,220)" }}></span>
-                  <strong>Cyan</strong> is the transition zone — comfortable for divers in
-                  spring suits.
-                </p>
-                <p className="info-p">
-                  <span className="swatch" style={{ background: "rgb(240,220,110)" }}></span>
-                  <strong>Yellow</strong> is warm SoCal summer water (66–70°F). Trunks weather.
-                </p>
-                <p className="info-p">
-                  <span className="swatch" style={{ background: "rgb(170,20,35)" }}></span>
-                  <strong>Red</strong> means anomaly — possible marine heatwave. Watch for
-                  kelp stress and harmful algal blooms.
-                </p>
+                {(() => {
+                  const r = activeRegion();
+                  const sstCopy = {
+                    ca: {
+                      blue:   "cold — typical Central Coast (54–57°F) and upwelling near Pt. Conception.",
+                      cyan:   "the transition zone — comfortable for divers in spring suits.",
+                      yellow: "warm SoCal summer water (66–70°F). Trunks weather.",
+                      red:    "anomaly — possible marine heatwave. Watch for kelp stress and harmful algal blooms.",
+                    },
+                    pnw: {
+                      blue:   "cold — typical Salish Sea / Olympic Coast (45–52°F). Drysuit conditions.",
+                      cyan:   "warmer outer-coast summer water (54–58°F). Thick wetsuit OK on calmer days.",
+                      yellow: "rare warm anomaly (60–65°F). Watch for stratification + bloom triggers.",
+                      red:    "extreme anomaly — marine heatwave territory. Kelp stress, harmful algal blooms.",
+                    },
+                    tropical: {
+                      blue:   "rare cold pocket (~72–76°F), upwelling near the Keys or Yucatan shelf.",
+                      cyan:   "typical winter Caribbean / Bahamas (76–80°F). Light wetsuit on long dives.",
+                      yellow: "typical summer Caribbean (82–86°F). Rash guard + boardies.",
+                      red:    "extreme warm anomaly — coral bleaching threshold (>86°F sustained).",
+                    },
+                  };
+                  const c = sstCopy[r] || sstCopy.ca;
+                  return (
+                    <>
+                      <p className="info-p">
+                        <span className="swatch" style={{ background: "rgb(40,130,210)" }}></span>
+                        <strong>Blue</strong> means {c.blue}
+                      </p>
+                      <p className="info-p">
+                        <span className="swatch" style={{ background: "rgb(120,220,220)" }}></span>
+                        <strong>Cyan</strong> is {c.cyan}
+                      </p>
+                      <p className="info-p">
+                        <span className="swatch" style={{ background: "rgb(240,220,110)" }}></span>
+                        <strong>Yellow</strong> is {c.yellow}
+                      </p>
+                      <p className="info-p">
+                        <span className="swatch" style={{ background: "rgb(170,20,35)" }}></span>
+                        <strong>Red</strong> means {c.red}
+                      </p>
+                    </>
+                  );
+                })()}
               </div>
             ) : layer === "chl" ? (
               <div className="info-section">
@@ -1878,10 +1937,24 @@ function DesktopView({ layer, setLayer, composite, setComposite, sstMode, setSst
       </div>
 
       <div className="attribution">
-        zoom 7 · 34.6°N −120.3°W · CA Coast bbox 31.8°→37.6°N · −124.0°→−116.8°W
+        {(() => {
+          const r = activeRegion();
+          const b = BBOX;
+          const tag =
+            r === "pnw"      ? "Pacific NW (beta)" :
+            r === "tropical" ? "FL + Caribbean (beta)" :
+            "CA Coast";
+          return `${tag} bbox ${b.latMin.toFixed(1)}°→${b.latMax.toFixed(1)}°N · ${b.lngMin.toFixed(1)}°→${b.lngMax.toFixed(1)}°W`;
+        })()}
       </div>
 
-      {mpaOn && <CoronadosBanner vb={renderVb} size={size} />}
+      {/* Coronados / CONANP disclaimer is CA-specific (the Coronados sit in
+          Mexican waters at the south end of the CA bbox). For PNW + tropical
+          the MPA layer doesn't even render CA data so the disclaimer is
+          irrelevant. Region-gate it explicitly. */}
+      {mpaOn && activeRegion() === "ca" && (
+        <CoronadosBanner vb={renderVb} size={size} />
+      )}
 
       {selectedMpa && (
         <MpaPopup mpa={selectedMpa} onClose={() => setSelectedMpa(null)} />

--- a/src/components/MobileSheet.jsx
+++ b/src/components/MobileSheet.jsx
@@ -47,7 +47,10 @@ const LAYERS = [
   { id: "wind",  label: "Wind",  unit: "kt" },
   { id: "swell", label: "Swell", unit: "ft" },
   { id: "current", label: "Current", unit: "kt" },
-  { id: "viz",   label: "Vis",   unit: "ft" },
+  // viz is marked beta until NorCal ground truth lands — see
+  // pipeline/fetch_visibility.py manifest-write block for the rationale.
+  // The chip below renders a "Beta" pill on this entry.
+  { id: "viz",   label: "Vis",   unit: "ft", beta: true },
 ];
 
 // Compact value-at-point readout. Returns "—" when the layer has no data
@@ -386,7 +389,10 @@ export default function MobileShell({
                 role="tab"
                 aria-selected={active}
               >
-                <span className="ms-chip-label">{L.label}</span>
+                <span className="ms-chip-label">
+                  {L.label}
+                  {L.beta && <span className="ms-chip-beta">Beta</span>}
+                </span>
                 <span className="ms-chip-sub mono">{sub}</span>
               </button>
             );

--- a/src/lib/dataSource.js
+++ b/src/lib/dataSource.js
@@ -9,6 +9,7 @@
 // new layer = one new file under loaders/, no more giant chain.
 
 import { BBOX } from "./mapData.js";
+import { manifestUrl, rewriteManifestUrls } from "./region.js";
 import {
   LAYER_LOADERS,
   decodeUVPng,
@@ -46,14 +47,16 @@ export { bucketKey, hourKey };
 
 export async function loadManifest() {
   try {
-    const res = await fetch("/data/manifest.json", { cache: "no-cache" });
+    const res = await fetch(manifestUrl(), { cache: "no-cache" });
     if (!res.ok) {
-      // Expected before the pipeline has run — keep silent, fall back to mock.
+      // Expected before the pipeline has run for the active region —
+      // keep silent, fall back to mock. (PNW + tropical commonly hit
+      // this branch in dev until their first refresh-data run lands.)
       state.ready = true;
       notify();
       return;
     }
-    const manifest = await res.json();
+    const manifest = rewriteManifestUrls(await res.json());
     state.manifest = manifest;
 
     // 2026-05-09: dispatch loaders in PARALLEL instead of one-by-one.

--- a/src/lib/loaders/current5d.js
+++ b/src/lib/loaders/current5d.js
@@ -14,12 +14,14 @@ import {
   currentSampleMask,
   landMaskedCurrentSample,
 } from "./decoders.js";
+import { rewriteManifestUrls } from "../region.js";
 
 export async function loadCurrent5d(info, state) {
   try {
     const sres = await fetch(info.summary_url, { cache: "no-cache" });
     if (!sres.ok) throw new Error(`currents summary ${info.summary_url} ${sres.status}`);
-    const summary = await sres.json();
+    // Region rewrite: see sst7d.js.
+    const summary = rewriteManifestUrls(await sres.json());
     state.layers.current5d = {
       summary,
       uvRange: info.uv_range,

--- a/src/lib/loaders/index.js
+++ b/src/lib/loaders/index.js
@@ -20,6 +20,7 @@ import { loadSst5d } from "./sst5d.js";
 import { loadSwell5d } from "./swell5d.js";
 import { loadWind5d } from "./wind5d.js";
 import { loadCurrent5d } from "./current5d.js";
+import { loadRtofs5d } from "./rtofs5d.js";
 import { loadWind } from "./wind.js";
 import { loadViz } from "./viz.js";
 import { loadScalarPng } from "./scalarPng.js";
@@ -33,6 +34,11 @@ export const LAYER_LOADERS = {
   swell5d:  (info, state) => loadSwell5d(info, state),
   wind5d:   (info, state) => loadWind5d(info, state),
   current5d:(info, state) => loadCurrent5d(info, state),
+  // rtofs5d is a parallel ocean-model forecast track to sst5d.
+  // Loader plumbs the data into state; UI exposure (toggle / compare
+  // view / difference map) is a deferred product decision — see
+  // src/lib/loaders/rtofs5d.js docstring.
+  rtofs5d:  (info, state) => loadRtofs5d(info, state),
   wind:     (info, state) => loadWind(info, state),
   viz:      (info, state) => loadViz(info, state),
   sst:      (info, state) => loadScalarPng("sst", info, state),

--- a/src/lib/loaders/rtofs5d.js
+++ b/src/lib/loaders/rtofs5d.js
@@ -1,0 +1,103 @@
+// RTOFS ocean-model 5-day forecast loader.
+//
+// Parallel forecast track to sst5d: NOAA RTOFS Global publishes daily
+// ocean-model forecast cycles at NOMADS. Where sst5d is anomaly-decay
+// persistence (simple, fast, no physics), rtofs5d carries actual ocean
+// dynamics — advection, wind forcing, thermocline. Plus surface currents,
+// which fill the HFRNet zero-coverage Caribbean gap.
+//
+// Sampled at +1d / +3d / +5d / +7d (4 leads). The pipeline writes:
+//   public/data/<region>/rtofs/
+//     summary.json       — { generated_at, init_cycle, days[] }
+//     sst_d{1,3,5,7}.png — SST PNG (linear, range from manifest)
+//     uv_d{1,3,5,7}.png  — RGBA currents (R=u, G=v over [-2,2] m/s, A=0 NaN)
+//
+// Output shape on `state.layers.rtofs5d`:
+//   {
+//     summary,                              // raw summary.json, region-rewritten
+//     sst:    { d1: decoded, d3: decoded, d5: decoded, d7: decoded },
+//     uv:     { d1: decoded, d3: decoded, d5: decoded, d7: decoded },
+//     model:  "NOAA_RTOFS_Global_2ds_prog",
+//     init_cycle: "20260513T00:00:00Z",
+//   }
+//
+// `decoded` from decodePng / decodeUVPng — same shape the other
+// forecast layers use, so the future UI compare-toggle can sample
+// pixel values with the existing decoder helpers.
+//
+// UI wiring is intentionally NOT done here. The data flows into state
+// and is inspectable via DevTools (`window.__appState?.layers?.rtofs5d`)
+// for ad-hoc validation. A toggle / overlay / difference-map is a
+// product decision pending; this loader plumbs the data so that work,
+// when it lands, doesn't have to plumb pipeline → manifest → state.
+
+import { decodePng, decodeUVPng } from "./decoders.js";
+import { rewriteManifestUrls } from "../region.js";
+
+export async function loadRtofs5d(info, state) {
+  try {
+    const sres = await fetch(info.summary_url, { cache: "no-cache" });
+    if (!sres.ok) {
+      throw new Error(`rtofs5d summary ${info.summary_url} ${sres.status}`);
+    }
+    const summary = rewriteManifestUrls(await sres.json());
+    state.layers.rtofs5d = {
+      summary,
+      sst: {},
+      uv: {},
+      model: info.model || summary.model || "RTOFS",
+      init_cycle: info.init_cycle || summary.init_cycle || null,
+    };
+
+    // SST decode range: manifest `range` (matches sst5d range for the
+    // region), falling back to summary `sst_range_c`.
+    const sstRange = info.range || summary.sst_range_c;
+    if (!sstRange) {
+      throw new Error("rtofs5d has no SST range");
+    }
+    // UV decode range: manifest `uv_range`, falling back to summary
+    // `uv_range_ms`. Same RGBA encoding the wind UV PNGs use.
+    const uvRange = info.uv_range || summary.uv_range_ms;
+    if (!uvRange) {
+      throw new Error("rtofs5d has no UV range");
+    }
+
+    const tasks = [];
+    (summary.days || []).forEach((d) => {
+      const dayOffset = Number.isInteger(d?.day_offset) ? d.day_offset : null;
+      if (dayOffset === null) return;
+      const slot = `d${dayOffset}`;
+
+      if (d.sst_url) {
+        tasks.push(
+          decodePng(d.sst_url, "linear", sstRange)
+            .then((decoded) => {
+              state.layers.rtofs5d.sst[slot] = {
+                ...decoded,
+                dates: d.date ? [d.date] : [],
+                stats: d,
+              };
+            })
+            .catch((e) => console.warn(`rtofs5d sst ${slot} failed`, e)),
+        );
+      }
+      if (d.uv_url) {
+        tasks.push(
+          // decodeUVPng signature: (url, [lo, hi]) — tuple, not separate args.
+          decodeUVPng(d.uv_url, uvRange)
+            .then((decoded) => {
+              state.layers.rtofs5d.uv[slot] = {
+                ...decoded,
+                dates: d.date ? [d.date] : [],
+                stats: d,
+              };
+            })
+            .catch((e) => console.warn(`rtofs5d uv ${slot} failed`, e)),
+        );
+      }
+    });
+    await Promise.all(tasks);
+  } catch (e) {
+    console.warn("dataSource: rtofs5d load failed", e);
+  }
+}

--- a/src/lib/loaders/sst5d.js
+++ b/src/lib/loaders/sst5d.js
@@ -20,12 +20,14 @@
 //   what fetch_sst_5day.py emits and what fetch.py emits.
 
 import { decodePng } from "./decoders.js";
+import { rewriteManifestUrls } from "../region.js";
 
 export async function loadSst5d(info, state) {
   try {
     const sres = await fetch(info.summary_url, { cache: "no-cache" });
     if (!sres.ok) throw new Error(`sst forecast summary ${info.summary_url} ${sres.status}`);
-    const summary = await sres.json();
+    // Region rewrite: see sst7d.js for the rationale.
+    const summary = rewriteManifestUrls(await sres.json());
     state.layers.sst5d = { summary };
     state.layers.sst = state.layers.sst || {};
     const scale = info.scale || summary.scale || "linear";

--- a/src/lib/loaders/sst7d.js
+++ b/src/lib/loaders/sst7d.js
@@ -7,12 +7,16 @@
 // to the original branch.
 
 import { decodePng } from "./decoders.js";
+import { rewriteManifestUrls } from "../region.js";
 
 export async function loadSst7d(info, state) {
   try {
     const sres = await fetch(info.summary_url, { cache: "no-cache" });
     if (!sres.ok) throw new Error(`sst summary ${info.summary_url} ${sres.status}`);
-    const summary = await sres.json();
+    // Region rewrite: summary.json carries bare `/data/sst/history/d0.png`
+    // URLs from the pipeline (CA-relative). For PNW + tropical those
+    // resolve to 404 unless we rewrite them to `/data/<region>/...`.
+    const summary = rewriteManifestUrls(await sres.json());
     state.layers.sst7d = { summary };
     state.layers.sst = state.layers.sst || {};
     const scale = info.scale || summary.scale || "linear";

--- a/src/lib/loaders/swell5d.js
+++ b/src/lib/loaders/swell5d.js
@@ -6,12 +6,14 @@
 // 2026-05-09 (Tier-1 follow-up).
 
 import { decodeWavePng, bucketKey } from "./decoders.js";
+import { rewriteManifestUrls } from "../region.js";
 
 export async function loadSwell5d(info, state) {
   try {
     const sres = await fetch(info.summary_url, { cache: "no-cache" });
     if (!sres.ok) throw new Error(`swell summary ${info.summary_url} ${sres.status}`);
-    const summary = await sres.json();
+    // Region rewrite: see sst7d.js.
+    const summary = rewriteManifestUrls(await sres.json());
     state.layers.swell5d = {
       summary,
       heightRange: info.height_range_m,

--- a/src/lib/loaders/wind5d.js
+++ b/src/lib/loaders/wind5d.js
@@ -6,12 +6,14 @@
 // 2026-05-09 (Tier-1 follow-up).
 
 import { decodeUVPng, computeSpeedKt, bucketKey } from "./decoders.js";
+import { rewriteManifestUrls } from "../region.js";
 
 export async function loadWind5d(info, state) {
   try {
     const sres = await fetch(info.summary_url, { cache: "no-cache" });
     if (!sres.ok) throw new Error(`summary ${info.summary_url} ${sres.status}`);
-    const summary = await sres.json();
+    // Region rewrite: see sst7d.js.
+    const summary = rewriteManifestUrls(await sres.json());
     state.layers.wind5d = {
       summary,
       uvRange:    info.uv_range,

--- a/src/lib/mapData.js
+++ b/src/lib/mapData.js
@@ -1,8 +1,37 @@
 // Map projection helpers and mocked sea data.
-// Bounding box: lat 31.8°N–37.6°N, lng -124.0° to -116.8° (extended south to
-// include Las Islas Coronado and east to give Tijuana coast breathing room).
+//
+// 2026-05-11 — BBOX is now region-aware (PR-FE-1). The frontend reads
+// `activeRegion()` at module load and selects the matching bbox so the
+// projection math (project/unproject/getFitted/GEO_ASPECT) all align
+// with whichever region's data the manifest carries. Switching
+// regions in the RegionSwitcher triggers a full reload (see
+// region.js → setActiveRegion), so it's safe for BBOX to be a const
+// at module level — it just gets a different value on the next boot.
+//
+// CA history that matters:
+//   2026-05-09 — bumped CA latMax 37.6 → 42.0 (NorCal expansion, dev).
+//   2026-05-10 — bumped CA lngMin -124.0 → -124.6 (Cape Mendocino, dev).
+//   2026-05-13 — bumped CA lngMin -124.6 → -127.0 (Pacific buffer, dev).
+//   2026-05-14 — bumped CA lngMin -127.0 → -128.5 (NorCal margin, dev).
+//   2026-05-15 — SOCAL LAUNCH PIN. NorCal expansion deferred to a later
+//                release once dive-shop scrapers cover Eureka / Fort
+//                Bragg / Mendocino / Bodega Bay (the viz model needs
+//                ground truth to calibrate norcal_* coefficients).
+//                Until then `ca` stays at the production SoCal bbox.
+//                See pipeline/regions/ca.py module docstring for the
+//                full launch-criteria writeup.
+//
+// The values here must stay in lockstep with pipeline/regions/*.py.
+// If you bump a region's bbox there, mirror it here. (A drift test
+// across these two sides is a follow-up TODO.)
+import { activeRegion } from "./region.js";
 
-export const BBOX = { latMin: 31.8, latMax: 37.6, lngMin: -124.0, lngMax: -116.8 };
+const REGION_BBOX = {
+  ca:       { latMin: 31.8, latMax: 37.6, lngMin: -124.0, lngMax: -116.8 },
+  pnw:      { latMin: 42.0, latMax: 49.0, lngMin: -127.0, lngMax: -122.0 },
+  tropical: { latMin: 10.0, latMax: 31.0, lngMin:  -98.0, lngMax:  -60.0 },
+};
+export const BBOX = REGION_BBOX[activeRegion()] || REGION_BBOX.ca;
 
 // Geographic aspect ratio (lng-degrees-as-distance / lat-degrees) at the
 // bbox's mid latitude. Lng degrees shrink by cos(lat); we compute it once
@@ -18,6 +47,14 @@ export const GEO_ASPECT =
 // pixels both represent the same on-the-ground distance regardless of the
 // container's aspect ratio. Returns the rectangle inside (0..w, 0..h) that
 // the geographic content should occupy.
+//
+// Aspect ratio is ALWAYS preserved — `1 km north` and `1 km east` are
+// always the same number of pixels. A previous (2026-05-09 morning)
+// attempt to fall back to aspect-fill when geo-aspect ≠ container-aspect
+// produced visibly stretched land features for the NorCal expansion
+// (CA coast looked ~3x too wide). Pillarbox is the right tradeoff —
+// the desktop layout's aspect should be matched to GEO_ASPECT instead
+// (handled at the .map-stage CSS level, not here).
 export function getFitted(w, h) {
   if (!(w > 0) || !(h > 0)) {
     return { marginX: 0, marginY: 0, innerW: w || 0, innerH: h || 0 };
@@ -139,18 +176,57 @@ export const ISLANDS = [
   { name: "S. Coronado",      lng: -117.25, lat: 32.38, rx: 0.022, ry: 0.035 },
 ];
 
-export const SAVED_SPOTS = [
-  { id: "monterey",  name: "Monterey",       lng: -121.92, lat: 36.62 },
-  { id: "morro",     name: "Morro Bay",      lng: -120.88, lat: 35.36 },
-  { id: "pt-concep", name: "Pt. Conception", lng: -120.47, lat: 34.45 },
-  { id: "santabarb", name: "Santa Barbara",  lng: -119.70, lat: 34.40 },
-  { id: "santacruz", name: "Santa Cruz I.",  lng: -119.75, lat: 34.05 },
-  { id: "malibu",    name: "Malibu",         lng: -118.78, lat: 34.02 },
-  { id: "catalina",  name: "Catalina",       lng: -118.45, lat: 33.39 },
-  { id: "lajolla",   name: "La Jolla",       lng: -117.28, lat: 32.85 },
-  { id: "sandiego",  name: "San Diego",      lng: -117.18, lat: 32.70 },
-  { id: "coronados", name: "Coronados",      lng: -117.27, lat: 32.40 },
-];
+// Region-aware saved spots. CA's list is hand-curated; PNW + tropical
+// get a starter set chosen from the spot pins enumerated in
+// docs/expansion-regions.md (PNW § 2 spot list, tropical § 3 spot
+// list). The full curated rosters live behind PR-PNW-1 and PR-TROP-7;
+// these placeholders exist so the sidebar / mobile sheet has
+// SOMETHING geographically meaningful for non-CA regions instead of
+// leaking CA spots into a Pacific NW or Caribbean map.
+const REGION_SAVED_SPOTS = {
+  ca: [
+    { id: "monterey",  name: "Monterey",       lng: -121.92, lat: 36.62 },
+    { id: "morro",     name: "Morro Bay",      lng: -120.88, lat: 35.36 },
+    { id: "pt-concep", name: "Pt. Conception", lng: -120.47, lat: 34.45 },
+    { id: "santabarb", name: "Santa Barbara",  lng: -119.70, lat: 34.40 },
+    { id: "santacruz", name: "Santa Cruz I.",  lng: -119.75, lat: 34.05 },
+    { id: "malibu",    name: "Malibu",         lng: -118.78, lat: 34.02 },
+    { id: "catalina",  name: "Catalina",       lng: -118.45, lat: 33.39 },
+    { id: "lajolla",   name: "La Jolla",       lng: -117.28, lat: 32.85 },
+    { id: "sandiego",  name: "San Diego",      lng: -117.18, lat: 32.70 },
+    { id: "coronados", name: "Coronados",      lng: -117.27, lat: 32.40 },
+  ],
+  pnw: [
+    { id: "edmonds",     name: "Edmonds UWP",   lng: -122.382, lat: 47.812 },
+    { id: "seacrest",    name: "Seacrest",      lng: -122.378, lat: 47.578 },
+    { id: "three-tree",  name: "Three Tree Pt", lng: -122.391, lat: 47.451 },
+    { id: "limekiln",    name: "Lime Kiln",     lng: -123.151, lat: 48.516 },
+    { id: "pile-pt",     name: "Pile Point",    lng: -123.075, lat: 48.471 },
+    { id: "salt-creek",  name: "Salt Creek",    lng: -123.703, lat: 48.166 },
+    { id: "neah-bay",    name: "Neah Bay",      lng: -124.620, lat: 48.367 },
+    { id: "sund-rock",   name: "Sund Rock",     lng: -123.158, lat: 47.435 },
+    { id: "octopus-hole",name: "Octopus Hole",  lng: -123.149, lat: 47.421 },
+    { id: "yaquina-head",name: "Yaquina Head",  lng: -124.078, lat: 44.674 },
+    { id: "sunset-bay",  name: "Sunset Bay",    lng: -124.378, lat: 43.337 },
+  ],
+  tropical: [
+    { id: "blue-heron",  name: "Blue Heron Br",   lng:  -80.045, lat: 26.783 },
+    { id: "jupiter",     name: "Jupiter Ledge",   lng:  -80.057, lat: 26.943 },
+    { id: "looe-key",    name: "Looe Key",        lng:  -81.408, lat: 24.547 },
+    { id: "molasses",    name: "Molasses Reef",   lng:  -80.402, lat: 25.011 },
+    { id: "vandenberg",  name: "Vandenberg",      lng:  -81.788, lat: 24.488 },
+    { id: "spiegel",     name: "Spiegel Grove",   lng:  -80.298, lat: 25.069 },
+    { id: "flower-gdn",  name: "Flower Garden",   lng:  -93.846, lat: 27.872 },
+    { id: "stuart-cove", name: "Stuart Cove",     lng:  -77.531, lat: 24.991 },
+    { id: "bloody-bay",  name: "Bloody Bay Wall", lng:  -80.097, lat: 19.711 },
+    { id: "palancar",    name: "Palancar",        lng:  -87.027, lat: 20.358 },
+    { id: "bonaire-1k",  name: "1000 Steps",      lng:  -68.397, lat: 12.219 },
+    { id: "blue-hole",   name: "Blue Hole",       lng:  -87.535, lat: 17.316 },
+  ],
+};
+
+export const SAVED_SPOTS =
+  REGION_SAVED_SPOTS[activeRegion()] || REGION_SAVED_SPOTS.ca;
 
 export const SST_STOPS = [
   { t: 0.00, c: [12, 38, 130] },
@@ -160,7 +236,18 @@ export const SST_STOPS = [
   { t: 0.85, c: [230, 110, 60] },
   { t: 1.00, c: [170, 20, 35] },
 ];
-export const SST_RANGE = [9, 25]; // °C
+// Region-aware SST color range. Must match the per-region encoder
+// override in pipeline/regions/{ca,pnw,tropical}.py
+// (layer_range_overrides.sst). If the frontend used a fixed CA range
+// against tropical data, the 25-32°C top end would saturate to flat
+// red — same bug the user caught in QA.
+const REGION_SST_RANGE = {
+  ca:       [9,  25], // °C — legacy CA calibration
+  pnw:      [5,  20], // °C — Olympic + Salish + OR outer coast
+  tropical: [20, 32], // °C — Caribbean / Gulf / Florida year-round
+};
+export const SST_RANGE =
+  REGION_SST_RANGE[activeRegion()] || REGION_SST_RANGE.ca;
 
 // ---- ΔT trend ramp (Phase A) -----------------------------------------
 // Diverging palette for the 3-day SST trend view. Centered at 0 °C

--- a/src/lib/region.js
+++ b/src/lib/region.js
@@ -1,0 +1,171 @@
+// Region routing — picks which `/data/<slug>/` tree the app reads.
+//
+// Source of truth resolution order:
+//   1. `?region=` URL parameter (sticky — also persisted to localStorage)
+//   2. `localStorage.region`
+//   3. Default: "ca"
+//
+// Mirrors `pipeline/regions/` on the Python side. Adding a new
+// region = (a) drop a new entry in `pipeline/regions/`, (b) add it
+// to VALID below, (c) add it to the RegionSwitcher REGIONS list.
+
+const VALID = ["ca", "pnw", "tropical"];
+const DEFAULT_REGION = "ca";
+
+let _cached = null;
+
+/**
+ * Hostname → region lock. Each Cloudflare Pages preview branch gets
+ * its own subdomain (pnw-beta.shouldidive.pages.dev,
+ * tropical-beta.shouldidive.pages.dev). If a visitor lands on one of
+ * those URLs we lock the region to that subdomain regardless of any
+ * URL param or localStorage value — the WHOLE POINT of the per-region
+ * preview is that PNW beta testers see only PNW.
+ *
+ * Returns null when the hostname doesn't match a known beta slug
+ * (= use URL/localStorage/default as before).
+ */
+function _regionFromHostname() {
+  try {
+    const h = (window.location.hostname || "").toLowerCase();
+    if (h.startsWith("pnw-beta.")) return "pnw";
+    if (h.startsWith("tropical-beta.")) return "tropical";
+    // ca-beta is a CA staging surface that mirrors dev's bundle (with
+    // NorCal expansion + PR-NC-1 viz calibration) deployed under a
+    // dedicated URL. Region is still "ca" — same /data/ tree as prod —
+    // but the hostname lock hides the RegionSwitcher so beta testers
+    // can't accidentally flip to PNW or tropical and confuse the
+    // feedback loop.
+    if (h.startsWith("ca-beta.")) return "ca";
+  } catch {
+    // SSR or no-window — fall through.
+  }
+  return null;
+}
+
+/**
+ * Read the active region. Resolution order:
+ *   1. Hostname (locks pnw-beta.* / tropical-beta.* subdomains)
+ *   2. ?region= URL param
+ *   3. localStorage.region
+ *   4. Default: "ca"
+ * Cached on first read so every consumer sees the same value within
+ * a page load.
+ */
+export function activeRegion() {
+  if (_cached !== null) return _cached;
+
+  // Hostname-pinned region wins over everything else. Without this
+  // the bundle on pnw-beta.shouldidive.pages.dev would default to
+  // "ca" on a clean visit and show CA data despite the URL — which
+  // is exactly what the user saw on first beta-URL load.
+  const fromHost = _regionFromHostname();
+  if (fromHost) {
+    _cached = fromHost;
+    return fromHost;
+  }
+
+  let resolved = DEFAULT_REGION;
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const fromUrl = params.get("region");
+    if (fromUrl && VALID.includes(fromUrl)) {
+      resolved = fromUrl;
+      try { window.localStorage.setItem("region", fromUrl); } catch {}
+    } else {
+      const stored = window.localStorage.getItem("region");
+      if (stored && VALID.includes(stored)) resolved = stored;
+    }
+  } catch {
+    // SSR / private-mode fallback — stick with the default.
+  }
+  _cached = resolved;
+  return resolved;
+}
+
+/**
+ * True when the current hostname pins the region (= a beta subdomain).
+ * Used by the RegionSwitcher to hide itself — switching regions on
+ * pnw-beta would be a no-op since hostname overrides the URL param.
+ */
+export function isRegionLocked() {
+  return _regionFromHostname() !== null;
+}
+
+/**
+ * Switch to a different region and reload. Reload is the cheap path:
+ * the entire data layer (manifest, layer PNGs, MPA polygons,
+ * coastline) needs to be re-fetched from the new region's tree, and
+ * the worker / loader caches don't know how to invalidate themselves
+ * piecemeal yet.
+ */
+export function setActiveRegion(next) {
+  if (!VALID.includes(next)) return;
+  try { window.localStorage.setItem("region", next); } catch {}
+  const url = new URL(window.location.href);
+  if (next === DEFAULT_REGION) url.searchParams.delete("region");
+  else url.searchParams.set("region", next);
+  window.history.replaceState({}, "", url);
+  window.location.reload();
+}
+
+/**
+ * Rewrite a `/data/...` URL into the active region's tree.
+ * For CA (the default region) the path is returned unchanged so
+ * everything in `public/data/` keeps working bit-for-bit.
+ */
+export function dataPath(absPath) {
+  const r = activeRegion();
+  if (r === DEFAULT_REGION) return absPath;
+  if (typeof absPath !== "string") return absPath;
+  return absPath.replace(/^\/data\//, `/data/${r}/`);
+}
+
+/**
+ * The manifest URL for the active region. Convenience wrapper —
+ * equivalent to `dataPath("/data/manifest.json")` but lets callers
+ * be explicit about intent.
+ */
+export function manifestUrl() {
+  return dataPath("/data/manifest.json");
+}
+
+/**
+ * Recursively rewrite every `/data/...` string in a manifest object
+ * so the loaders fetch from the correct region tree. The pipeline
+ * currently writes manifest URLs as bare `/data/<file>.png` regardless
+ * of which region produced it; this rewrite lets the frontend stay
+ * agnostic of that detail. Mutates in place + returns the same
+ * reference for chaining.
+ */
+export function rewriteManifestUrls(manifest) {
+  const r = activeRegion();
+  if (r === DEFAULT_REGION || !manifest || typeof manifest !== "object") {
+    return manifest;
+  }
+  const prefix = `/data/${r}/`;
+  function walk(obj) {
+    if (Array.isArray(obj)) {
+      for (const v of obj) walk(v);
+      return;
+    }
+    if (!obj || typeof obj !== "object") return;
+    for (const key of Object.keys(obj)) {
+      const v = obj[key];
+      if (typeof v === "string" && v.startsWith("/data/") &&
+          !v.startsWith(prefix)) {
+        obj[key] = prefix + v.slice("/data/".length);
+      } else if (v && typeof v === "object") {
+        walk(v);
+      }
+    }
+  }
+  walk(manifest);
+  return manifest;
+}
+
+export function listRegions() {
+  return [...VALID];
+}
+
+export const DEFAULT_REGION_ID = DEFAULT_REGION;

--- a/src/styles/mobile.css
+++ b/src/styles/mobile.css
@@ -448,6 +448,24 @@
      the topbar only needs the brand mark + a settings cog. */
   .topbar-meta > span { display: none; }
   .topbar-meta { gap: 8px; }
+  /* Mobile region switcher: compact the `Region <select>` chip so it
+     doesn't collide with the ShouldIDive brand at 390px. Caught in QA
+     2026-05-11 — at 390px the "Region" label + select would push the
+     brand-name into the dropdown. Hide the uppercase label and tighten
+     the select padding; the select itself stays large enough to tap. */
+  .region-switcher-label { display: none; }
+  .region-switcher select {
+    padding: 4px 18px 4px 6px;
+    background-position: calc(100% - 8px) center, calc(100% - 4px) center;
+    max-width: 130px;
+  }
+
+  /* Hide the lat/lng axis labels on mobile — they collided with the
+     MPAs/Bottom pill row sitting above the peek strip at the same
+     vertical position. Power-users on desktop get the precise readout
+     in the cursor-position attribution; phone users don't. The
+     graticule LINES stay (still useful as distance cues). */
+  .graticule text { display: none; }
   /* The old `Live` chip in the topbar is now redundant — MobileShell's
      own status row shows the same liveness via the green dot next to
      the layer name. Hide it to reclaim vertical space. */

--- a/src/styles/shell.css
+++ b/src/styles/shell.css
@@ -81,6 +81,49 @@
   font-weight: 500;
 }
 
+/* Region switcher chip — sits at the left of the topbar-meta cluster.
+ * Same visual weight as the status pill so it doesn't dominate, but
+ * always-visible to make multi-region discoverable. */
+.region-switcher {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--ink-3);
+  font-size: 11px;
+  cursor: pointer;
+}
+.region-switcher-label {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 10px;
+  color: var(--ink-3);
+}
+.region-switcher select {
+  background: var(--bg-sunken);
+  color: var(--ink);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 3px 8px;
+  font-size: 11px;
+  font-family: inherit;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, currentColor 50%),
+                    linear-gradient(135deg, currentColor 50%, transparent 50%);
+  background-position: calc(100% - 12px) center, calc(100% - 7px) center;
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+  padding-right: 22px;
+}
+.region-switcher select:hover {
+  border-color: var(--ink-3);
+}
+.region-switcher select:focus {
+  outline: 2px solid var(--accent, oklch(0.65 0.15 230));
+  outline-offset: 1px;
+}
+
 .icon-btn {
   display: inline-flex;
   align-items: center;
@@ -380,7 +423,9 @@
   cursor: not-allowed;
 }
 .sst-mode-toggle span,
-.sst-beta-pill {
+.sst-beta-pill,
+.layer-toggle .lt-beta,
+.ms-chip-beta {
   display: inline-flex;
   align-items: center;
   margin-left: 5px;
@@ -391,6 +436,28 @@
   font-size: 9px;
   font-weight: 800;
   text-transform: uppercase;
+}
+
+/* Viz layer chip — beta pill sits next to the value sub-line, not the
+   label, so it doesn't expand the chip's compressed grid layout when
+   the layer-toggle row is in 5- or 6-column mode. */
+.layer-toggle .lt-beta {
+  margin: 1px 0 0;
+  padding: 0 3px;
+  font-size: 8px;
+  letter-spacing: 0.5px;
+  align-self: center;
+}
+.layer-toggle button.active .lt-beta {
+  background: rgba(194, 65, 12, 0.22);
+}
+
+/* Mobile chip — beta pill inline with the label. */
+.ms-chip-beta {
+  margin-left: 4px;
+  padding: 0 3px;
+  font-size: 8px;
+  letter-spacing: 0.5px;
 }
 
 .composite-window {
@@ -532,11 +599,27 @@
   .tip-fish { padding: 4px 6px; }
 }
 
-/* Saved spots — bottom-left */
+/* Saved spots — bottom-left.
+ *
+ * max-height caps so the panel cannot grow tall enough to crash into
+ * the .controls-tl layer panel at top: 56px. Caught in QA at 1280x720
+ * where the 10-spot CA list overflowed upward and covered the layer
+ * toggles + forecast controls. Reserve 380px for everything above the
+ * spots panel (topbar + layer controls + how-to-read), then scroll the
+ * spots list inside whatever height is left.
+ */
 .spots-bl {
   bottom: 12px;
   left: 12px;
   width: 248px;
+  max-height: calc(100vh - 380px);
+  display: flex;
+  flex-direction: column;
+}
+.spots-bl .panel-body {
+  overflow-y: auto;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 .spots-list {
   display: flex;

--- a/tests/appFeatureContracts.test.js
+++ b/tests/appFeatureContracts.test.js
@@ -70,8 +70,9 @@ test("Current, swell, wind, and mobile overlay features remain wired", () => {
 
 test("CI runs frontend and data feature contracts before publishing", () => {
   const pkg = JSON.parse(read("package.json"));
-  const deployWorkflow = read(".github/workflows/refresh-ca-data.yml");
-  const frontendWorkflow = read(".github/workflows/frontend-tests.yml");
+  const refreshWorkflow = read(".github/workflows/refresh-ca-data.yml");
+  const deployProdWorkflow = read(".github/workflows/deploy-prod.yml");
+  const devChecksWorkflow = read(".github/workflows/dev-checks.yml");
 
   // Relaxed from `assert.equal` to `assert.match` so adding more glob
   // targets to the test script (e.g. tests/checkpoints/*.test.js)
@@ -82,6 +83,22 @@ test("CI runs frontend and data feature contracts before publishing", () => {
     "pkg.scripts.test must run `node --test` over the top-level tests/*.test.js glob, " +
     "optionally followed by additional globs (e.g. tests/checkpoints/*.test.js)");
   assert.equal(pkg.scripts["test:data-contracts"], "node tests/dataFeatureContracts.mjs");
-  assert.match(frontendWorkflow, /Run frontend regression tests[\s\S]*npm test[\s\S]*Build[\s\S]*npm run build/);
-  assert.match(deployWorkflow, /Run frontend regression tests[\s\S]*npm test[\s\S]*Run data feature contracts[\s\S]*npm run test:data-contracts[\s\S]*Build[\s\S]*npm run build/);
+  // dev-checks.yml is the canonical pre-merge gate — it runs `npm test`
+  // (web-tests job) and `npm run build` (web-build job). The legacy
+  // `frontend-tests.yml` was deleted 2026-05-08 because dev-checks
+  // covers the same surface plus lint/smoke/visual-paint.
+  assert.match(devChecksWorkflow, /name:\s*web-tests[\s\S]*npm test/);
+  assert.match(devChecksWorkflow, /name:\s*web-build[\s\S]*npm run build/);
+  // 2026-05-13: build + deploy steps moved out of refresh-ca-data.yml
+  // and into deploy-prod.yml. refresh-ca-data.yml now (a) runs the
+  // frontend + data-contract tests against the refreshed PNGs, (b)
+  // commits the data, (c) explicitly triggers deploy-prod.yml via
+  // `gh workflow run`. deploy-prod.yml owns the build + Cloudflare
+  // publish via the deploy-cloudflare composite action.
+  assert.match(refreshWorkflow,
+    /Run frontend regression tests[\s\S]*npm test[\s\S]*Run data feature contracts[\s\S]*npm run test:data-contracts[\s\S]*Trigger production deploy[\s\S]*gh workflow run deploy-prod\.yml/,
+    "refresh-ca-data.yml must run frontend + data-contract tests, then trigger deploy-prod.yml");
+  assert.match(deployProdWorkflow,
+    /uses:\s*\.\/\.github\/actions\/deploy-cloudflare[\s\S]*branch:\s*main/,
+    "deploy-prod.yml must use the deploy-cloudflare composite action with branch=main");
 });

--- a/tests/checkpoints/rendering-math.test.js
+++ b/tests/checkpoints/rendering-math.test.js
@@ -44,11 +44,13 @@ test("cp-rendering-math: BBOX is sane (lat/lng ordered, CA coast)", () => {
     `BBOX latMin must be < latMax (got ${BBOX.latMin} >= ${BBOX.latMax})`);
   assert.equal(BBOX.lngMin < BBOX.lngMax, true,
     `BBOX lngMin must be < lngMax (got ${BBOX.lngMin} >= ${BBOX.lngMax})`);
-  // Sanity: should cover CA coast roughly 31.8..37.6 N, -124..-116.8 W.
-  // Anything wildly outside this range = the bbox got corrupted during
-  // editing.
+  // Sanity: should cover the CA coast. Initially scoped to SoCal +
+  // Bay Area edge (31.8..37.6 N); 2026-05-09 expanded to full CA
+  // coast (31.8..42.0 N — see docs/expansion-norcal.md). The bounds
+  // here are loose enough to allow either era + tight enough to flag
+  // a corruption (e.g. someone accidentally typed 420 instead of 42).
   assert.equal(
-    BBOX.latMin > 30 && BBOX.latMax < 40,
+    BBOX.latMin > 30 && BBOX.latMax <= 43,
     true, `BBOX latitude range looks wrong: ${BBOX.latMin}..${BBOX.latMax}`,
   );
   assert.equal(


### PR DESCRIPTION
## DO NOT MERGE YET

Draft PR — stays open for CI + dev preview validation. The SoCal upgrade is **ready to ship** but the user has explicitly asked to keep it out of prod until they say go. Mark ready-for-review when approved.

## Why staged

Full dev-branch work (NorCal expansion to latMax=42.0 + lngMin=-128.5 + `norcal_*` viz coefficients) is shelved on `dev` until two unblock criteria are met:

1. Dive-shop scrapers covering Eureka / Fort Bragg / Mendocino / Bodega Bay so the visibility model has ground-truth observations to calibrate `norcal_*` coefficients against.
2. At least a few weeks of those observations flowing through the watchdog without unresolved bias findings.

Until then, this PR ships the SoCal-pinned subset of the dev work. `pipeline/regions/ca.py` and `src/lib/mapData.js` are pinned to the pre-expansion bbox (lat 31.8–37.6, lng -124.0 to -116.8). The `norcal_*` viz coefficients are present in code but won't fire because no cells reach that lat band.

## What ships to SoCal users

### Pipeline — data quality
- **NOAA OISST v2.1 1991-2020 30-yr SST climatology** replaces the 1-year prior-year-sample baseline that baked the 2024-25 marine heatwave into the "normal."
- **Region-aware SST encoding range** in `fetch_climatology.py` + `fetch_visibility.py` — pre-emptive fix for the encode/decode bug class (no-op on SoCal; prevents future regression).
- **Climatology host migration** off `coastwatch.pfeg.noaa.gov` (broken from GHA egress) to `coastwatch.noaa.gov`.
- **Bathy-derived land mask** on wind (`fetch_wind.py` + `fetch_wind_5day.py`) and chl (`chl_blend.py`). Box-averaged + 0.7 threshold so coastal cells with mostly ocean keep data; cells mostly land get NaN'd. Wind streamlines now stop crisply at the coast; chl DINEOF gap-fill no longer bleeds past the shoreline.
- **Sidecar JSON bbox tracking** on `fetch_bathy.py` (`bathy.json`) and `fetch_climatology.py` (`climo_meta.json`). Bbox bumps force regen automatically rather than serving a stale grid against new coords.

### Pipeline — region scaffolding
- `pipeline/regions/` package with CA + PNW + tropical configs. PNW + tropical are skeletons (won't fire unless `SHOULDIDIVE_REGION` env var is set); CA is pinned to SoCal here.
- All fetchers read `active_region().bbox` instead of hardcoded constants. Zero behavior change in prod (env unset → default `ca` → SoCal bbox preserved).

### Pipeline — visibility model
- `viz` layer marked **beta** in the manifest with `beta_reason`. LayerSpec accepts the new keys; frontend renders a small "Beta" pill on desktop and mobile chips. Honest: the model has no NorCal ground truth and only sparse SoCal calibration.

### Pipeline — tests
- `pipeline/tests/test_data_integrity.py` — 42-test suite over {correct, consistent, plausible, fresh}. Runs in `pipeline-tests` CI job on every PR. Catches the bug classes we hit this week (bbox-stale cache, wind misregistration, chl bleeding past coast, NaN floods).

### Security / ops hardening
- **CSP, HSTS (1y + includeSubDomains), X-Frame-Options DENY, Permissions-Policy, COOP/CORP** via `public/_headers`.
- **Scanner-path 404 middleware** at `functions/_middleware.js` — ~50 known scanner paths (/.env, /.git/*, /wp-*, etc.) return crisp 404 instead of SPA fallback's 200+HTML.
- **Analytics endpoint hardened** — origin allowlist + Content-Type filter + session-ID charset restriction in `functions/api/analytics/event.js`.
- **`robots.txt`, `security.txt` (RFC 9116), `sitemap.xml`** in `public/`.
- **Dependabot + CodeQL** — weekly grouped patch/minor PRs + JS + Python SAST.
- **`SECURITY.md`** — full posture writeup.

## Validation plan (do these before un-drafting)

- [ ] `dev-checks.yml` passes (pipeline-tests, web-build, web-lint, web-tests, web-smoke, mobile-static, secrets-scan, workflow-lint, manifest-validate, cp-visual-paint).
- [ ] Cloudflare Pages preview at `https://dev.shouldidive.pages.dev` (or PR-scoped preview if available) eyeballs clean: SoCal bbox renders, no NorCal cells, "Beta" pill on viz chip, wind stops at coast, chl stops at coast.
- [ ] `pipeline-tests` 42-test suite green across the three regions (CA wired, PNW + tropical skeleton).
- [ ] Verify NorCal lat range produces no map cells (latMax = 37.6).

## What's NOT in this PR
- NorCal scrapers (Eureka, Fort Bragg, Mendocino, Bodega Bay) — separate later PR.
- NorCal bbox launch (latMax 37.6 → 42.0, lngMin -124.0 → -128.5) — separate later PR after scrapers + watchdog clean weeks.
- Workflow files (`refresh-*.yml`, `deploy-*.yml`) — kept at main's versions; not touching deploy plumbing here.
- `public/data/*` — kept at main's versions; the bot will refresh against the new fetchers after merge.

## Rollback
Revert this PR via `git revert -m 1 <merge-sha>` on a new branch off main; opens a revert PR through the same gate. The pre-existing pipeline outputs in `public/data/` remain valid baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)