### PR TITLE
feat(baja): scaffold Pacific + Sea of Cortez region

### DIFF
--- a/.github/workflows/deploy-baja-beta.yml
+++ b/.github/workflows/deploy-baja-beta.yml
@@ -1,0 +1,56 @@
+name: Deploy baja-beta (code-only)
+
+# Code-only deploy to the baja-beta Cloudflare Pages preview branch
+# (Baja Mexico — Pacific + Sea of Cortez). Fires automatically after
+# `dev-checks` passes on `dev`, OR via manual workflow_dispatch
+# (e.g. from refresh-baja-*.yml workflows after they commit fresh
+# data).
+#
+# See deploy-ca-beta.yml for the broader rationale on splitting
+# code-deploy from data-refresh.
+#
+# Cannot reach prod: wrangler --branch=baja-beta routes to the
+# Cloudflare Pages preview branch within the same project, never
+# the production custom domain.
+
+on:
+  workflow_run:
+    workflows: ["Dev checks"]
+    types: [completed]
+    branches: [dev]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-baja-beta
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || 'dev' }}
+
+      - uses: ./.github/actions/deploy-cloudflare
+        with:
+          branch: baja-beta
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Annotate run with preview URL
+        run: |
+          {
+            echo "## baja-beta preview deployed"
+            echo
+            echo "Preview URL: https://baja-beta.shouldidive.pages.dev"
+            echo "Commit:      \`${{ github.event.workflow_run.head_sha || github.sha }}\`"
+            echo
+            echo "_Production at shouldidive.com is unchanged._"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/refresh-baja-data.yml
+++ b/.github/workflows/refresh-baja-data.yml
@@ -1,0 +1,163 @@
+name: Refresh baja — data (daily)
+
+# Baja Mexico (Pacific + Sea of Cortez) — DAILY data refresh at 07:30 UTC.
+# Writes to public/data/baja/ and deploys to
+# baja-beta.shouldidive.pages.dev (Cloudflare preview branch —
+# wrangler --branch=baja-beta cannot reach shouldidive.com).
+#
+# Time slot rationale:
+#   06:00 CA data, 06:15 CA-beta data, 06:30 PNW data,
+#   07:00 tropical data, 07:30 baja data → 30-min spacing across
+#   the daily morning refresh window so the runners don't queue.
+
+on:
+  schedule:
+    - cron: "30 7 * * *"
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Git ref to refresh against (default: dev)"
+        required: false
+        default: "dev"
+        type: string
+      force_climo:
+        description: "Force-rebuild sst_climo.png even if the cached month matches (use after fixing climo encoding bugs)"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: refresh-baja-data
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    env:
+      SHOULDIDIVE_REGION: baja
+    permissions:
+      contents: write
+      actions: write   # for `gh workflow run deploy-baja-beta.yml` at the end
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch || (github.event_name == 'schedule' && 'dev' || github.ref) }}
+          token: ${{ secrets.BOT_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pipeline/requirements.txt
+
+      - name: Install pipeline dependencies
+        run: pip install -r pipeline/requirements.txt
+
+      - name: Fetch latest ocean data (SST, chl, kd490)
+        # Baja hull spans -118 to -106.5 lng × 22 to 32.6 lat. Smaller
+        # than tropical (~12° × 10.6° vs tropical's 38° × 21°) so the
+        # tropical 35-min budget is overkill — use 25 min, same as the
+        # CA budget which has a comparable bbox size.
+        continue-on-error: true
+        timeout-minutes: 25
+        env:
+          EARTHDATA_TOKEN: ${{ secrets.EARTHDATA_TOKEN }}
+        run: python pipeline/fetch.py
+
+      - name: Sentinel — fail loudly if ocean fetch produced no fresh output
+        # See refresh-ca-data.yml for the full rationale. SHOULDIDIVE_REGION
+        # is inherited from the job env, so the sentinel looks at
+        # public/data/baja/ automatically.
+        run: python pipeline/check_fetch_freshness.py --layer sst
+
+      - name: Fetch 7-day precipitation
+        continue-on-error: true
+        timeout-minutes: 5
+        run: python pipeline/fetch_precip.py
+
+      - name: Fetch river discharge (no-op for baja — CA USGS stations only)
+        continue-on-error: true
+        timeout-minutes: 5
+        run: python pipeline/fetch_rivers.py
+
+      - name: Fetch tide range (no-op for baja — NOAA CO-OPS stops at the US border)
+        continue-on-error: true
+        timeout-minutes: 5
+        run: python pipeline/fetch_tides.py
+
+      - name: Refresh climatology if needed
+        continue-on-error: true
+        run: |
+          if [ "${{ inputs.force_climo }}" = "true" ]; then
+            python pipeline/fetch_climatology.py --force
+          else
+            python pipeline/fetch_climatology.py
+          fi
+
+      - name: Fetch bathymetry (one-shot)
+        continue-on-error: true
+        timeout-minutes: 5
+        run: python pipeline/fetch_bathy.py
+
+      - name: Fetch coastline (one-shot)
+        continue-on-error: true
+        timeout-minutes: 8
+        run: python pipeline/fetch_coastline.py
+
+      - name: Fetch MPA boundaries (empty for baja until PR-BAJA-3 wires CONANP)
+        continue-on-error: true
+        timeout-minutes: 5
+        run: python pipeline/fetch_mpa.py
+
+      - name: Probe all external feeds
+        continue-on-error: true
+        timeout-minutes: 5
+        env:
+          EARTHDATA_TOKEN: ${{ secrets.EARTHDATA_TOKEN }}
+        run: python pipeline/check_feeds.py
+
+      - name: Run 5-day SST forecast
+        continue-on-error: true
+        run: python pipeline/fetch_sst_5day.py
+
+      - name: Run visibility prediction
+        # baja declares subtractive_tropical viz variant, but the
+        # formula doesn't exist yet (same forward-declaration state
+        # as tropical). Falls back to chl-based CA model and predicts
+        # ~100ft viz everywhere south of 28°N. Known wrong; PR-TROP-5
+        # fixes both tropical AND baja simultaneously.
+        continue-on-error: true
+        run: python pipeline/fetch_visibility.py
+
+      - name: Fetch RTOFS ocean-model forecast
+        # Pulls NOAA RTOFS Global 2ds prog NetCDFs from NOMADS for
+        # forecast leads +1d / +3d / +5d / +7d. Adds parallel SST
+        # forecast track + surface currents for the Sea of Cortez
+        # (where HFRNet has zero coverage south of San Diego).
+        continue-on-error: true
+        timeout-minutes: 25
+        run: python pipeline/fetch_rtofs.py
+
+      - name: Commit refreshed baja data
+        if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add public/data/baja/
+          if git diff --staged --quiet; then
+            echo "No baja data changes to commit."
+          else
+            git commit -m "data: refresh baja $(date -u +%Y-%m-%d)"
+            for attempt in 1 2 3; do
+              if git push; then break; fi
+              echo "push failed (attempt $attempt) — rebasing"
+              git pull --rebase --autostash origin "$(git rev-parse --abbrev-ref HEAD)"
+            done
+          fi
+
+      - name: Trigger baja-beta deploy
+        if: success() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run deploy-baja-beta.yml --ref dev

--- a/.github/workflows/refresh-baja-wind.yml
+++ b/.github/workflows/refresh-baja-wind.yml
@@ -1,0 +1,97 @@
+name: Refresh baja — wind (hourly)
+
+# Baja Mexico (Pacific + Sea of Cortez) — HOURLY wind/swell/currents at :00.
+# Time slot rationale: CA :15, PNW :30, tropical :45, CA-beta :50 →
+# pick :00 (top of hour) for baja. HRRR covers down to ~22°N over
+# Mexico (the full Baja peninsula and the Sea of Cortez), so HRRR
+# is the primary wind source for the whole region; GFS fallback
+# remains in fetch_wind.py for any sub-hour HRRR outages.
+# Currents are model-inferred (HFRNet has zero coverage south of
+# San Diego at ~32.5°N).
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Git ref to refresh against (default: dev)"
+        required: false
+        default: "dev"
+        type: string
+
+concurrency:
+  group: refresh-baja-wind
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    env:
+      SHOULDIDIVE_REGION: baja
+    permissions:
+      contents: write
+      actions: write   # for `gh workflow run deploy-baja-beta.yml` at the end
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch || (github.event_name == 'schedule' && 'dev' || github.ref) }}
+          token: ${{ secrets.BOT_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pipeline/requirements.txt
+
+      - name: Install pipeline dependencies
+        run: pip install -r pipeline/requirements.txt
+
+      - name: Fetch wind (HRRR over Baja + GFS fallback)
+        continue-on-error: true
+        timeout-minutes: 5
+        run: python pipeline/fetch_wind.py
+
+      - name: Fetch 5-day hourly wind
+        continue-on-error: true
+        timeout-minutes: 15
+        run: python pipeline/fetch_wind_5day.py
+
+      - name: Fetch 5-day hourly swell
+        continue-on-error: true
+        timeout-minutes: 10
+        run: python pipeline/fetch_swell_5day.py
+
+      - name: Fetch WaveWatch III nowcast
+        continue-on-error: true
+        timeout-minutes: 5
+        run: python pipeline/fetch_waves.py
+
+      - name: Fetch surface currents (model-inferred — zero HFR coverage south of US border)
+        continue-on-error: true
+        timeout-minutes: 5
+        run: python pipeline/fetch_currents.py
+
+      - name: Commit refreshed baja wind data
+        if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add public/data/baja/
+          if git diff --staged --quiet; then
+            echo "No baja wind data changes to commit."
+          else
+            git commit -m "wind: refresh baja $(date -u +%Y-%m-%dT%H:%MZ)"
+            for attempt in 1 2 3; do
+              if git push; then break; fi
+              echo "push failed (attempt $attempt) — rebasing"
+              git pull --rebase --autostash origin "$(git rev-parse --abbrev-ref HEAD)"
+            done
+          fi
+
+      - name: Trigger baja-beta deploy
+        if: success() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run deploy-baja-beta.yml --ref dev

--- a/docs/expansion-baja.md
+++ b/docs/expansion-baja.md
@@ -1,0 +1,211 @@
+# ShouldIDive — Baja Mexico expansion plan
+
+Companion to `docs/expansion-regions.md` (which scopes PNW + tropical). Baja Mexico
+extends the same region-aware infrastructure to cover the Pacific side of the Baja
+California peninsula and the Sea of Cortez, presented as a single "Baja Mexico"
+region in the switcher.
+
+The scaffold (this PR) lands the `Region` dataclass entry, the frontend wiring,
+and the CI workflow trio (`refresh-baja-data.yml`, `refresh-baja-wind.yml`,
+`deploy-baja-beta.yml`). The follow-up PR series (PR-BAJA-2..5) fills in the
+gaps that are flagged TBD below.
+
+---
+
+## 1. Geography — why two sub-bboxes
+
+The Baja peninsula sits between two distinct water bodies:
+
+- **Pacific (west):** California Current cold tongue in the north (Ensenada →
+  Cedros, 14–18°C winter), warmer mid-latitude water near Magdalena Bay,
+  warm tropical surface water by Cabo. Classic kelp-forest sites at Bahía
+  Tortugas + the offshore islands (Cedros, San Benitos, Guadalupe).
+- **Sea of Cortez (east):** warm clear gulf water, 20–31°C surface temps,
+  strong tidal mixing in the Midriff (Tiburón / San Esteban / Ángel de la
+  Guarda) bringing cold deep water to the surface mid-summer. The famous
+  dive sites — Cabo Pulmo, La Paz / Espíritu Santo, Loreto Bay, Mulegé,
+  Bahía de los Ángeles — all sit on this side.
+
+The peninsula itself is ~100 km wide on average and 1,200 km long. A single
+bbox would dedicate ~30% of every PNG to land pixels. The split mirrors
+tropical's `gulf_se` + `caribbean` precedent:
+
+```python
+# in pipeline/regions/baja.py
+subregion_bboxes = {
+    "pacific":       dict(lat_min=22.5, lat_max=32.6, lng_min=-118.0, lng_max=-109.5),
+    "sea_of_cortez": dict(lat_min=22.0, lat_max=32.0, lng_min=-115.5, lng_max=-106.5),
+}
+```
+
+The two overlap over the peninsula's land mass; both passes get land-masked so
+the overlap is harmless.
+
+**Outer hull bbox** (what the frontend's map shows): lat 22.0–32.6°N,
+lng −118.0 to −106.5°W.
+
+---
+
+## 2. Lat zones — the longitude-aware problem returns
+
+Both `tropical` and `baja` have the same structural issue with the current
+`classify_zone` walker: it's lat-only, but the Pacific side and the Sea of
+Cortez side have very different water at the same latitude (Pacific at 25°N
+is cool California-Current; Cortez at 25°N is warm gulf water).
+
+For the scaffold we keep lat-only zones and accept the misclassification, in
+exactly the same posture tropical/ does (see `tropical.py` module docstring):
+
+```python
+lat_zone_bounds = {
+    "north_baja":  (28.00, 90.00),   # Ensenada → Cedros + Midriff Islands
+    "mid_baja":    (24.50, 28.00),   # Vizcaíno + Magdalena + Loreto
+    "south_baja":  (-90.00, 24.50),  # Cabo / La Paz / Cabo Pulmo
+}
+```
+
+PR-TROP-1 (longitude-aware classifier, originally scoped for tropical) will
+unblock proper zone calibration for baja too — the same machinery applies.
+
+---
+
+## 3. Viz model variant — `subtractive_tropical` forward-declaration
+
+Picking the viz model for Baja was a non-obvious call:
+
+| Variant                  | Fit                                              |
+|--------------------------|--------------------------------------------------|
+| `chl_based` (CA/PNW)     | Right for cold productive Pacific Baja north,  |
+|                          | wrong for clear Sea of Cortez sites              |
+| `subtractive_tropical`   | Right for clear Cortez sites + Cabo,            |
+|                          | wrong for cold Pacific Baja north                |
+
+We pick `subtractive_tropical` for the scaffold (matching the user-confirmed
+choice on 2026-05-17). The formula itself doesn't exist yet — `tropical` also
+declares the variant as a forward-declaration. PR-TROP-5 implements the math
+in `viz_predict/`; baja inherits the fix automatically once that lands.
+
+**Until PR-TROP-5:** visibility prediction falls back to chl-based CA model
+output and predicts ~100 ft viz everywhere south of 28°N. Known wrong;
+visibility chip should arguably be hidden on baja-beta until the variant
+formula lands.
+
+Alternative considered: a separate `baja_blend` variant that weights chl
+(Pacific) and subtractive (Cortez) per-pixel based on longitude relative to
+the peninsula. Deferred — until PR-TROP-5 sets the subtractive baseline, a
+blend variant has nothing to blend against.
+
+---
+
+## 4. Per-layer data-source coverage
+
+Coverage is mixed south of the US border. The scaffold ships fetchers
+unchanged; this table captures what each one will actually return.
+
+| Layer                    | Source            | Baja coverage                                 |
+|--------------------------|-------------------|-----------------------------------------------|
+| SST (daily, history)     | NASA OB.DAAC      | Global — fine                                 |
+| SST 5-day forecast       | NOAA OISST/RTOFS  | Global — fine                                 |
+| Chlorophyll              | NASA OB.DAAC      | Global — fine                                 |
+| Kd490                    | NASA OB.DAAC      | Global — fine                                 |
+| Wind (now + 5d)          | NOAA HRRR + GFS   | HRRR covers down to ~22°N — full Baja in HRRR |
+| Swell (now + 5d)         | NOAA WaveWatch III| Global — fine                                 |
+| Surface currents         | HFRNet            | **Zero** south of San Diego (~32.5°N)         |
+| Surface currents (model) | NOAA RTOFS Global | Global — primary current source for baja      |
+| Bathymetry               | GMRT              | Global — fine                                 |
+| Coastline                | NOAA GSHHG        | Global — fine                                 |
+| MPA polygons             | CDFW + NOAA NMS   | **None** — Mexican MPAs need CONANP fetcher   |
+| Tide range               | NOAA CO-OPS       | **None** — stops at the US border             |
+| Climatology              | NOAA              | Global — fine                                 |
+| Precipitation (7d)       | NOAA CPC          | Global — fine                                 |
+
+**Two structural gaps** that won't be fixed in the scaffold PR:
+
+1. **MPA polygons.** Mexico has ~70 marine protected areas covering Baja
+   waters: Islas del Pacífico Biosphere Reserve, Cabo Pulmo NP, Loreto Bay
+   NP, Espíritu Santo NP, the Midriff (Ángel de la Guarda) protected area,
+   etc. Source: CONANP's SIG portal at https://sig.conanp.gob.mx/.
+   Format is not the WDPA polygon format `fetch_mpa.py` consumes. PR-BAJA-3
+   adds a CONANP-specific ingest.
+
+2. **Tide stations.** NOAA CO-OPS has one cooperator station near Ensenada
+   (San Diego coverage technically extends south but station IDs are
+   US-side). Mexican equivalents are CICESE (academic) and SEMAR (navy);
+   neither publishes JSON in the format `fetch_tides.py` consumes. The
+   `tide_stations=[]` in `baja.py` makes `fetch_tides.py` a no-op for the
+   region and `fetch_visibility.py` falls back to its default tide_index.
+   PR-BAJA-4 wires up a CICESE-compatible ingest.
+
+---
+
+## 5. Spot pins
+
+No Baja entries in `_spot_lookup.json` yet. The classic sites to seed in
+PR-BAJA-5:
+
+**Pacific side:**
+- Bahía Tortugas (Cedros), Isla Cedros, Isla San Benito, Isla Guadalupe
+  (great-white-shark cage diving), Punta Banda / Todos Santos islands,
+  Bahía Magdalena (gray whales — surface activity, not dive).
+
+**Sea of Cortez:**
+- Cabo Pulmo NP (the famous coral reef rebound), La Paz / Espíritu Santo
+  / Los Islotes (sea-lion colony), Cerralvo, Las Ánimas, El Bajo seamount
+  (hammerhead schools), Loreto / Isla Carmen / Isla Coronados (Baja's
+  Coronados — distinct from CA's Coronados), Mulegé, Bahía de los Ángeles
+  (whale sharks), Puerto Peñasco, San Felipe.
+
+**Mainland-side Cortez:**
+- Mazatlán, Topolobampo (mantas), San Carlos / Guaymas.
+
+The seed pass should pull from BCS-published dive operator listings (Cabo
+Pulmo Dive Center, Cortez Club La Paz, Dive Ninja Cabo, etc.) — same
+methodology that seeded CA from BeachCitiesCuba + SouthCoastDivers.
+
+---
+
+## 6. SST range override
+
+Sea-of-Cortez summer max hits ~31°C in the northern gulf (Puerto Peñasco /
+San Felipe in August). Pacific-side winter min: ~14°C in the upwelling
+tongue off Cedros in February. So:
+
+```python
+layer_range_overrides = {
+    "sst":   (14.0, 32.0),
+    "sst7d": (14.0, 32.0),
+    "sst5d": (14.0, 32.0),
+}
+```
+
+That's a slightly wider window than tropical (20–32) because the Pacific
+Baja north end pulls the floor down to California-Current temps. Slightly
+narrower than CA (9–25) on the cold end because Baja never sees winter
+upwelling water below ~13°C.
+
+---
+
+## 7. Cloudflare Pages — one human-side prereq
+
+The `deploy-baja-beta.yml` workflow assumes a `baja-beta` Cloudflare Pages
+preview branch exists. Creating the branch is a one-time UI step in the
+Cloudflare dashboard (Pages → shouldidive → Settings → Builds &
+deployments → Preview branches → add `baja-beta`). Until that's done the
+first deploy will fail with a "branch not configured" error.
+
+---
+
+## 8. PR plan
+
+| PR        | Scope                                                                            |
+|-----------|----------------------------------------------------------------------------------|
+| BAJA-1 ✅ | Scaffold (this PR): `regions/baja.py`, registry, frontend wiring, CI workflows  |
+| BAJA-2    | HYCOM Sea-of-Cortez nest (if a public endpoint exists; otherwise stays RTOFS)    |
+| BAJA-3    | CONANP MPA polygon ingest                                                        |
+| BAJA-4    | CICESE / SEMAR tide-station ingest                                               |
+| BAJA-5    | Spot pin seed pass + popup metadata                                              |
+| TROP-5    | `subtractive_tropical` viz formula (unblocks visibility for both baja + tropical) |
+| TROP-1    | Longitude-aware `classify_zone` (unblocks proper zone calibration for both)      |
+
+Once BAJA-2..5 land + TROP-5 + TROP-1 land, baja-beta can graduate from
+"beta" to a chip drop in the production switcher.

--- a/pipeline/regions/__init__.py
+++ b/pipeline/regions/__init__.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 import os
 
 from ._region import Region
+from .baja import REGION as _BAJA
 from .ca import REGION as _CA
 from .pnw import REGION as _PNW
 from .tropical import REGION as _TROPICAL
@@ -60,6 +61,7 @@ _REGISTRY: dict[str, Region] = {
     _CA.name:       _CA,
     _PNW.name:      _PNW,
     _TROPICAL.name: _TROPICAL,
+    _BAJA.name:     _BAJA,
 }
 
 DEFAULT_REGION = "ca"

--- a/pipeline/regions/baja.py
+++ b/pipeline/regions/baja.py
@@ -1,0 +1,153 @@
+"""Baja Mexico region config — SKELETON.
+
+Covers both sides of the Baja California peninsula: the Pacific
+side (west, cold California-Current upwelling water in the north +
+warmer mid-latitude water near Magdalena Bay) and the Sea of Cortez
+(east, warm clear gulf water with strong tidal mixing in the Midriff
+islands at the north end and 30°C+ surface temps in summer).
+
+Two sub-bbox splits (``pacific`` + ``sea_of_cortez``) for the same
+reason ``tropical`` splits into ``gulf_se`` + ``caribbean`` — one
+overall bbox would push past runtime + data-volume caps for a single
+matrix fetch job, and the Baja peninsula itself sits between the two
+water bodies so a single bbox would waste ~30% of every PNG on land.
+The two sub-bboxes overlap over the peninsula; the fetchers land-mask
+both passes so the overlap is harmless.
+
+## What's intentionally missing
+
+* DriverCoefficients — the ``subtractive_tropical`` viz model is the
+  right SHAPE for clear Sea-of-Cortez water (Cabo Pulmo, La Paz,
+  Espíritu Santo) but the FORMULA itself doesn't exist yet — the
+  ``tropical`` scaffold also declares ``subtractive_tropical`` as a
+  forward-declaration. Visibility prediction for Baja will fall back
+  to the chl-based CA model (and predict ~100 ft viz everywhere)
+  until PR-TROP-5 lands the formula.
+* HYCOM Sea-of-Cortez nest — the global HYCOM grid resolves the
+  Cortez at 1/12°, fine for surface fields but too coarse for the
+  Midriff-Islands choke points where tidal currents hit 4-5 kt.
+  PR-BAJA-2 would tap CICESE's regional ROMS run if a public
+  endpoint exists.
+* CONANP MPA polygons — Mexico has ~70 marine protected areas south
+  of the US border (Islas del Pacífico Biosphere Reserve, Cabo
+  Pulmo NP, Loreto Bay NP, Espíritu Santo NP, …). The current
+  ``fetch_mpa.py`` only pulls CDFW / NOAA NMS polygons; CONANP
+  polygons live at https://sig.conanp.gob.mx/ and need a separate
+  fetcher (PR-BAJA-3).
+* Tide stations — NOAA CO-OPS coverage stops at the US border with
+  one exception (Ensenada via international cooperator). The Mexican
+  equivalent is CICESE / SEMAR; their station JSONs are not in the
+  same format ``fetch_tides.py`` expects. Empty list here means
+  ``fetch_tides.py`` is a no-op for baja and ``fetch_visibility.py``
+  falls back to its default tide_index (PR-BAJA-4).
+* Spot pins — no Baja entries in ``_spot_lookup.json`` yet. The
+  classic sites (Cabo Pulmo, Sea of Cortez liveaboard route, Cedros,
+  Guadalupe Island) come in PR-BAJA-5.
+
+DO NOT consume this region from the running pipeline yet beyond the
+fetcher passes that don't need any of the above — bathymetry, SST,
+chl, kd490, wind, swell, currents will produce real data; visibility,
+MPA overlay, tide_index, and the spot pin layer will be empty or wrong.
+"""
+from __future__ import annotations
+
+from ._region import Region
+
+
+# Outer hull of the two sub-region bboxes — the frontend's region
+# switcher only knows the overall bounds; the per-subregion fetch
+# jobs handle the actual data fetching.
+#
+# Northern bound 32.6°N: ~10 km of overlap with the CA region's
+# southern edge at 31.8°N (CA bbox extends south to 31.8 so the
+# Coronados show on the CA map; baja's north edge picks up just
+# slightly north of that line so the regions visually butt against
+# each other without a gap when a user switches).
+#
+# Southern bound 22.0°N: Cabo San Lucas sits at ~22.9°N. The extra
+# 1° south gives the Gorda Banks (offshore seamount, classic
+# spearfishing + striped marlin spot) breathing room on the south
+# edge of the rendered map.
+_HULL_BBOX = dict(lat_min=22.0, lat_max=32.6, lng_min=-118.0, lng_max=-106.5)
+
+
+REGION = Region(
+    name="baja",
+    display_name="Baja Mexico",
+    bbox=_HULL_BBOX,
+    subregion_bboxes={
+        # Pacific side: west of the peninsula. -118°W gives ~150 km
+        # of open Pacific west of Punta Eugenia (-115°W) to capture
+        # the California-Current upwelling tongue that drives the
+        # cold-water kelp-forest sites at Cedros + San Benitos.
+        # Eastern edge at -109.5°W intentionally crosses the
+        # peninsula's east coast near Cabo so the southern tip
+        # ("the corridor") is fully covered.
+        "pacific":        dict(lat_min=22.5, lat_max=32.6,
+                               lng_min=-118.0, lng_max=-109.5),
+        # Sea of Cortez: between peninsula and mainland Mexico.
+        # -115.5°W western edge crosses the peninsula east coast
+        # near Bahía de los Ángeles; -106.5°W eastern edge sits
+        # off Mazatlán. Lat 22.0-32.0 covers Cabo Corrientes-line
+        # in the south up to the Colorado River delta in the
+        # north (Puerto Peñasco / San Felipe).
+        "sea_of_cortez": dict(lat_min=22.0, lat_max=32.0,
+                               lng_min=-115.5, lng_max=-106.5),
+    },
+    lat_zone_bounds={
+        # Lat-only zones — same caveat as tropical: ``classify_zone``
+        # walks lat-only, so a point at 25°N on the Pacific side gets
+        # the same zone as a point at 25°N in the Sea of Cortez,
+        # despite very different water (cold-blue vs warm-green).
+        # Longitude-aware classification lands with the same
+        # PR-TROP-1 fix that tropical needs.
+        #
+        # north_pacific_upwelling: California-Current cold tongue.
+        #   Pacific side from Ensenada (32.5°N) down through
+        #   Cedros (28.3°N). On the Sea-of-Cortez side this lat
+        #   band covers the Midriff Islands (Tiburón, San Esteban,
+        #   Ángel de la Guarda) — water is COLD here too due to
+        #   tidal mixing, so the same zone is approximately right
+        #   for both sides.
+        "north_baja":   (28.00, 90.00),
+        # mid_baja: Vizcaíno transition + Magdalena Bay (Pacific)
+        #   + Loreto / Mulegé (Cortez). Water mixes between cool
+        #   California-Current and warm Tropical-Surface here.
+        "mid_baja":     (24.50, 28.00),
+        # south_baja: Cabo + La Paz + Cabo Pulmo. Warm clear water
+        #   year-round, classic subtractive_tropical regime.
+        "south_baja":   (-90.00, 24.50),
+    },
+    # Same dist labels as CA/PNW/tropical — see tropical.py for the
+    # broader discussion on why renaming would coordinate-break the
+    # DriverCoefficients dict. The labels still make sense for
+    # Baja: nearshore (peninsular coast + mangrove shoals), islands
+    # (Cedros / Guadalupe / Espíritu Santo / Tiburón etc.), offshore
+    # (Gorda Banks + the seamounts west of Cabo).
+    dist_labels=["nearshore", "islands", "offshore"],
+    viz_model_variant="subtractive_tropical",
+    data_dir_slug="baja",
+    layer_range_overrides={
+        # Sea-of-Cortez summer max: 31°C in the northern gulf in
+        # August. Pacific-side winter min: ~14°C in the upwelling
+        # tongue off Cedros in February. 14-32°C captures the
+        # realistic seasonal swing across the whole region without
+        # wasting encoding bits on temperatures we'll never see.
+        "sst":   (14.0, 32.0),
+        "sst7d": (14.0, 32.0),
+        "sst5d": (14.0, 32.0),
+    },
+    # NOAA CO-OPS has effectively zero Mexican coverage. Ensenada
+    # is the one cooperator station near the border. Empty list →
+    # fetch_tides.py is a no-op for baja and fetch_visibility.py
+    # falls back to its default tide_index. PR-BAJA-4 (CICESE /
+    # SEMAR ingest) will populate this.
+    tide_stations=[],
+    notes=(
+        "SKELETON — pacific + sea_of_cortez sub-bboxes, "
+        "subtractive_tropical viz forward-declaration like tropical/. "
+        "Empty tide_stations + no Mexican MPA polygons + no spot pins "
+        "yet (PR-BAJA-3..5). Visibility prediction will be wrong "
+        "until PR-TROP-5 implements the subtractive_tropical formula."
+    ),
+)

--- a/pipeline/tests/test_regions.py
+++ b/pipeline/tests/test_regions.py
@@ -54,6 +54,7 @@ def test_all_regions_load():
     assert "ca" in names
     assert "pnw" in names
     assert "tropical" in names
+    assert "baja" in names
     for n in names:
         r = get_region(n)
         assert isinstance(r, Region)
@@ -79,7 +80,7 @@ def test_active_region_respects_env(monkeypatch):
 # Per-region invariants — every region must have a sane bbox
 # ---------------------------------------------------------------------
 
-@pytest.mark.parametrize("name", ["ca", "pnw", "tropical"])
+@pytest.mark.parametrize("name", ["ca", "pnw", "tropical", "baja"])
 def test_bbox_is_geographically_sane(name):
     r = get_region(name)
     b = r.bbox
@@ -91,7 +92,7 @@ def test_bbox_is_geographically_sane(name):
     assert -180 < b["lng_max"] < 180, f"{name}: lng_max out of range"
 
 
-@pytest.mark.parametrize("name", ["ca", "pnw", "tropical"])
+@pytest.mark.parametrize("name", ["ca", "pnw", "tropical", "baja"])
 def test_bbox_array_matches_dict(name):
     r = get_region(name)
     arr = r.bbox_array
@@ -99,19 +100,19 @@ def test_bbox_array_matches_dict(name):
                    r.bbox["lng_max"], r.bbox["lat_max"]]
 
 
-@pytest.mark.parametrize("name", ["ca", "pnw", "tropical"])
+@pytest.mark.parametrize("name", ["ca", "pnw", "tropical", "baja"])
 def test_lat_zone_bounds_non_empty(name):
     r = get_region(name)
     assert r.lat_zone_bounds, f"{name}: must define at least one lat zone"
 
 
-@pytest.mark.parametrize("name", ["ca", "pnw", "tropical"])
+@pytest.mark.parametrize("name", ["ca", "pnw", "tropical", "baja"])
 def test_dist_labels_non_empty(name):
     r = get_region(name)
     assert r.dist_labels, f"{name}: must define dist_labels"
 
 
-@pytest.mark.parametrize("name", ["ca", "pnw", "tropical"])
+@pytest.mark.parametrize("name", ["ca", "pnw", "tropical", "baja"])
 def test_data_dir_slug_safe(name):
     r = get_region(name)
     assert r.data_dir_slug

--- a/src/components/RegionSwitcher.jsx
+++ b/src/components/RegionSwitcher.jsx
@@ -9,6 +9,7 @@ const REGIONS = [
   { id: "ca",       label: "California" },
   { id: "pnw",      label: "Pacific NW (beta)" },
   { id: "tropical", label: "FL + Caribbean (beta)" },
+  { id: "baja",     label: "Baja Mexico (beta)" },
 ];
 
 export default function RegionSwitcher() {

--- a/src/lib/region.js
+++ b/src/lib/region.js
@@ -9,7 +9,7 @@
 // region = (a) drop a new entry in `pipeline/regions/`, (b) add it
 // to VALID below, (c) add it to the RegionSwitcher REGIONS list.
 
-const VALID = ["ca", "pnw", "tropical"];
+const VALID = ["ca", "pnw", "tropical", "baja"];
 const DEFAULT_REGION = "ca";
 
 let _cached = null;
@@ -30,6 +30,7 @@ function _regionFromHostname() {
     const h = (window.location.hostname || "").toLowerCase();
     if (h.startsWith("pnw-beta.")) return "pnw";
     if (h.startsWith("tropical-beta.")) return "tropical";
+    if (h.startsWith("baja-beta.")) return "baja";
     // ca-beta is a CA staging surface that mirrors dev's bundle (with
     // NorCal expansion + PR-NC-1 viz calibration) deployed under a
     // dedicated URL. Region is still "ca" — same /data/ tree as prod —


### PR DESCRIPTION
## Summary

- Adds `pipeline/regions/baja.py` as the fourth region entry — split sub-bboxes (Pacific west + Sea of Cortez east) mirroring `tropical/`'s pattern. Outer hull spans 22.0–32.6°N × −118.0 to −106.5°W.
- Wires the frontend chip ("Baja Mexico (beta)"), the `baja-beta.` hostname lock in `src/lib/region.js`, and extends `pipeline/tests/test_regions.py` parametrize lists.
- Ships the CI workflow trio: `refresh-baja-data.yml` (daily 07:30 UTC), `refresh-baja-wind.yml` (hourly :00), `deploy-baja-beta.yml` (fires after dev-checks green).
- Design doc at `docs/expansion-baja.md` captures bbox rationale, viz-variant pick (`subtractive_tropical` — forward-declaration, formula blocked on PR-TROP-5), per-layer data-source coverage table, and PR-BAJA-2..5 follow-up plan (CONANP MPA, CICESE tides, spot pins).

## Known gaps (called out in expansion-baja.md)

- No Mexican MPA polygons until PR-BAJA-3 wires CONANP
- No Mexican tide stations until PR-BAJA-4 wires CICESE/SEMAR
- No spot pins until PR-BAJA-5
- Visibility prediction is wrong (chl-based fallback) until PR-TROP-5 lands the subtractive formula — affects both `baja` and `tropical`

## Test plan

- [x] `dev-checks.yml` green on `f63123ea` (pipeline-tests, web-build, web-lint, web-tests, web-smoke, mobile-static, secrets-scan, workflow-lint, manifest-validate, cp-visual-paint all ✓)
- [ ] After merge: trigger `refresh-baja-data.yml` via workflow_dispatch and verify SST / chl / kd490 PNGs land in `public/data/baja/`
- [ ] Trigger `refresh-baja-wind.yml` and verify wind / swell / currents PNGs land
- [ ] Create the `baja-beta` Cloudflare Pages preview branch in the dashboard (one-time human-side prereq for `deploy-baja-beta.yml`)
- [ ] Visit `https://baja-beta.shouldidive.pages.dev` after the first deploy and eyeball each layer chip across the new bbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)