### PR TITLE
fix(uptime-monitor): use Chrome UA so CF doesn't 403 GHA

### DIFF
--- a/.github/workflows/uptime-monitor.yml
+++ b/.github/workflows/uptime-monitor.yml
@@ -95,8 +95,15 @@ jobs:
             # $1 = name, $2 = url, $3 = optional content predicate
             local name="$1" url="$2" predicate="${3:-}"
             local code
+            # Use a real-Chrome UA — Cloudflare's bot detection on
+            # GHA runner IPs returns 403 to obviously-bot user agents
+            # (see PR #48 for the same fix applied to live-runtime).
+            # The custom X-Source header preserves our ability to
+            # identify uptime-monitor traffic in CF logs / our own
+            # analytics endpoint if/when we want to.
             code=$(curl -sS -L \
-              -A 'shouldidive-uptime-monitor/1.0 (+https://github.com/Michaelpjob/ShoudiDive)' \
+              -A 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36' \
+              -H 'X-Source: shouldidive-uptime-monitor/1.0' \
               -o /tmp/probe_body \
               -w '%{http_code}' \
               --max-time 30 \


### PR DESCRIPTION
First real run of uptime-monitor flagged shouldidive.com as DOWN. False positive — CF returns 403 to obviously-bot user agents from GHA runners. Same root cause as the live-cp-render 403 we fixed in PR #48.

Switching to the same real-Chrome UA. Preserves a custom `X-Source: shouldidive-uptime-monitor/1.0` header so we can still identify our own monitor traffic in CF logs if needed.

## Test plan
- [ ] After merge, manually trigger uptime-monitor — should now show `homepage: OK` / `manifest: OK`.
- [ ] The bogus site-down issue (#53) auto-closes on the next scheduled tick (~5 min after merge).
