### PR TITLE
fix(uptime-monitor): probe via Node fetch (curl TLS gets 403)

### DIFF
--- a/.github/workflows/uptime-monitor.yml
+++ b/.github/workflows/uptime-monitor.yml
@@ -68,128 +68,25 @@ jobs:
       failed: ${{ steps.check.outputs.failed }}
       details: ${{ steps.check.outputs.details }}
     steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
       - name: Probe homepage + manifest
         id: check
-        # set +e: don't abort the step on a non-zero curl — we want
-        # to handle the result structurally and emit it as the
-        # `failed` output for the downstream issue-management jobs.
+        # The probe uses Node's built-in fetch (undici), not curl.
+        # Cloudflare fingerprints curl's TLS handshake separately from
+        # its UA, so even with a Chrome UA, curl-from-GHA gets 403'd.
+        # Node fetch passes through CF reliably (verified by the
+        # long-running live-cp-manifest probe that uses the same stack).
         #
-        # Probe output goes to STDOUT (not a captured variable) so the
-        # GH Actions run log shows exactly what happened. The DETAILS
-        # output is also written, but only for templating the issue
-        # body — stdout is the authoritative debug surface.
-        #
-        # We ALWAYS exit 0 from this step. Status of the probe is
-        # carried by the `failed` output. The downstream jobs use
-        # `if: always() && needs.probe.outputs.failed != '0'` (or
-        # `== '0'`) to decide whether to open / close the issue.
-        # Why not exit 1 on failure: a failed step causes
-        # `needs:`-dependent jobs to be SKIPPED by default, which
-        # would mean the alert never fires.
-        shell: bash
-        run: |
-          set +e
-          set -o pipefail
-
-          probe() {
-            # $1 = name, $2 = url, $3 = optional content predicate
-            local name="$1" url="$2" predicate="${3:-}"
-            local code
-            # Use a real-Chrome UA — Cloudflare's bot detection on
-            # GHA runner IPs returns 403 to obviously-bot user agents
-            # (see PR #48 for the same fix applied to live-runtime).
-            # The custom X-Source header preserves our ability to
-            # identify uptime-monitor traffic in CF logs / our own
-            # analytics endpoint if/when we want to.
-            code=$(curl -sS -L \
-              -A 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36' \
-              -H 'X-Source: shouldidive-uptime-monitor/1.0' \
-              -o /tmp/probe_body \
-              -w '%{http_code}' \
-              --max-time 30 \
-              "$url")
-            local curl_rc=$?
-            if [ "$curl_rc" != "0" ]; then
-              echo "::warning::$name FAIL: curl exit $curl_rc (network / TLS / timeout)"
-              return 1
-            fi
-            if [ "$code" != "200" ]; then
-              echo "::warning::$name FAIL: HTTP $code"
-              return 1
-            fi
-            if [ -n "$predicate" ]; then
-              if ! eval "$predicate" </tmp/probe_body >/dev/null 2>&1; then
-                echo "::warning::$name FAIL: HTTP 200 but content predicate failed"
-                return 1
-              fi
-            fi
-            echo "$name OK: HTTP 200"
-            return 0
-          }
-
-          probe_with_retry() {
-            local name="$1" url="$2" predicate="${3:-}"
-            if probe "$name" "$url" "$predicate"; then
-              return 0
-            fi
-            echo "$name first attempt failed; sleeping 30 s before retry..."
-            sleep 30
-            probe "$name" "$url" "$predicate"
-          }
-
-          failed=0
-          details_lines=()
-
-          # ---- Homepage probe ------------------------------------------
-          echo "::group::homepage"
-          if probe_with_retry homepage "https://shouldidive.com/" ""; then
-            details_lines+=("homepage: OK")
-          else
-            failed=$((failed + 1))
-            details_lines+=("homepage: FAIL (see ::warning:: above)")
-          fi
-          echo "::endgroup::"
-
-          # ---- Manifest probe ------------------------------------------
-          # 200 OK with a valid JSON body and a 4-element bbox. Catches
-          # the "CDN returned an HTML error page with status 200" case.
-          echo "::group::manifest"
-          if probe_with_retry manifest \
-            "https://shouldidive.com/data/manifest.json" \
-            "jq -e '.bbox | length == 4'"; then
-            details_lines+=("manifest: OK")
-          else
-            failed=$((failed + 1))
-            details_lines+=("manifest: FAIL (see ::warning:: above)")
-          fi
-          echo "::endgroup::"
-
-          # ---- Emit outputs --------------------------------------------
-          details=$(printf '%s\n' "${details_lines[@]}")
-
-          {
-            echo "failed=$failed"
-            echo "details<<EOF"
-            echo "$details"
-            echo "EOF"
-          } >>"$GITHUB_OUTPUT"
-
-          {
-            echo "## Uptime probe"
-            echo
-            echo "Failures this tick: $failed"
-            echo
-            echo '```'
-            echo "$details"
-            echo '```'
-          } >>"$GITHUB_STEP_SUMMARY"
-
-          if [ "$failed" -gt 0 ]; then
-            echo "::error::$failed probe(s) failed. See warnings above. The alerting job will open / update the rolling site-down issue."
-          fi
-
-          # Always exit 0 — see header comment.
-          exit 0
+        # The script writes outputs to $GITHUB_OUTPUT and ALWAYS exits 0.
+        # Status flows through the `failed` output, not the exit code,
+        # so the downstream issue-management jobs aren't skipped on
+        # probe failure (see workflow header for full rationale).
+        run: node tests/uptime-monitor.mjs
 
   open-or-update-issue:
     needs: probe

--- a/tests/uptime-monitor.mjs
+++ b/tests/uptime-monitor.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * Standalone Node uptime probe — invoked by .github/workflows/uptime-monitor.yml
+ *
+ * Why a Node script (and not curl in YAML):
+ *   Cloudflare's bot detection on GHA runner IPs returns HTTP 403 to
+ *   plain curl regardless of User-Agent — it fingerprints the TLS
+ *   handshake (curl's JA3 differs sharply from real browser stacks).
+ *   Node's built-in `fetch` uses undici, whose TLS fingerprint isn't
+ *   on CF's blocklist for our zone (verified via live-cp-manifest
+ *   which has been hitting the same site reliably for weeks).
+ *
+ * Behavior:
+ *   * Each URL is probed once. On non-OK, sleeps 30 s and probes again.
+ *     Only PAIRED failure escalates — defends against transient CF
+ *     edge flutters.
+ *   * Per-URL outcome printed to stdout with GH log annotation syntax
+ *     (::group::, ::warning::, ::error::) so the run page is the
+ *     authoritative debug surface.
+ *   * Failure count written to $GITHUB_OUTPUT under key `failed`.
+ *     A details summary is also written under key `details` for use
+ *     in the issue body the downstream job composes.
+ *   * Always exits 0 — the workflow uses the `failed` output (not the
+ *     exit code) to decide whether to fire the alert.
+ */
+import { appendFileSync } from "node:fs";
+import { setTimeout as sleep } from "node:timers/promises";
+
+
+const PROBES = [
+  {
+    name: "homepage",
+    url: "https://shouldidive.com/",
+    // No content predicate — anything 200 is fine for the front door.
+  },
+  {
+    name: "manifest",
+    url: "https://shouldidive.com/data/manifest.json",
+    // Catch the "200 OK but body is an HTML error page" case.
+    contentPredicate: (body) => {
+      try {
+        const j = JSON.parse(body);
+        return Array.isArray(j.bbox) && j.bbox.length === 4;
+      } catch {
+        return false;
+      }
+    },
+  },
+];
+
+const FETCH_TIMEOUT_MS = 30_000;
+const RETRY_WAIT_MS = 30_000;
+
+/**
+ * Single probe attempt. Returns { ok, msg } — msg is a one-line
+ * human-readable status.
+ */
+async function probeOnce({ name, url, contentPredicate }) {
+  const controller = new AbortController();
+  const timer = globalThis.setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const resp = await fetch(url, {
+      headers: {
+        // Real-Chrome UA + X-Source for our own audit logs.
+        "User-Agent":
+          "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 " +
+          "(KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36",
+        "X-Source": "shouldidive-uptime-monitor/1.0",
+        // Disable HTTP caching at the edge for this probe.
+        "Cache-Control": "no-cache",
+      },
+      signal: controller.signal,
+      redirect: "follow",
+    });
+    if (resp.status !== 200) {
+      return { ok: false, msg: `${name} FAIL: HTTP ${resp.status}` };
+    }
+    if (contentPredicate) {
+      const body = await resp.text();
+      if (!contentPredicate(body)) {
+        return { ok: false, msg: `${name} FAIL: HTTP 200 but content predicate failed` };
+      }
+    }
+    return { ok: true, msg: `${name} OK: HTTP 200` };
+  } catch (err) {
+    return { ok: false, msg: `${name} FAIL: ${err.name}: ${err.message}` };
+  } finally {
+    globalThis.clearTimeout(timer);
+  }
+}
+
+async function probeWithRetry(spec) {
+  const first = await probeOnce(spec);
+  if (first.ok) return first;
+  console.log(`::warning::${first.msg}`);
+  console.log(`${spec.name} first attempt failed; sleeping ${RETRY_WAIT_MS / 1000} s before retry...`);
+  await sleep(RETRY_WAIT_MS);
+  const second = await probeOnce(spec);
+  return second;
+}
+
+async function main() {
+  let failed = 0;
+  const lines = [];
+
+  for (const spec of PROBES) {
+    console.log(`::group::${spec.name}`);
+    const result = await probeWithRetry(spec);
+    if (result.ok) {
+      console.log(result.msg);
+      lines.push(`${spec.name}: OK`);
+    } else {
+      console.log(`::warning::${result.msg}`);
+      lines.push(`${spec.name}: ${result.msg}`);
+      failed += 1;
+    }
+    console.log("::endgroup::");
+  }
+
+  const details = lines.join("\n");
+
+  // Emit GITHUB_OUTPUT for the downstream issue-management jobs.
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `failed=${failed}\n`);
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `details<<EOF\n${details}\nEOF\n`,
+    );
+  }
+
+  // Emit a step summary for easy debugging from the UI.
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(
+      process.env.GITHUB_STEP_SUMMARY,
+      `## Uptime probe\n\nFailures this tick: ${failed}\n\n\`\`\`\n${details}\n\`\`\`\n`,
+    );
+  }
+
+  if (failed > 0) {
+    console.log(
+      `::error::${failed} probe(s) failed. ` +
+        `Downstream job will open / update the site-down issue.`,
+    );
+  } else {
+    console.log("All probes OK.");
+  }
+
+  // ALWAYS exit 0 — see workflow comment for rationale.
+  process.exit(0);
+}
+
+await main();


### PR DESCRIPTION
Previous fix (Chrome UA via curl) didn't clear the 403 — CF fingerprints curl's TLS handshake separately from the UA header. Even with the right UA string, curl-from-GHA gets blocked.

Node's built-in fetch (undici) uses a different TLS stack that passes CF's filter reliably (verified by live-cp-manifest, which has been hitting the same site for weeks without issue).

Lifted the probe into `tests/uptime-monitor.mjs` so the same script can be reused from other harnesses later if needed.

## Test plan
- [ ] After merge, manually trigger uptime-monitor — should show `homepage: OK` / `manifest: OK`.
- [ ] The bogus site-down issue (#53) auto-closes on the next scheduled tick.
