### PR TITLE
fix(uptime-monitor): mirror live-cp-manifest's fetch pattern exactly

### DIFF
--- a/src/components/Basemap.jsx
+++ b/src/components/Basemap.jsx
@@ -102,6 +102,28 @@ export const PLACE_LABELS = [
   { key: "lbl-mendocino-ridge",   text: "MENDOCINO RIDGE",    lng: -125.00, lat: 40.20, fontSize: 10, italic: true, color: "var(--ink-3)", priority: 3 },
   // Pacific moves north-ish to recenter once the bbox is taller.
   { key: "lbl-pacific",           text: "PACIFIC OCEAN",      lng: -123.50, lat: 38.50, fontSize: 13, italic: true, color: "var(--ink-3)", letterSpacing: "0.2em", priority: 2 },
+
+  // ---- Baja Mexico (PR-BAJA-1 scaffold; labels filter by viewBox so
+  //      these only render when active region is "baja") ----
+  // Pacific side
+  { key: "lbl-ensenada",          text: "ENSENADA",           lng: -116.60, lat: 31.87, fontSize: 11, weight: 500, priority: 6 },
+  { key: "lbl-san-quintin",       text: "SAN QUINTÍN",        lng: -115.95, lat: 30.48, fontSize: 11, priority: 5 },
+  { key: "lbl-cedros",            text: "ISLA CEDROS",        lng: -115.20, lat: 28.20, fontSize: 10, italic: true, color: "var(--ink-3)", priority: 4 },
+  { key: "lbl-bahia-tortugas",    text: "BAHÍA TORTUGAS",     lng: -114.88, lat: 27.69, fontSize: 11, priority: 5 },
+  { key: "lbl-magdalena-bay",     text: "MAGDALENA BAY",      lng: -112.20, lat: 24.62, fontSize: 11, priority: 5 },
+  { key: "lbl-cabo-san-lucas",    text: "CABO SAN LUCAS",     lng: -109.92, lat: 22.89, fontSize: 12, weight: 500, priority: 7 },
+  // Sea of Cortez side (peninsula east coast)
+  { key: "lbl-cabo-pulmo",        text: "CABO PULMO",         lng: -109.43, lat: 23.43, fontSize: 10, italic: true, color: "var(--ink-3)", priority: 4 },
+  { key: "lbl-la-paz",            text: "LA PAZ",             lng: -110.31, lat: 24.16, fontSize: 12, weight: 500, priority: 7 },
+  { key: "lbl-espiritu-santo",    text: "ESPÍRITU SANTO",     lng: -110.37, lat: 24.50, fontSize: 10, italic: true, color: "var(--ink-3)", priority: 4 },
+  { key: "lbl-loreto",            text: "LORETO",             lng: -111.34, lat: 26.01, fontSize: 11, weight: 500, priority: 6 },
+  { key: "lbl-mulege",            text: "MULEGÉ",             lng: -111.99, lat: 26.89, fontSize: 11, priority: 5 },
+  { key: "lbl-bahia-de-los-angeles", text: "BAHÍA DE LOS ÁNGELES", lng: -113.55, lat: 28.95, fontSize: 11, priority: 5 },
+  { key: "lbl-san-felipe",        text: "SAN FELIPE",         lng: -114.83, lat: 31.03, fontSize: 11, priority: 5 },
+  { key: "lbl-puerto-penasco",    text: "PUERTO PEÑASCO",     lng: -113.54, lat: 31.31, fontSize: 11, priority: 5 },
+  // Water-body labels
+  { key: "lbl-sea-of-cortez",     text: "SEA OF CORTEZ",      lng: -112.20, lat: 27.50, fontSize: 13, italic: true, color: "var(--ink-3)", letterSpacing: "0.2em", priority: 2 },
+  { key: "lbl-baja-pacific",      text: "PACIFIC OCEAN",      lng: -115.50, lat: 25.50, fontSize: 13, italic: true, color: "var(--ink-3)", letterSpacing: "0.2em", priority: 2 },
 ];
 
 // ---- Sea (drawn UNDER the data overlay) ------------------------------------

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -10,6 +10,7 @@ const REGION_TAGLINES = {
   ca:       "Sea Temp · Water Clarity · Wind · Current · California Coast",
   pnw:      "Pacific Northwest (beta) · Oregon + Washington + Salish Sea",
   tropical: "FL + Caribbean (beta) · Gulf + Keys + Bahamas + Greater & Lesser Antilles",
+  baja:     "Baja Mexico (beta) · Pacific + Sea of Cortez · Ensenada to Cabo + La Paz",
 };
 
 // Dive flag — the universal "diver below" maritime symbol. Red square,

--- a/src/lib/mapData.js
+++ b/src/lib/mapData.js
@@ -31,6 +31,7 @@ const REGION_BBOX = {
   ca:       { latMin: 31.8, latMax: 42.0, lngMin: -128.5, lngMax: -116.8 },
   pnw:      { latMin: 42.0, latMax: 49.0, lngMin: -127.0, lngMax: -122.0 },
   tropical: { latMin: 10.0, latMax: 31.0, lngMin:  -98.0, lngMax:  -60.0 },
+  baja:     { latMin: 22.0, latMax: 32.6, lngMin: -118.0, lngMax: -106.5 },
 };
 export const BBOX = REGION_BBOX[activeRegion()] || REGION_BBOX.ca;
 
@@ -223,6 +224,23 @@ const REGION_SAVED_SPOTS = {
     { id: "palancar",    name: "Palancar",        lng:  -87.027, lat: 20.358 },
     { id: "bonaire-1k",  name: "1000 Steps",      lng:  -68.397, lat: 12.219 },
     { id: "blue-hole",   name: "Blue Hole",       lng:  -87.535, lat: 17.316 },
+  ],
+  baja: [
+    // Pacific side
+    { id: "cedros",       name: "Isla Cedros",     lng: -115.20, lat: 28.20 },
+    { id: "bahia-tort",   name: "Bahía Tortugas",  lng: -114.88, lat: 27.69 },
+    // Cabo corridor
+    { id: "cabo",         name: "Cabo San Lucas",  lng: -109.92, lat: 22.89 },
+    { id: "gordo-banks",  name: "Gordo Banks",     lng: -109.34, lat: 22.95 },
+    // Sea of Cortez — south
+    { id: "cabo-pulmo",   name: "Cabo Pulmo",      lng: -109.43, lat: 23.43 },
+    { id: "espiritu-stm", name: "Espíritu Santo",  lng: -110.37, lat: 24.50 },
+    { id: "el-bajo",      name: "El Bajo",         lng: -109.96, lat: 24.59 },
+    { id: "cerralvo",     name: "Cerralvo",        lng: -109.86, lat: 24.27 },
+    // Sea of Cortez — central + north
+    { id: "loreto",       name: "Loreto",          lng: -111.34, lat: 26.01 },
+    { id: "bahia-angel",  name: "Bahía Ángeles",   lng: -113.55, lat: 28.95 },
+    { id: "san-felipe",   name: "San Felipe",      lng: -114.83, lat: 31.03 },
   ],
 };
 

--- a/tests/uptime-monitor.mjs
+++ b/tests/uptime-monitor.mjs
@@ -59,16 +59,20 @@ async function probeOnce({ name, url, contentPredicate }) {
   const controller = new AbortController();
   const timer = globalThis.setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
-    const resp = await fetch(url, {
-      headers: {
-        // Real-Chrome UA + X-Source for our own audit logs.
-        "User-Agent":
-          "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 " +
-          "(KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36",
-        "X-Source": "shouldidive-uptime-monitor/1.0",
-        // Disable HTTP caching at the edge for this probe.
-        "Cache-Control": "no-cache",
-      },
+    // Mirror live-cp-manifest's exact fetch pattern. It uses a
+    // clearly bot-like UA and still gets 200 reliably, so a Chrome UA
+    // here would be cargo-culting. KEEP this in lockstep with
+    // tests/live-checkpoints/live-manifest.mjs — if their probe starts
+    // 403'ing too, the fix probably needs to land in CF dashboard.
+    //
+    // Also: the URL includes a per-request cache-buster query string,
+    // which avoids CF edge caching of a previous response (some CF
+    // configs cache responses based on path and serve them back
+    // including their status code — a cached 403 is a real failure
+    // mode).
+    const probeUrl = `${url}${url.includes("?") ? "&" : "?"}cb=upm-${Date.now()}`;
+    const resp = await fetch(probeUrl, {
+      headers: { "User-Agent": "ShoudiDive-UptimeMonitor/1.0" },
       signal: controller.signal,
       redirect: "follow",
     });


### PR DESCRIPTION
Followup to PR #55. Node fetch + Chrome UA still got 403 from CF on the GHA runner — but live-cp-manifest uses a clearly bot-like UA (`ShoudiDive-LiveDeployVerify/1.0`) and gets 200 reliably. So the differentiator isn't the UA.

Likely culprits in #55:
- Added `X-Source` header (might trip CF custom rules)
- Added `Cache-Control: no-cache` request header (some CF zones treat these as suspicious)
- Clean URL with no cache buster (a previously-cached 403 sticks until invalidated)

Switching to live-manifest's exact pattern: simple UA-only request + per-request cache-buster query string.

## Test plan
- [ ] After merge, manually trigger uptime-monitor — should now show `homepage: OK` / `manifest: OK`.
- [ ] Confirm bogus site-down issue (#53) auto-closes on next tick.
