### PR TITLE
fix(wind): threshold 0.5 was the wrong direction — go 0.7→0.9

### DIFF
--- a/pipeline/fetch_wind.py
+++ b/pipeline/fetch_wind.py
@@ -315,7 +315,7 @@ def regrid_to_bbox(lat2d, lng2d, u, v, source: str):
 # crispness improves once bathy lands.
 
 def load_land_mask(out_dir: Path, grid_w: int, grid_h: int,
-                   land_threshold: float = 0.5) -> np.ndarray | None:
+                   land_threshold: float = 0.9) -> np.ndarray | None:
     """Read bathy.png and downsample to a wind-grid-resolution land mask.
 
     Returns a boolean numpy array where True = land, False = ocean.
@@ -323,16 +323,23 @@ def load_land_mask(out_dir: Path, grid_w: int, grid_h: int,
 
     `land_threshold` controls how aggressively coastal cells get flagged:
       0.3 = a cell is "land" if >30% of its area is land (most aggressive)
-      0.5 = a cell is "land" if more than half its area is land (default)
-      0.7 = a cell is "land" only if >70% of its area is land (most lenient
-            — previous default; produced visible halos near Channel Islands
-            because cells that were ~60% land kept wind data but had
-            particles dying quickly inside them, so the rendering looked
-            patchy. 0.5 is a better balance: still keeps wind data over
-            cells that are majority ocean, which covers the actual
-            nearshore.)
-      0.9 = essentially no mask at the wind-grid level — defers all land
-            handling to the frontend's pixel-resolution geojson mask.
+      0.5 = a cell is "land" if >50% of its area is land
+      0.7 = a cell is "land" only if >70% of its area is land
+      0.9 = a cell is "land" only if >90% of its area is land (default —
+            essentially the pipeline mask only fires for cells fully on
+            land. Coastal cells with ANY meaningful ocean fraction keep
+            wind data. The visible "halo" the user saw at 0.7 was the
+            colorfill going transparent for cells that were ~70%+ land
+            (e.g. tight against a small island). The frontend pixel-
+            resolution geojson mask + the SVG LandBasemap occlude wind
+            over actual land anyway — the pipeline mask only needs to
+            zero out cells that are FULLY on land so the encoded PNG
+            doesn't carry meaningless HRRR-over-Sierra-Nevada values.
+
+    The bathy.png it reads classifies pixels as land (==0) vs ocean
+    (depth 1..255). Box-averaging that boolean over the (src_h/grid_h)
+    × (src_w/grid_w) tile that each wind cell covers gives us the
+    fraction of land per wind cell.
 
     2026-05-14 — first attempt at this used nearest-neighbor sampling
     (a single bathy pixel near each wind cell's center decided land vs

--- a/pipeline/fetch_wind_5day.py
+++ b/pipeline/fetch_wind_5day.py
@@ -256,22 +256,26 @@ def regrid_to_bbox(lat2d, lng2d, u, v, source: str):
 # to u/v before encoding.
 
 def load_land_mask(out_root: Path, grid_w: int, grid_h: int,
-                   land_threshold: float = 0.5) -> np.ndarray | None:
+                   land_threshold: float = 0.9) -> np.ndarray | None:
     """Read bathy.png (region's data dir) and downsample to wind grid.
 
     Returns True=land boolean array, or None if bathy.png isn't there.
-    Uses box-averaged land area fraction with threshold (default 0.5)
-    so coastal cells with majority ocean keep valid wind data. See
-    fetch_wind.py docstring for the long version — same algorithm
-    intentionally duplicated here so each fetcher can run independently
-    without an inter-fetcher import.
+    Uses box-averaged land area fraction with threshold (default 0.9)
+    so the mask only fires on cells fully on land. See fetch_wind.py
+    docstring for the long version — same algorithm intentionally
+    duplicated here so each fetcher can run independently without an
+    inter-fetcher import.
 
-    2026-05-18: threshold tightened 0.7 → 0.5. The previous default
-    left a visible streamline-density halo around Channel Islands +
-    coastline (cells right at the boundary kept wind data but particles
-    died inside them too fast). 0.5 still flags pure-land cells,
-    keeps majority-ocean coastal cells, AND aligns with the frontend
-    pixel-mask boundary so the visible coast is sharper.
+    2026-05-19: threshold loosened 0.7 → 0.9 (was briefly 0.5 in a
+    misdirected attempt). User reported a visible black halo around
+    Channel Islands + coast. Root cause: cells that were ~70%+ land
+    were NaN'd, which made their colorfill transparent and left a
+    visible gap between offshore wind colorfill and the SVG land
+    basemap. The frontend pixel-resolution geojson mask occludes
+    wind streamlines over actual land anyway, so the pipeline mask
+    only needs to zero out cells that are FULLY on land (e.g. a
+    cell over Sierra Nevada — terrain-friction values that don't
+    mean anything for diving conditions).
     """
     region_data_dir = active_region().data_output_dir(out_root)
     bathy_path = region_data_dir / "bathy.png"


### PR DESCRIPTION
PR #60's threshold tightening (0.7 → 0.5) made the visible halo **worse**, not better. Lower threshold flags MORE cells as land, NaN's MORE coastal cells in the encoded PNG, makes the colorfill transparent for a wider band.

Going the other direction: 0.7 → **0.9**. Now the pipeline mask only fires on cells that are ~fully on land. Coastal cells with any meaningful ocean fraction keep their wind data and render the colorfill all the way to the shoreline.

## Why this leniency is safe

The SVG `LandBasemap` renders OVER the colorfill at vector resolution, so a wind cell that contains both ocean and land still gets correctly visually occluded over the land portion. `WindParticles` also already kills streamlines via the frontend geojson mask. The pipeline mask therefore only needs to defend against cells fully on land (e.g. a wind cell over Sierra Nevada), where the HRRR/GFS terrain-friction value isn't meaningful and would propagate a couple kts of "wind" via bilinear smear.

Combined with the spawn-locality bias from PR #60, this should collapse the halo.

## Test plan
- [ ] After merge + next refresh-ca-wind cycle, eyeball the SoCal-bight view. Halo should be gone or down to <1 px wide.
