### PR TITLE
ux(chips): mark Current layer chip as Beta on desktop + mobile

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1377,10 +1377,11 @@ function DesktopView({ layer, setLayer, composite, setComposite, sstMode, setSst
             <button
               className={layer === "current" ? "active" : ""}
               onClick={() => setLayer("current")}
-              title="Surface current speed and direction from HFR observations plus tide/wind inference"
+              title="Surface current speed and direction from HFR observations plus tide/wind inference (BETA — model blends sparse HF-radar coverage with bulk wind/tide inference; verify against local knowledge)."
             >
               <span className="lt-label">Current</span>
               <span className="lt-sub">kt</span>
+              <span className="lt-beta">Beta</span>
             </button>
             <button
               className={layer === "viz" ? "active" : ""}

--- a/src/components/MobileSheet.jsx
+++ b/src/components/MobileSheet.jsx
@@ -46,7 +46,10 @@ const LAYERS = [
   { id: "chl",   label: "Chl",   unit: "mg/m³" },
   { id: "wind",  label: "Wind",  unit: "kt" },
   { id: "swell", label: "Swell", unit: "ft" },
-  { id: "current", label: "Current", unit: "kt" },
+  // current is beta — HFR coverage is sparse on the CA coast and the
+  // inference blend (HFR + tide + wind) underestimates submesoscale
+  // features like upwelling jets. The chip renders a "Beta" pill.
+  { id: "current", label: "Current", unit: "kt", beta: true },
   // viz is marked beta until NorCal ground truth lands — see
   // pipeline/fetch_visibility.py manifest-write block for the rationale.
   // The chip below renders a "Beta" pill on this entry.


### PR DESCRIPTION
User requested. Current layer carries the same caveats Vis does (sparse HFR coverage, inference blend that underestimates submesoscale features like upwelling jets, no NorCal validation), so the chip should signal that with the Beta pill.

Two changes, both alongside how Vis is wired:
- `src/App.jsx` — desktop chip gets `<span className="lt-beta">Beta</span>` + an expanded title attribute explaining the caveat for hover/focus users
- `src/components/MobileSheet.jsx` — LAYERS array entry gets `beta: true`; existing JSX renders `<span className="ms-chip-beta">` for any entry with that flag

## Test plan
- [ ] After merge, confirm desktop + mobile Current chip shows the Beta pill matching Vis's styling.
