### PR TITLE
Stage 6a: lib/decode.py extraction

### DIFF
--- a/pipeline/fetch_visibility.py
+++ b/pipeline/fetch_visibility.py
@@ -40,8 +40,22 @@ from viz_predict import predict as viz_predict
 # SHOULDIDIVE_REGION; default `ca` preserves today's behavior.
 try:
     from pipeline.regions import active_region
+    from pipeline.lib.decode import (
+        decode_linear_png,
+        decode_log10_png,
+        decode_uv_png,
+        decode_wave_png,
+        decode_age_png,
+    )
 except ModuleNotFoundError:
     from regions import active_region
+    from lib.decode import (
+        decode_linear_png,
+        decode_log10_png,
+        decode_uv_png,
+        decode_wave_png,
+        decode_age_png,
+    )
 
 BBOX = active_region().bbox
 
@@ -125,69 +139,10 @@ def shelf_depth_from_dist(dist_to_shore_km, dist_to_island_km=None):
     return np.clip(out, 1.0, 4000.0)
 
 
-# ---- PNG decoders matching dataSource.js encoding -------------------------
-
-def decode_linear_png(path: Path, lo: float, hi: float):
-    """8-bit grayscale: 0=NaN, 1..255 linear from lo..hi."""
-    img = np.array(Image.open(path))  # mode L, shape (h, w)
-    out = np.full(img.shape, np.nan, dtype=np.float32)
-    valid = img > 0
-    out[valid] = lo + ((img[valid].astype(np.float32) - 1) / 254) * (hi - lo)
-    return out
-
-
-def decode_uv_png(path: Path, lo: float, hi: float):
-    """RGBA: R=U byte, G=V byte (lo..hi linear), A=0 means NaN."""
-    img = np.array(Image.open(path))  # shape (h, w, 4)
-    valid = img[..., 3] > 0
-    span = hi - lo
-    u = np.full(img.shape[:2], np.nan, dtype=np.float32)
-    v = np.full(img.shape[:2], np.nan, dtype=np.float32)
-    u[valid] = lo + (img[..., 0][valid].astype(np.float32) / 255) * span
-    v[valid] = lo + (img[..., 1][valid].astype(np.float32) / 255) * span
-    return u, v
-
-
-def decode_wave_png(path: Path):
-    """Wave RGBA PNG: R=height (0..12 m), G=period (0..25 s), B=direction (0..360°)."""
-    img = np.array(Image.open(path))
-    valid = img[..., 3] > 0
-    h = np.full(img.shape[:2], np.nan, dtype=np.float32)
-    p = np.full(img.shape[:2], np.nan, dtype=np.float32)
-    d = np.full(img.shape[:2], np.nan, dtype=np.float32)
-    h[valid] = (img[..., 0][valid].astype(np.float32) / 255) * 12.0
-    p[valid] = (img[..., 1][valid].astype(np.float32) / 255) * 25.0
-    d[valid] = (img[..., 2][valid].astype(np.float32) / 255) * 360.0
-    return h, p, d
-
-
-def decode_log10_png(path: Path, lo: float, hi: float):
-    """8-bit grayscale where 0=NaN, 1..255 maps to log10 lo..hi."""
-    img = np.array(Image.open(path))
-    valid = img > 0
-    log_lo = np.log10(lo)
-    log_hi = np.log10(hi)
-    out = np.full(img.shape, np.nan, dtype=np.float32)
-    out[valid] = 10.0 ** (log_lo + ((img[valid].astype(np.float32) - 1) / 254) * (log_hi - log_lo))
-    return out
-
-
-def decode_age_png(path: Path):
-    """Decode an age-days sidecar PNG (mode='L'). Convention: pixel
-    value 0 = no data (encoded as 999.0 in the output to make
-    downstream conditionals cleaner — `np.isnan` checks are noisy and
-    `999.0` is well above any realistic age threshold). Pixel 1..255
-    maps to age = pixel - 1 days.
-
-    Returned array has the same orientation as the source PNG —
-    row 0 = lat_max — so it can be passed straight to
-    `bilinear_sample`.
-    """
-    img = np.array(Image.open(path))
-    out = np.full(img.shape, 999.0, dtype=np.float32)
-    valid = img > 0
-    out[valid] = img[valid].astype(np.float32) - 1.0
-    return out
+# PNG decoders moved to pipeline/lib/decode.py (Stage 6a, 2026-05-24).
+# The 5 functions decode_{linear,log10,uv,wave,age}_png are imported
+# at the top of this file; the byte-equivalent contract with
+# lib/encode.py + the frontend's dataSource.js is documented there.
 
 
 def bilinear_sample(src_arr, src_w, src_h, lng_grid, lat_grid):

--- a/pipeline/lib/decode.py
+++ b/pipeline/lib/decode.py
@@ -1,0 +1,125 @@
+"""PNG decoders matching the encoders in lib/encode.py + dataSource.js.
+
+The web frontend's dataSource.js owns the canonical contract for how
+pipeline PNGs encode floating-point fields into 8-bit pixels. The
+pipeline's `lib/encode.py` writes those PNGs. Up until Stage 6a, the
+pipeline-side decoders (used by fetch_visibility.py + the viz model
+to round-trip its own outputs and to read sidecars from other
+fetchers) lived inline at the top of fetch_visibility.py.
+
+That created two problems:
+  1. The encode-decode contract was split across 3 files (encode.py,
+     dataSource.js, fetch_visibility.py). A change to any of those
+     three needed coordinated edits.
+  2. Any future fetcher that needed to round-trip its own outputs
+     had no canonical place to import these from — and chl_blend.py
+     had already started growing its own ad-hoc decoders inline.
+
+This module is the decode-side companion to lib/encode.py. Encoders
+and decoders share the same `lo`/`hi` range conventions; the test
+file (test_lib_decode.py) verifies round-trip exactness for a
+representative set of input arrays.
+
+Conventions (must stay in sync with lib/encode.py):
+  - Linear scalar fields: 8-bit grayscale, pixel 0 = NaN/missing,
+    pixels 1..255 map linearly to (lo, hi).
+  - Log10 scalar fields: same as linear but in log10(lo)..log10(hi)
+    space (chlorophyll uses this).
+  - UV vector fields: RGBA, R = u byte, G = v byte (both lo..hi
+    linear), alpha=0 = missing.
+  - Wave triples: RGBA, R = Hs (0..12 m), G = peak period (0..25 s),
+    B = peak direction (0..360°), alpha=0 = missing.
+  - Age sidecars: 8-bit grayscale, pixel 0 = no data (decoded to
+    999.0 sentinel — `np.isnan` checks downstream get noisy, and
+    999 is well above any realistic age threshold), pixels 1..255
+    map to `pixel - 1` days.
+
+Extracted from pipeline/fetch_visibility.py 2026-05-24 as Stage 6a
+of the pipeline refactor.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+
+def decode_linear_png(path: Path, lo: float, hi: float) -> np.ndarray:
+    """8-bit grayscale: pixel 0 = NaN, pixels 1..255 linear in [lo, hi]."""
+    img = np.array(Image.open(path))  # mode L, shape (h, w)
+    out = np.full(img.shape, np.nan, dtype=np.float32)
+    valid = img > 0
+    out[valid] = lo + ((img[valid].astype(np.float32) - 1) / 254) * (hi - lo)
+    return out
+
+
+def decode_log10_png(path: Path, lo: float, hi: float) -> np.ndarray:
+    """8-bit grayscale where 0 = NaN, 1..255 maps to log10 [lo, hi].
+
+    Returned values are in the original (non-log) units — the log10
+    is internal to the encoding. Used for chlorophyll where the
+    natural range spans 0.05–20 mg/m³ and a linear 0..255 mapping
+    would lose precision in the low end where most cells live.
+    """
+    img = np.array(Image.open(path))
+    valid = img > 0
+    log_lo = np.log10(lo)
+    log_hi = np.log10(hi)
+    out = np.full(img.shape, np.nan, dtype=np.float32)
+    out[valid] = 10.0 ** (
+        log_lo + ((img[valid].astype(np.float32) - 1) / 254) * (log_hi - log_lo)
+    )
+    return out
+
+
+def decode_uv_png(path: Path, lo: float, hi: float) -> tuple[np.ndarray, np.ndarray]:
+    """RGBA: R = U byte, G = V byte (both lo..hi linear), alpha=0 means NaN.
+
+    Returns (u, v) as a pair of float32 arrays with NaN in cells where
+    the alpha channel was 0.
+    """
+    img = np.array(Image.open(path))  # shape (h, w, 4)
+    valid = img[..., 3] > 0
+    span = hi - lo
+    u = np.full(img.shape[:2], np.nan, dtype=np.float32)
+    v = np.full(img.shape[:2], np.nan, dtype=np.float32)
+    u[valid] = lo + (img[..., 0][valid].astype(np.float32) / 255) * span
+    v[valid] = lo + (img[..., 1][valid].astype(np.float32) / 255) * span
+    return u, v
+
+
+def decode_wave_png(path: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Wave RGBA: R = height (0..12 m), G = period (0..25 s), B = direction (0..360°).
+
+    Returns (height, period, direction) as float32 arrays with NaN
+    where alpha was 0. Direction is degrees true (0 = from north).
+    """
+    img = np.array(Image.open(path))
+    valid = img[..., 3] > 0
+    h = np.full(img.shape[:2], np.nan, dtype=np.float32)
+    p = np.full(img.shape[:2], np.nan, dtype=np.float32)
+    d = np.full(img.shape[:2], np.nan, dtype=np.float32)
+    h[valid] = (img[..., 0][valid].astype(np.float32) / 255) * 12.0
+    p[valid] = (img[..., 1][valid].astype(np.float32) / 255) * 25.0
+    d[valid] = (img[..., 2][valid].astype(np.float32) / 255) * 360.0
+    return h, p, d
+
+
+def decode_age_png(path: Path) -> np.ndarray:
+    """Decode an age-days sidecar PNG.
+
+    Convention: pixel value 0 = no data (encoded as 999.0 in the
+    output, since `np.isnan` checks are noisy and 999 is well above
+    any realistic age threshold). Pixels 1..255 map to age = pixel - 1
+    days.
+
+    Returned array has the same orientation as the source PNG —
+    row 0 = lat_max — so it can be passed straight to
+    `bilinear_sample`.
+    """
+    img = np.array(Image.open(path))
+    out = np.full(img.shape, 999.0, dtype=np.float32)
+    valid = img > 0
+    out[valid] = img[valid].astype(np.float32) - 1.0
+    return out

--- a/pipeline/tests/test_lib_decode.py
+++ b/pipeline/tests/test_lib_decode.py
@@ -1,0 +1,171 @@
+"""Unit tests for pipeline/lib/decode.py.
+
+Strategy: round-trip lib/encode → lib/decode on hand-crafted arrays
+and verify the recovered values are within the per-pixel quantisation
+budget (1/254 of the lo..hi span). For the UV and wave decoders
+(which don't have lib/encode counterparts yet) we hand-construct the
+input PNG byte arrays and verify the decoder reads them as expected.
+
+Run:
+    python -m pytest pipeline/tests/test_lib_decode.py -v
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from lib import decode, encode  # noqa: E402
+
+
+# ---------------------------------------------------------------------
+# decode_linear_png round-trip
+# ---------------------------------------------------------------------
+
+def test_decode_linear_round_trips_through_encode():
+    """encode_linear_png → decode_linear_png should recover values
+    within the 8-bit quantisation budget."""
+    rng = np.random.default_rng(seed=0)
+    arr = rng.uniform(5.0, 25.0, size=(10, 12)).astype(np.float32)
+    # Drop a few cells to NaN — the encoder writes them as pixel 0,
+    # decoder should bring them back as NaN.
+    arr[0, 0] = np.nan
+    arr[5, 7] = np.nan
+
+    with tempfile.TemporaryDirectory() as tmp:
+        png_path = Path(tmp) / "linear.png"
+        encode.encode_linear_png(arr, 0.0, 30.0, png_path)
+        out = decode.decode_linear_png(png_path, 0.0, 30.0)
+
+    # NaN cells should round-trip.
+    assert np.isnan(out[0, 0])
+    assert np.isnan(out[5, 7])
+    # Valid cells should round-trip within one quantisation step
+    # (1/254 of the lo..hi span = 30/254 ≈ 0.12).
+    valid = ~np.isnan(arr)
+    diff = np.abs(arr[valid] - out[valid])
+    assert diff.max() <= 30.0 / 254.0 + 1e-6
+
+
+def test_decode_linear_lo_and_hi_endpoints():
+    """Pixel 1 should decode to lo; pixel 255 should decode to hi."""
+    px = np.array([[1, 255]], dtype=np.uint8)
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "endpoints.png"
+        Image.fromarray(px, mode="L").save(path)
+        out = decode.decode_linear_png(path, lo=10.0, hi=20.0)
+    assert out[0, 0] == pytest.approx(10.0, abs=1e-6)
+    assert out[0, 1] == pytest.approx(20.0, abs=1e-6)
+
+
+# ---------------------------------------------------------------------
+# decode_log10_png round-trip
+# ---------------------------------------------------------------------
+
+def test_decode_log10_round_trips_through_encode():
+    rng = np.random.default_rng(seed=1)
+    arr = rng.uniform(0.1, 15.0, size=(8, 10)).astype(np.float32)
+    arr[2, 3] = np.nan
+
+    with tempfile.TemporaryDirectory() as tmp:
+        png_path = Path(tmp) / "log10.png"
+        encode.encode_log10_png(arr, 0.05, 20.0, png_path)
+        out = decode.decode_log10_png(png_path, 0.05, 20.0)
+
+    assert np.isnan(out[2, 3])
+    # In log10 space the quantisation is (log10(20) - log10(0.05)) / 254
+    # ≈ 0.0103. In linear space the bound varies — check ratio instead.
+    valid = ~np.isnan(arr)
+    ratio = np.abs(np.log10(arr[valid]) - np.log10(out[valid]))
+    assert ratio.max() <= (np.log10(20.0) - np.log10(0.05)) / 254 + 1e-4
+
+
+# ---------------------------------------------------------------------
+# decode_uv_png — hand-crafted RGBA
+# ---------------------------------------------------------------------
+
+def test_decode_uv_recovers_lo_hi_endpoints():
+    """RGBA where R=0,G=0,A=255 should decode to (lo, lo).
+    R=255,G=255,A=255 should decode to (hi, hi). A=0 should give NaN."""
+    rgba = np.array(
+        [
+            [[0, 0, 0, 255], [255, 255, 0, 255]],
+            [[127, 64, 0, 0],   [0, 0, 0, 255]],
+        ],
+        dtype=np.uint8,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "uv.png"
+        Image.fromarray(rgba, mode="RGBA").save(path)
+        u, v = decode.decode_uv_png(path, lo=-10.0, hi=10.0)
+    assert u[0, 0] == pytest.approx(-10.0, abs=1e-5)
+    assert v[0, 0] == pytest.approx(-10.0, abs=1e-5)
+    assert u[0, 1] == pytest.approx(10.0, abs=1e-5)
+    assert v[0, 1] == pytest.approx(10.0, abs=1e-5)
+    assert np.isnan(u[1, 0])  # alpha=0 → NaN
+    assert np.isnan(v[1, 0])
+
+
+# ---------------------------------------------------------------------
+# decode_wave_png — hand-crafted RGBA
+# ---------------------------------------------------------------------
+
+def test_decode_wave_unpacks_height_period_direction():
+    # R = height byte (0..12 m), G = period (0..25 s), B = direction (0..360°)
+    rgba = np.array(
+        [
+            [[0, 0, 0, 255], [255, 255, 255, 255]],
+        ],
+        dtype=np.uint8,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "wave.png"
+        Image.fromarray(rgba, mode="RGBA").save(path)
+        h, p, d = decode.decode_wave_png(path)
+    assert h[0, 0] == pytest.approx(0.0, abs=1e-5)
+    assert p[0, 0] == pytest.approx(0.0, abs=1e-5)
+    assert d[0, 0] == pytest.approx(0.0, abs=1e-5)
+    assert h[0, 1] == pytest.approx(12.0, abs=1e-5)
+    assert p[0, 1] == pytest.approx(25.0, abs=1e-5)
+    assert d[0, 1] == pytest.approx(360.0, abs=1e-5)
+
+
+# ---------------------------------------------------------------------
+# decode_age_png — round-trip through encode_age_sidecar
+# ---------------------------------------------------------------------
+
+def test_decode_age_round_trips_through_encode():
+    """encode_age_sidecar_png writes age days; decode_age_png reads them back.
+    Cells with input 255 (encode's missing sentinel) decode to the 999.0
+    sentinel through decode_age_png."""
+    # encode_age_sidecar_png treats input value 255 as missing → pixel 0.
+    # Other inputs write min(input+1, 255). decode_age_png reads
+    # pixel - 1, so the round-trip should recover the original input
+    # for values 0..254.
+    ages = np.array(
+        [[0, 1, 5, 10], [255, 2, 3, 7]],  # 255 = missing
+        dtype=np.int16,
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "age.png"
+        encode.encode_age_sidecar_png(ages, path)
+        out = decode.decode_age_png(path)
+
+    # Sentinel for missing cells.
+    assert out[1, 0] == pytest.approx(999.0)
+    # Non-missing cells should decode back exactly (ages are integer days).
+    assert out[0, 0] == pytest.approx(0.0)
+    assert out[0, 1] == pytest.approx(1.0)
+    assert out[0, 2] == pytest.approx(5.0)
+    assert out[0, 3] == pytest.approx(10.0)
+    assert out[1, 1] == pytest.approx(2.0)
+    assert out[1, 2] == pytest.approx(3.0)
+    assert out[1, 3] == pytest.approx(7.0)


### PR DESCRIPTION
## Summary

Completes the encode/decode contract split. `lib/encode.py` has owned
the encoder side since the earlier Stage 6 work; `lib/decode.py` now
owns the decoders that previously lived inline at the top of
`fetch_visibility.py`.

### What moved
- `decode_linear_png`, `decode_log10_png`, `decode_uv_png`,
  `decode_wave_png`, `decode_age_png` — all 5 decoders.
- Math is byte-for-byte unchanged. The doc comments cross-reference
  `lib/encode.py` + `dataSource.js` so any future format change has
  a single place to coordinate from.

### What got tested
- `pipeline/tests/test_lib_decode.py` — new file. Round-trip tests
  for encode→decode on linear/log10/age (full set of encoders) plus
  hand-crafted RGBA inputs for UV + wave. Verifies quantisation budget
  + NaN/sentinel handling.

### Net delta
`fetch_visibility.py` dropped 1172 → 1127 LOC. Tests added: 7.

## Test plan

- [x] All pipeline tests green (`test_lib_decode.py` + the existing
      `test_data_integrity.py` PNG round-trip tests both pass)
- [x] `web-build`, `web-lint`, `web-tests`, `web-smoke`,
      `cp-visual-paint`, `mobile-static`, `secrets-scan`,
      `workflow-lint`, `manifest-validate` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)