### PR TITLE
Stage 6a: complete lib/http migration (rtofs + chl_blend)

### DIFF
--- a/pipeline/chl_blend.py
+++ b/pipeline/chl_blend.py
@@ -57,8 +57,10 @@ from PIL import Image
 # tropical when those regions are wired in PR-X-3.
 try:
     from pipeline.regions import active_region
+    from pipeline.lib.http import http_get
 except ModuleNotFoundError:
     from regions import active_region
+    from lib.http import http_get
 
 BBOX = active_region().bbox
 
@@ -171,10 +173,12 @@ def _nasa_search_files(session: requests.Session, sensor: str, d: date) -> list[
         "edate": d.isoformat(),
         "results_as_file": 1,
     }
-    try:
-        r = session.get(NASA_OBDAAC_FILE_SEARCH, params=params, timeout=HTTP_TIMEOUT)
-    except requests.RequestException as exc:
-        print(f"  nasa-search {sensor} {d}: {exc.__class__.__name__}: {exc}", flush=True)
+    # Stage 6a (2026-05-24): http_get adds retries on the EARTHDATA
+    # session — previously a transient 503 dropped the daily file.
+    r = http_get(NASA_OBDAAC_FILE_SEARCH, params=params,
+                 timeout=HTTP_TIMEOUT, session=session)
+    if r is None:
+        print(f"  nasa-search {sensor} {d}: all retries failed", flush=True)
         return []
     if r.status_code != 200:
         return []
@@ -194,10 +198,9 @@ def _nasa_download(session: requests.Session, filename: str) -> Optional[Path]:
     if cache_path.exists():
         return cache_path
     url = f"{NASA_OBDAAC_GETFILE}/{filename}"
-    try:
-        r = session.get(url, timeout=HTTP_TIMEOUT, allow_redirects=True)
-    except requests.RequestException as exc:
-        print(f"  nasa-dl {filename}: {exc.__class__.__name__}: {exc}", flush=True)
+    r = http_get(url, timeout=HTTP_TIMEOUT, session=session, allow_redirects=True)
+    if r is None:
+        print(f"  nasa-dl {filename}: all retries failed", flush=True)
         return None
     if r.status_code != 200 or len(r.content) < 50_000:
         # < 50 KB is almost certainly the Earthdata HTML login page or a
@@ -309,10 +312,9 @@ def _make_noaa_erddap_fetcher(host: str, dataset: str, has_altitude: bool = True
                 f"[({BBOX['lng_min']}):1:({BBOX['lng_max']})]"
             )
             session = _noaa_session()
-            try:
-                r = session.get(url, timeout=HTTP_TIMEOUT)
-            except requests.RequestException as exc:
-                print(f"  noaa-erddap {dataset} {d}: {exc.__class__.__name__}", flush=True)
+            r = http_get(url, timeout=HTTP_TIMEOUT, session=session)
+            if r is None:
+                print(f"  noaa-erddap {dataset} {d}: all retries failed", flush=True)
                 return None
             if r.status_code != 200:
                 return None

--- a/pipeline/fetch_rtofs.py
+++ b/pipeline/fetch_rtofs.py
@@ -56,14 +56,15 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import numpy as np
-import requests
 import xarray as xr
 from PIL import Image
 
 try:
     from pipeline.regions import active_region
+    from pipeline.lib.http import http_get
 except ModuleNotFoundError:
     from regions import active_region
+    from lib.http import http_get
 
 REGION = active_region()
 BBOX = REGION.bbox
@@ -107,11 +108,11 @@ SST_RANGE = tuple(_overrides.get("sst5d", _overrides.get("sst", (9.0, 25.0))))
 UV_RANGE = (-2.0, 2.0)
 
 
-SESSION = requests.Session()
-SESSION.headers.update({
-    "Accept": "*/*",
-    "User-Agent": "shouldidive/0.1 (rtofs fetcher)",
-})
+# Stage 6a (2026-05-24): per-file Session replaced with the shared
+# lib/http.http_get path. Adds exponential-backoff retries on NOMADS
+# transient 5xx — previously the streaming download silently
+# fell back to "try prior cycle" on any first-attempt failure,
+# costing the freshest RTOFS init cycle.
 
 
 def _candidate_cycles(now: datetime) -> list[tuple[str, str]]:
@@ -151,9 +152,10 @@ def _fetch_lead(yyyymmdd: str, lead_hours: int) -> Path | None:
     url = _file_url(yyyymmdd, lead_hours)
     print(f"  GET {url}", flush=True)
     try:
-        r = SESSION.get(url, timeout=300, stream=True)
-        if r.status_code != 200:
-            print(f"    HTTP {r.status_code} — try prior cycle")
+        r = http_get(url, timeout=300, stream=True)
+        if r is None or r.status_code != 200:
+            code = r.status_code if r is not None else "ERR"
+            print(f"    HTTP {code} — try prior cycle")
             return None
         # Stream to disk to avoid holding the 155 MB blob in memory
         # twice (network buffer + write buffer).


### PR DESCRIPTION
## Summary

Final 2 fetchers brought through the lib/http_get migration. After
this PR, every fetcher in the daily hot path routes through
\`pipeline/lib/http.http_get\` (with retries + shared session) or
\`pipeline/lib/nomads\` (for the NOMADS-specific cycle-discovery dance).

### What's in this PR

- **\`fetch_rtofs.py\`**: 7th fetcher migrated. Previously a single
  transient 503 dropped the freshest RTOFS init cycle entirely.
  Now retries with exponential backoff. stream=True flow unchanged
  (the caller still iterates r.iter_content for the 155MB NetCDF
  download).

- **\`chl_blend.py\`**: 3 inline \`session.get(...)\` call sites routed
  through \`http_get(..., session=session)\`. The two-session pattern
  (_earthdata_session() bearer + _noaa_session()) is preserved — the
  agent-led scope flagged this as the explicit use case for
  http_get's session= kwarg.

### Why this matters

The Stage 6 scope flagged "stale data wins" as a class of bug
affecting viz prediction. The chl_blend retry gap in particular
contributed: a single OB.DAAC 503 would silently drop the day's
chl observation, causing the viz predictor to fall through to
stale chl_2d/3d. With retries, transient upstream failures don't
break the daily snapshot anymore.

### Tally after this PR

| Fetcher | Route | Status |
|---|---|---|
| fetch.py | http_get | ✓ pre-existing |
| fetch_wind.py | http_get | ✓ pre-existing |
| fetch_climatology.py | http_get + cleanup | ✓ this session |
| fetch_waves.py | lib/nomads | ✓ this session |
| fetch_wind_5day.py | lib/nomads | ✓ this session |
| fetch_swell_5day.py | lib/nomads | ✓ this session |
| fetch_tides.py | http_get | ✓ this session |
| fetch_rivers.py | http_get | ✓ this session |
| fetch_rtofs.py | http_get (stream) | ✓ this PR |
| chl_blend.py | http_get(session=) | ✓ this PR |

## Test plan

- [x] All pipeline tests green
- [x] All dev-checks (web-build/lint/tests/smoke/visual-paint/
      mobile-static/secrets-scan/workflow-lint/manifest-validate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)