### PR TITLE
feat(kelp): add CDFW Administrative Kelp Beds overlay (CA-only)

### DIFF
--- a/.github/workflows/refresh-ca-data.yml
+++ b/.github/workflows/refresh-ca-data.yml
@@ -119,6 +119,15 @@ jobs:
         timeout-minutes: 5
         run: python pipeline/fetch_mpa.py
 
+      - name: Fetch CDFW Administrative Kelp Beds
+        # ArcGIS FeatureServer (ds3135). 87 reference polygons; rarely
+        # changes — most days emits byte-identical output. continue-on-
+        # error so a transient ArcGIS 5xx doesn't break the rest of the
+        # daily refresh.
+        continue-on-error: true
+        timeout-minutes: 5
+        run: python pipeline/fetch_kelp.py
+
       - name: Probe all external feeds
         continue-on-error: true
         timeout-minutes: 5

--- a/pipeline/fetch_kelp.py
+++ b/pipeline/fetch_kelp.py
@@ -1,0 +1,229 @@
+"""Fetch CDFW Administrative Kelp Beds (R7, ds3135) for the active region,
+clip to bbox, slim properties, and write to
+public/data/<region>/kelp-beds.geojson (or `public/data/kelp-beds.geojson`
+for CA).
+
+The 87 administrative kelp beds are management/reference boundaries for
+commercial kelp harvest — *not* observed canopy. They rarely change, so
+this fetcher runs in the daily refresh workflow but emits identical output
+most days.
+
+Differences from fetch_mpa.py (worth knowing):
+  * Source endpoint is an ArcGIS FeatureServer query (paginated) rather
+    than a static .geojson download.
+  * Field names aren't fully standardised — we discover them via a
+    fallback chain like fetch_mpa.py does.
+  * Coordinates are rounded to 4 decimals (~11 m) instead of 3, since
+    nearshore edge precision is the whole point of this overlay.
+
+Run on demand or as a daily refresh step:
+  python pipeline/fetch_kelp.py
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import requests
+
+# Bbox via pipeline/regions/ (PR-X-1). CA / PNW / tropical / baja switch
+# on SHOULDIDIVE_REGION; default `ca` preserves today's behavior. CDFW
+# Administrative Kelp Beds is California-only today — for non-CA
+# regions the bbox-clip step will keep 0 features and we write an empty
+# FeatureCollection (KelpLayer.jsx no-ops on missing data).
+try:
+    from pipeline.regions import active_region
+except ModuleNotFoundError:
+    from regions import active_region
+
+BBOX = active_region().bbox
+
+# CDFW ArcGIS FeatureServer — Administrative Kelp Beds (ds3135),
+# layer 0, GeoJSON output in WGS84 (outSR=4326).
+BASE_URL = (
+    "https://services2.arcgis.com/Uq9r85Potqm3MfRV/arcgis/rest/services/"
+    "biosds3135_fpu/FeatureServer/0/query"
+)
+PAGE_SIZE = 1000  # 87 features fit one page, but pagination is defensive.
+
+ROOT = Path(__file__).resolve().parents[1]
+OUT_PATH = active_region().data_output_dir(ROOT) / "kelp-beds.geojson"
+
+
+def slugify(name: str) -> str:
+    s = name.lower()
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    return s.strip("-")
+
+
+def feature_bounds(geom: dict) -> tuple[float, float, float, float]:
+    """Compute (min_lng, min_lat, max_lng, max_lat) for a Polygon/MultiPolygon."""
+    coords = geom["coordinates"]
+    pts: list[tuple[float, float]] = []
+    if geom["type"] == "Polygon":
+        for ring in coords:
+            pts.extend(ring)
+    elif geom["type"] == "MultiPolygon":
+        for poly in coords:
+            for ring in poly:
+                pts.extend(ring)
+    if not pts:
+        return (0, 0, 0, 0)
+    xs = [p[0] for p in pts]
+    ys = [p[1] for p in pts]
+    return (min(xs), min(ys), max(xs), max(ys))
+
+
+def round_coords(geom: dict, decimals: int = 4) -> dict:
+    """Round all coordinates in-place to keep JSON small. 4 decimals ~ 11 m."""
+
+    def r(p):
+        return [round(p[0], decimals), round(p[1], decimals)]
+
+    def round_ring(ring):
+        return [r(p) for p in ring]
+
+    if geom["type"] == "Polygon":
+        geom["coordinates"] = [round_ring(ring) for ring in geom["coordinates"]]
+    elif geom["type"] == "MultiPolygon":
+        geom["coordinates"] = [
+            [round_ring(ring) for ring in poly] for poly in geom["coordinates"]
+        ]
+    return geom
+
+
+def fetch_all_features() -> list[dict]:
+    """Page through the FeatureServer query endpoint until exhausted.
+
+    The CDFW service returns `properties.exceededTransferLimit = true`
+    (or `exceededTransferLimit = true` at the top level on older
+    versions) when more pages remain. We defensively check both.
+    """
+    features: list[dict] = []
+    offset = 0
+    while True:
+        params = {
+            "where": "1=1",
+            "outFields": "*",
+            "outSR": "4326",
+            "f": "geojson",
+            "resultOffset": offset,
+            "resultRecordCount": PAGE_SIZE,
+        }
+        print(f"GET {BASE_URL}?resultOffset={offset}")
+        r = requests.get(BASE_URL, params=params, timeout=120)
+        r.raise_for_status()
+        page = r.json()
+        page_feats = page.get("features", []) or []
+        features.extend(page_feats)
+        # Server can flag continuation at the top level OR inside properties.
+        more = bool(
+            page.get("exceededTransferLimit")
+            or (page.get("properties") or {}).get("exceededTransferLimit")
+        )
+        if not more or not page_feats:
+            break
+        offset += len(page_feats)
+        if offset > 100_000:
+            # Safety fuse — kelp beds are tiny, runaway pagination = bug.
+            print(f"WARN: aborting pagination at offset={offset}")
+            break
+    return features
+
+
+def main() -> None:
+    raw_features = fetch_all_features()
+
+    keep = []
+    for feat in raw_features:
+        geom = feat.get("geometry")
+        if not geom:
+            continue
+        min_lng, min_lat, max_lng, max_lat = feature_bounds(geom)
+        if max_lng < BBOX["lng_min"] or min_lng > BBOX["lng_max"]:
+            continue
+        if max_lat < BBOX["lat_min"] or min_lat > BBOX["lat_max"]:
+            continue
+
+        props = feat.get("properties", {}) or {}
+        # Bed name — common ArcGIS field variants.
+        name = (
+            props.get("BED_NAME")
+            or props.get("BedName")
+            or props.get("NAME")
+            or props.get("Name")
+            or props.get("KELP_BED_NAME")
+        )
+        # Bed number — try the documented variants.
+        bed_number = (
+            props.get("BED_NUMBER")
+            or props.get("BedNumber")
+            or props.get("Bed_Number")
+            or props.get("BED_NO")
+            or props.get("KelpBedNo")
+        )
+        # Status — open / closed / leasable / leased.
+        status_raw = (
+            props.get("STATUS")
+            or props.get("Status")
+            or props.get("BED_STATUS")
+            or props.get("BedStatus")
+            or props.get("LEASE_STATUS")
+        )
+        status = str(status_raw).strip().lower() if status_raw else None
+
+        area_km2 = None
+        if props.get("Shape_Area") is not None:
+            try:
+                # Shape_Area on ArcGIS Online (WGS84) is in m² when the
+                # service is configured with a geometric area calc.
+                area_km2 = round(float(props["Shape_Area"]) / 1e6, 3)
+            except (TypeError, ValueError):
+                area_km2 = None
+
+        # Derive an id: prefer slugified name; fall back to bed number.
+        if name:
+            kelp_id = slugify(str(name))
+        elif bed_number is not None:
+            kelp_id = f"kelp-bed-{bed_number}"
+        else:
+            # Truly anonymous feature — skip rather than emit a junk id.
+            continue
+
+        slim_props = {
+            "id": kelp_id,
+            "name": name or f"Kelp Bed {bed_number}",
+            "bedNumber": bed_number,
+            "status": status,
+            "areaKm2": area_km2,
+        }
+
+        keep.append(
+            {
+                "type": "Feature",
+                "geometry": round_coords(geom, decimals=4),
+                "properties": slim_props,
+            }
+        )
+
+    out = {"type": "FeatureCollection", "features": keep}
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUT_PATH.write_text(json.dumps(out, separators=(",", ":")))
+    size_kb = OUT_PATH.stat().st_size / 1024
+    print(
+        f"wrote {len(keep)} kelp bed features to {OUT_PATH.name} "
+        f"({size_kb:.1f} KB; raw fetched: {len(raw_features)})"
+    )
+    # Print status distribution for visibility — matches the type
+    # distribution print in fetch_mpa.py.
+    statuses: dict[str, int] = {}
+    for f in keep:
+        s = f["properties"]["status"] or "unknown"
+        statuses[s] = statuses.get(s, 0) + 1
+    for s, n in sorted(statuses.items(), key=lambda kv: -kv[1]):
+        print(f"  {s}: {n}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/components/DesktopLayout.jsx
+++ b/src/components/DesktopLayout.jsx
@@ -145,8 +145,10 @@ export default function DesktopLayout({
   activeComposite, compositeText, timeOpts, layerIsReal,
   // Saved-spots panel state (analytics-wrapped setter lives in MapShell)
   activeSpot, setActiveSpot,
-  // MPA/bathy toggles (state owned by App, side-effect wrappers in MapShell)
-  mpaOn, bathyOn, updateMpaOn, updateBathyOn,
+  // MPA/bathy/kelp toggles (state owned by App, side-effect wrappers in MapShell)
+  mpaOn, bathyOn, kelpOn, updateMpaOn, updateBathyOn, updateKelpOn,
+  // Kelp Bed Zones are CA-only today; hide the chip in beta regions.
+  kelpAvailable,
   // Map viewport (zoom +/− buttons + recenter)
   size, zoomAt, resetView,
   // Manifest data state (legend "no data" indicator)
@@ -199,6 +201,17 @@ export default function DesktopLayout({
             >
               Bottom
             </button>
+            {kelpAvailable && (
+              <button
+                type="button"
+                className={"mpa-pill" + (kelpOn ? " active" : "")}
+                onClick={(e) => { e.stopPropagation(); updateKelpOn(!kelpOn); }}
+                title={kelpOn ? "Kelp bed zones visible · click to hide" : "Kelp bed zones hidden · click to show"}
+                aria-pressed={kelpOn}
+              >
+                Kelp
+              </button>
+            )}
             <Chevron open={controlsOpen} />
           </span>
         </div>

--- a/src/components/KelpLayer.jsx
+++ b/src/components/KelpLayer.jsx
@@ -1,0 +1,114 @@
+import { useEffect, useMemo, useState } from "react";
+import { project } from "../lib/mapData.js";
+import { dataPath } from "../lib/region.js";
+
+// Color/style by lease status, per kelp-MVP handover.
+// CDFW Administrative Kelp Beds publish a STATUS field with values like
+// open / leasable / leased / closed (case-insensitive — fetch_kelp.py
+// lowercases for us). Outline 1.6 px to match MpaLayer; fill 10–14%
+// opacity so kelp doesn't drown the SST raster underneath.
+const KELP_STYLE = {
+  open:       { stroke: "#2e7d32", fill: "rgba(46, 125, 50, 0.14)" },
+  leasable:   { stroke: "#43a047", fill: "rgba(67, 160, 71, 0.12)" },
+  leased:     { stroke: "#1b5e20", fill: "rgba(27, 94, 32, 0.16)" },
+  closed:     { stroke: "#6d4c41", fill: "rgba(109, 76, 65, 0.14)" },
+};
+const DEFAULT_STYLE = { stroke: "#558b2f", fill: "rgba(85, 139, 47, 0.10)" };
+
+export function styleForStatus(status) {
+  if (!status) return DEFAULT_STYLE;
+  return KELP_STYLE[String(status).toLowerCase()] || DEFAULT_STYLE;
+}
+
+// Single shared promise so React StrictMode + multiple toggles don't refetch.
+let kelpPromise = null;
+function loadKelpBeds() {
+  if (kelpPromise) return kelpPromise;
+  // Default cache mode so the browser revalidates with the CDN instead of
+  // serving a permanently-pinned copy from disk.
+  kelpPromise = fetch(dataPath("/data/kelp-beds.geojson"))
+    .then((r) => (r.ok ? r.json() : null))
+    .catch(() => null);
+  return kelpPromise;
+}
+
+function ringToPath(ring, w, h) {
+  if (!ring.length) return "";
+  // Match Basemap.jsx: 3-decimal precision so kelp edges stay crisp at zoom.
+  const [x0, y0] = project(ring[0][0], ring[0][1], w, h);
+  let d = `M${x0.toFixed(3)} ${y0.toFixed(3)}`;
+  for (let i = 1; i < ring.length; i++) {
+    const [x, y] = project(ring[i][0], ring[i][1], w, h);
+    d += `L${x.toFixed(3)} ${y.toFixed(3)}`;
+  }
+  return d + "Z";
+}
+
+function geometryToPath(geom, w, h) {
+  if (!geom) return "";
+  if (geom.type === "Polygon") {
+    return geom.coordinates.map((ring) => ringToPath(ring, w, h)).join(" ");
+  }
+  if (geom.type === "MultiPolygon") {
+    return geom.coordinates
+      .flatMap((poly) => poly.map((ring) => ringToPath(ring, w, h)))
+      .join(" ");
+  }
+  return "";
+}
+
+export default function KelpLayer({ width, height, active, onSelect }) {
+  const [features, setFeatures] = useState(null);
+
+  useEffect(() => {
+    if (!active) return;
+    let cancelled = false;
+    loadKelpBeds().then((fc) => {
+      if (cancelled || !fc) return;
+      setFeatures(fc.features || []);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [active]);
+
+  // Pre-project everything once per (width, height, features) — avoids
+  // re-projecting on every viewBox change since viewBox handles zoom for us.
+  const paths = useMemo(() => {
+    if (!features) return [];
+    return features.map((f) => ({
+      id: f.properties.id,
+      props: f.properties,
+      d: geometryToPath(f.geometry, width, height),
+      style: styleForStatus(f.properties.status),
+    }));
+  }, [features, width, height]);
+
+  if (!active || !paths.length) return null;
+
+  return (
+    <g className="kelp-layer">
+      {paths.map((p) => (
+        <path
+          key={p.id}
+          d={p.d}
+          fill={p.style.fill}
+          stroke={p.style.stroke}
+          strokeWidth="1.6"
+          strokeOpacity="0.85"
+          style={{ cursor: "pointer", pointerEvents: "visiblePainted" }}
+          onMouseDown={(e) => e.stopPropagation()}
+          onTouchStart={(e) => e.stopPropagation()}
+          onTouchMove={(e) => e.stopPropagation()}
+          onTouchEnd={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelect?.(p.props);
+          }}
+        >
+          <title>{p.props.name}{p.props.status ? ` — ${p.props.status}` : ""}</title>
+        </path>
+      ))}
+    </g>
+  );
+}

--- a/src/components/KelpPopup.jsx
+++ b/src/components/KelpPopup.jsx
@@ -1,0 +1,99 @@
+// Kelp-bed popup describing a single CDFW Administrative Kelp Bed.
+// Cloned from MpaPopup.jsx as part of the Kelp Bed Zones MVP
+// (Phase 1, Task C in outputs/KELP-M~1.MD).
+//
+// IMPORTANT: These are management/reference boundaries for commercial
+// kelp harvest — NOT observed canopy. The disclaimer at the bottom
+// makes that explicit so divers don't mistake the polygons for "kelp
+// is currently here."
+
+import { useEffect } from "react";
+import { styleForStatus } from "./KelpLayer.jsx";
+
+function labelForStatus(status) {
+  if (!status) return "Unknown";
+  const s = String(status).toLowerCase();
+  if (s === "open") return "Open";
+  if (s === "leasable") return "Leasable";
+  if (s === "leased") return "Leased";
+  if (s === "closed") return "Closed";
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+export default function KelpPopup({ kelp, onClose }) {
+  const style = styleForStatus(kelp.status);
+  const officialUrl =
+    "https://wildlife.ca.gov/Conservation/Marine/Kelp";
+  useEffect(() => {
+    const onKeyDown = (e) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+  return (
+    <div className="mpa-popup-overlay" onClick={onClose} role="presentation">
+      <div
+        className="mpa-popup"
+        role="dialog"
+        aria-modal="true"
+        aria-label={`${kelp.name} kelp bed details`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          className="mpa-popup-close"
+          onClick={onClose}
+          aria-label="Close kelp bed details"
+        >
+          ×
+        </button>
+        <div className="mpa-popup-head">
+          <div>
+            <div className="mpa-popup-name">{kelp.name}</div>
+            <div className="mpa-popup-fullname">
+              CDFW Administrative Kelp Bed
+              {kelp.bedNumber != null ? ` · #${kelp.bedNumber}` : ""}
+            </div>
+          </div>
+          {kelp.status && (
+            <span
+              className="mpa-pill"
+              style={{ background: style.fill, borderColor: style.stroke, color: style.stroke }}
+            >
+              {labelForStatus(kelp.status)}
+            </span>
+          )}
+        </div>
+        <p className="mpa-popup-body">
+          Administrative kelp beds are CDFW management boundaries for
+          commercial kelp harvest. Lease status indicates whether the
+          bed is open to harvest, available for lease, currently leased,
+          or closed.
+        </p>
+        <p className="mpa-popup-meta mono">
+          {kelp.areaKm2 ? `${kelp.areaKm2} km²` : ""}
+        </p>
+        <a
+          className="mpa-popup-link"
+          href={officialUrl}
+          target="_blank"
+          rel="noreferrer"
+        >
+          ↗ Official CDFW kelp page
+        </a>
+        <p className="mpa-popup-disclaimer">
+          Kelp bed zones are management / reference boundaries and may
+          not represent current kelp canopy.
+        </p>
+        <button
+          type="button"
+          className="mpa-popup-done"
+          onClick={onClose}
+        >
+          Back to map
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/MapShell.jsx
+++ b/src/components/MapShell.jsx
@@ -31,6 +31,7 @@ import { SeaBasemap, LandBasemap, OceanMaskDefs, PLACE_LABELS } from "./Basemap.
 import DataOverlay from "./DataOverlay.jsx";
 import WindParticles from "./WindParticles.jsx";
 import MpaLayer from "./MpaLayer.jsx";
+import KelpLayer from "./KelpLayer.jsx";
 import BathyLayer, {
   visibleBathyFeatures,
   bathyLabels,
@@ -39,6 +40,7 @@ import MapLabels from "./MapLabels.jsx";
 import MobileSheet from "./MobileSheet.jsx";
 import BathyPopup from "./BathyPopup.jsx";
 import MpaPopup from "./MpaPopup.jsx";
+import KelpPopup from "./KelpPopup.jsx";
 import CoronadosBanner from "./CoronadosBanner.jsx";
 import { selToSlotKey } from "./WindDayGrid.jsx";
 import WindTimeline from "./WindTimeline.jsx";
@@ -135,9 +137,19 @@ export default function MapShell({ layer, setLayer, composite, setComposite, sst
   // PrefsContext — extracted in Stage 5c (2026-05-23) so they no
   // longer have to be drilled through App → MapShell as props.
   const { prefs, setPref } = usePrefs();
-  const { opacity, units, mpaOn, bathyOn } = prefs;
+  const { opacity, units, mpaOn, bathyOn, kelpOn } = prefs;
   const setMpaOn = (v) => setPref("mpaOn", v);
   const setBathyOn = (v) => setPref("bathyOn", v);
+  const setKelpOn = (v) => setPref("kelpOn", v);
+
+  // Kelp Bed Zones is California-only today — CDFW ds3135 covers CA
+  // commercial kelp harvest boundaries, which are CA state-water
+  // constructs. Baja / PNW / tropical regions either have no analog
+  // (Baja: SEMARNAT manages a different scheme) or the data isn't
+  // published as a featureserver. The chip + layer hide outside CA so
+  // we don't show a useless toggle.
+  const REGIONS_WITH_KELP = new Set(["ca"]);
+  const kelpAvailable = REGIONS_WITH_KELP.has(activeRegion());
   // Timeline layers use a slot-key string derived from their selection
   // state; helpers fall back to a valid slot if the requested one has no
   // data. Chl/viz keep the legacy integer composite.
@@ -190,8 +202,9 @@ export default function MapShell({ layer, setLayer, composite, setComposite, sst
   const {
     selectedMpa, setSelectedMpa,
     selectedBathy, setSelectedBathy,
+    selectedKelp, setSelectedKelp,
     bathyFeatures,
-  } = usePopupState({ mpaOn, bathyOn });
+  } = usePopupState({ mpaOn, bathyOn, kelpOn });
 
   // updateMpaOn / updateBathyOn stay here — they wrap mpaOn/bathyOn
   // setters (which are App-level state, not hook-managed) AND
@@ -207,6 +220,11 @@ export default function MapShell({ layer, setLayer, composite, setComposite, sst
     const value = typeof next === "function" ? next(bathyOn) : next;
     if (!value) setSelectedBathy(null);
     setBathyOn(value);
+  };
+  const updateKelpOn = (next) => {
+    const value = typeof next === "function" ? next(kelpOn) : next;
+    if (!value) setSelectedKelp(null);
+    setKelpOn(value);
   };
 
   // Stale hover state from the previous layer carries an incompatible val
@@ -609,6 +627,16 @@ export default function MapShell({ layer, setLayer, composite, setComposite, sst
           }}
         />
 
+        <KelpLayer
+          width={size.w}
+          height={size.h}
+          active={kelpOn && kelpAvailable}
+          onSelect={(kelp) => {
+            track("popup_open", { kind: "kelp", status: kelp?.status || "unknown" });
+            setSelectedKelp(kelp);
+          }}
+        />
+
         <BathyLayer
           width={size.w}
           height={size.h}
@@ -743,8 +771,9 @@ export default function MapShell({ layer, setLayer, composite, setComposite, sst
         timeOpts={timeOpts}
         layerIsReal={layerIsReal}
         activeSpot={activeSpot} setActiveSpot={setActiveSpot}
-        mpaOn={mpaOn} bathyOn={bathyOn}
-        updateMpaOn={updateMpaOn} updateBathyOn={updateBathyOn}
+        mpaOn={mpaOn} bathyOn={bathyOn} kelpOn={kelpOn}
+        kelpAvailable={kelpAvailable}
+        updateMpaOn={updateMpaOn} updateBathyOn={updateBathyOn} updateKelpOn={updateKelpOn}
         size={size} zoomAt={zoomAt} resetView={resetView}
         dataState={dataState}
         isMobile={isMobile}
@@ -760,6 +789,10 @@ export default function MapShell({ layer, setLayer, composite, setComposite, sst
 
       {selectedMpa && (
         <MpaPopup mpa={selectedMpa} onClose={() => setSelectedMpa(null)} />
+      )}
+
+      {selectedKelp && (
+        <KelpPopup kelp={selectedKelp} onClose={() => setSelectedKelp(null)} />
       )}
 
       {selectedBathy && (
@@ -787,6 +820,8 @@ export default function MapShell({ layer, setLayer, composite, setComposite, sst
         dataState={dataState}
         setMpaOn={updateMpaOn}
         setBathyOn={updateBathyOn}
+        setKelpOn={updateKelpOn}
+        kelpAvailable={kelpAvailable}
         activeSpot={activeSpot} setActiveSpot={setActiveSpot}
         timeOpts={timeOpts}
         compositeText={compositeText}

--- a/src/components/MobileSheet.jsx
+++ b/src/components/MobileSheet.jsx
@@ -126,6 +126,8 @@ export default function MobileShell({
   dataState,
   setMpaOn,
   setBathyOn,
+  setKelpOn,
+  kelpAvailable,
   activeSpot, setActiveSpot,
   timeOpts,
   compositeText,
@@ -139,7 +141,7 @@ export default function MobileShell({
   // wraps them with a popup-clearing side effect before passing them in
   // (see updateMpaOn/updateBathyOn there).
   const { prefs } = usePrefs();
-  const { units, mpaOn, bathyOn } = prefs;
+  const { units, mpaOn, bathyOn, kelpOn } = prefs;
   // wind + swell + current use slot keys; sst uses history/forecast slots
   // when loaded; chl/viz use integer composites.
   //
@@ -257,6 +259,19 @@ export default function MobileShell({
               >
                 Bottom Detail
               </button>
+              {kelpAvailable && (
+                <button
+                  type="button"
+                  className={"mpa-pill" + (kelpOn ? " active" : "")}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setKelpOn(!kelpOn);
+                  }}
+                  aria-pressed={kelpOn}
+                >
+                  Kelp Beds
+                </button>
+              )}
             </div>
           </section>
 
@@ -333,6 +348,19 @@ export default function MobileShell({
         >
           Bottom
         </button>
+        {kelpAvailable && (
+          <button
+            type="button"
+            className={"mpa-pill" + (kelpOn ? " active" : "")}
+            onClick={(e) => {
+              e.stopPropagation();
+              setKelpOn(!kelpOn);
+            }}
+            aria-pressed={kelpOn}
+          >
+            Kelp
+          </button>
+        )}
       </div>
 
       {/* Always-visible peek strip ------------------------------------- */}

--- a/src/contexts/PrefsContext.jsx
+++ b/src/contexts/PrefsContext.jsx
@@ -21,7 +21,7 @@ import { track } from "../lib/analytics.js";
 
 const PREF_KEY = "ca-coast-conditions:prefs:v1";
 const OVERLAY_DEFAULTS_MIGRATION_KEY = "ca-coast-conditions:prefs:migrations:overlay-defaults-v1";
-const DEFAULT_PREFS = { theme: "light", opacity: 0.62, units: "F", mpaOn: true, bathyOn: true };
+const DEFAULT_PREFS = { theme: "light", opacity: 0.62, units: "F", mpaOn: true, bathyOn: true, kelpOn: true };
 
 function loadPrefs() {
   try {

--- a/src/hooks/usePopupState.js
+++ b/src/hooks/usePopupState.js
@@ -9,9 +9,10 @@
 // cleanup-on-cancel pattern.
 //
 // API:
-//   const p = usePopupState({ mpaOn, bathyOn });
+//   const p = usePopupState({ mpaOn, bathyOn, kelpOn });
 //   p.selectedMpa, p.setSelectedMpa       — currently-clicked MPA polygon, null = closed
 //   p.selectedBathy, p.setSelectedBathy   — currently-clicked bathy feature (seamount/reef/community spot)
+//   p.selectedKelp, p.setSelectedKelp     — currently-clicked kelp bed polygon, null = closed
 //   p.bathyFeatures                       — lazy-loaded GeoJSON feature array, null until bathyOn is true
 //   p.setBathyFeatures                    — exposed for test/dev tooling; rarely called outside the lazy-load effect
 //
@@ -25,9 +26,10 @@ import { useEffect, useState } from "react";
 
 import { loadBathyFeatures } from "../components/BathyLayer.jsx";
 
-export function usePopupState({ mpaOn, bathyOn }) {
+export function usePopupState({ mpaOn, bathyOn, kelpOn }) {
   const [selectedMpa, setSelectedMpa] = useState(null);
   const [selectedBathy, setSelectedBathy] = useState(null);
+  const [selectedKelp, setSelectedKelp] = useState(null);
   const [bathyFeatures, setBathyFeatures] = useState(null);
 
   // Close MPA popup when the MPA layer is turned off.
@@ -39,6 +41,11 @@ export function usePopupState({ mpaOn, bathyOn }) {
   useEffect(() => {
     if (!bathyOn) setSelectedBathy(null);
   }, [bathyOn]);
+
+  // Close kelp popup when the kelp layer is turned off.
+  useEffect(() => {
+    if (!kelpOn) setSelectedKelp(null);
+  }, [kelpOn]);
 
   // Lazy-load bathy features whenever the layer flips on (used for
   // both the SVG markers and the screen-space labels). Cancel on
@@ -57,6 +64,7 @@ export function usePopupState({ mpaOn, bathyOn }) {
   return {
     selectedMpa, setSelectedMpa,
     selectedBathy, setSelectedBathy,
+    selectedKelp, setSelectedKelp,
     bathyFeatures, setBathyFeatures,
   };
 }

--- a/tests/appFeatureContracts.test.js
+++ b/tests/appFeatureContracts.test.js
@@ -112,6 +112,14 @@ test("Current, swell, wind, and mobile overlay features remain wired", () => {
   assert.match(mobileSheet, /className="ms-overlay-quick"/);
   assert.match(mobileSheet, /aria-pressed=\{mpaOn\}/);
   assert.match(mobileSheet, /aria-pressed=\{bathyOn\}/);
+  // 2026-05-26 (Kelp Bed Zones MVP): the Kelp pill is rendered both in
+  // the open-sheet "Overlays" section AND in the always-visible
+  // .ms-overlay-quick strip. It's region-gated by `kelpAvailable`
+  // (CA-only today) so the chip never shows on Baja/PNW/tropical.
+  // Pinning aria-pressed={kelpOn} ensures the toggle stays wired in
+  // both spots — a future refactor that drops one renderer trips here
+  // before the build does.
+  assert.match(mobileSheet, /aria-pressed=\{kelpOn\}/);
   assert.match(styles, /\.ms-overlay-quick/);
   assert.match(styles, /\.mpa-popup-close/);
   assert.match(styles, /\.mpa-popup-done/);


### PR DESCRIPTION
## Summary

Phase 1 MVP of the Kelp Bed Zones feature: ships an opt-in vector overlay of California's 87 CDFW administrative kelp beds alongside the existing MPA + Bottom Detail toggles. Region-gated to CA — Baja / PNW / tropical hide the chip entirely because ds3135 is a CA state-water construct.

- **Data**: `pipeline/fetch_kelp.py` paginates the CDFW ArcGIS FeatureServer, bbox-clips via `active_region()`, 4-decimal coordinate rounding (~11 m, enough for nearshore edges). Output → `public/data/kelp-beds.geojson`.
- **Layer**: `KelpLayer.jsx` (cloned from `MpaLayer.jsx`) renders each bed with a status-keyed green palette — open / leasable / leased / closed. Single-shared-promise fetch guard so StrictMode + toggle thrashing doesn't refetch.
- **Popup**: `KelpPopup.jsx` carries the required disclaimer — _"Kelp bed zones are management / reference boundaries and may not represent current kelp canopy."_ — so divers don't misread the polygons as observed canopy.
- **UI**: Kelp pill added to the desktop controls header AND both mobile overlay locations (`.ms-overlay-quick` peek strip + open-sheet "Overlays" section).
- **Pref**: `kelpOn: true` auto-defaults via spread merge — no migration key needed.
- **Pipeline gate**: New `Fetch CDFW Administrative Kelp Beds` step in `refresh-ca-data.yml` (continue-on-error, 5-min timeout, runs after the MPA fetch).
- **Test**: `appFeatureContracts.test.js` asserts `aria-pressed={kelpOn}` stays wired in MobileSheet.

Phase 2 (per-bed canopy from MODIS/Landsat) and Phase 3 (kelp seasonality scoring) are deliberately out of scope for this MVP.

## Test plan

- [x] `npm run lint` — clean (no new errors on touched files)
- [x] `npm run build` — clean (Vite 313 KB bundle, no warnings)
- [x] `npm test` — appFeatureContracts new kelp assertion passes; only pre-existing Windows-side `rendering-math.test.js` ESM-URL bug fails (unrelated)
- [ ] dev-checks.yml gate (pipeline-tests + web-build + web-lint + web-tests + web-smoke + secrets-scan + workflow-lint + manifest-validate)
- [ ] Visually verify on `https://dev.shouldidive.pages.dev` after deploy-dev fires from this push: Kelp chip appears on CA, hidden on Baja
- [ ] Click a kelp polygon → popup renders with disclaimer + lease status + CDFW link
- [ ] Mobile: pill appears in both peek strip AND open-sheet Overlays section

🤖 Generated with [Claude Code](https://claude.com/claude-code)